### PR TITLE
Bootstrap office-cli (0.0.1)

### DIFF
--- a/.claude/skills.local.yaml.example
+++ b/.claude/skills.local.yaml.example
@@ -1,0 +1,14 @@
+# Per-machine config for steward's skills.
+# Copy this to skills.local.yaml (git-ignored) and adjust for your environment.
+# Skills read skills.local.yaml first, falling back to this example.
+
+# Path to the Culture server's agent manifest (suffix → directory mapping).
+# Used by: agent-config (resolving a registered agent suffix to its repo dir).
+culture_server_yaml: ~/.culture/server.yaml
+
+# Sibling project paths checked during the pr-review alignment-delta step.
+# Workspace-relative paths (../foo) are preferred. Skills skip entries
+# that don't exist on disk, so commenting out missing ones isn't required.
+sibling_projects:
+  - ../culture
+  - ../daria

--- a/.claude/skills/gh-issues/SKILL.md
+++ b/.claude/skills/gh-issues/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: gh-issues
+description: >
+  Fetch GitHub issues with full body and comments. Use when checking issues,
+  reviewing bug reports, or the user says "check issues", "fetch issues",
+  "issue #N", or references GitHub issue numbers.
+triggers:
+  - check issues
+  - fetch issues
+  - issue #
+  - github issues
+  - verify issues
+---
+
+# GitHub Issues Skill
+
+Fetch one or more GitHub issues with full body text and all comments.
+
+## Usage
+
+### Single issue
+
+```bash
+bash .claude/skills/gh-issues/scripts/gh-issues.sh 191
+```
+
+### Range
+
+```bash
+bash .claude/skills/gh-issues/scripts/gh-issues.sh 191-197
+```
+
+### Specific list
+
+```bash
+bash .claude/skills/gh-issues/scripts/gh-issues.sh 191 195 197
+```
+
+### Explicit repo
+
+```bash
+bash .claude/skills/gh-issues/scripts/gh-issues.sh --repo owner/repo 42-50
+```
+
+Output is JSON per issue with: number, title, state, labels, body, and comments array.

--- a/.claude/skills/gh-issues/scripts/gh-issues.sh
+++ b/.claude/skills/gh-issues/scripts/gh-issues.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Fetch GitHub issues with full body and comments
+# Usage: gh-issues.sh [RANGE|NUMBER] [--repo OWNER/REPO]
+#   gh-issues.sh 191-197          # range
+#   gh-issues.sh 191              # single
+#   gh-issues.sh 191 192 195      # list
+#   gh-issues.sh --repo foo/bar 5 # explicit repo
+
+set -euo pipefail
+
+REPO_FLAG=""
+NUMBERS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "Error: --repo requires a value (OWNER/REPO)" >&2
+        echo "Usage: gh-issues.sh [RANGE|NUMBER...] [--repo OWNER/REPO]" >&2
+        exit 1
+      fi
+      REPO_FLAG="--repo $2"
+      shift 2 ;;
+    *-*)  # range like 191-197
+      IFS='-' read -r start end <<< "$1"
+      for ((i=start; i<=end; i++)); do NUMBERS+=("$i"); done
+      shift ;;
+    *)  NUMBERS+=("$1"); shift ;;
+  esac
+done
+
+if [[ ${#NUMBERS[@]} -eq 0 ]]; then
+  echo "Usage: gh-issues.sh [RANGE|NUMBER...] [--repo OWNER/REPO]" >&2
+  exit 1
+fi
+
+for num in "${NUMBERS[@]}"; do
+  echo "========================================"
+  echo "ISSUE #${num}"
+  echo "========================================"
+  # shellcheck disable=SC2086
+  gh issue view "$num" $REPO_FLAG --json number,title,state,labels,body,comments \
+    --jq '{
+      number: .number,
+      title: .title,
+      state: .state,
+      labels: [.labels[].name],
+      body: .body,
+      comments: [.comments[] | {author: .author.login, body: .body}]
+    }' 2>/dev/null || echo "ERROR: Could not fetch issue #${num}"
+  echo
+done

--- a/.claude/skills/notebooklm/SKILL.md
+++ b/.claude/skills/notebooklm/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: notebooklm
+description: >
+  Generate GitHub links to repo documentation for NotebookLM ingestion.
+  Use when: the user wants to create a NotebookLM notebook about a project,
+  needs doc links for a repo, or says "notebooklm", "notebook sources",
+  "get repo sources", or "doc links".
+---
+
+# NotebookLM — Repo Source Links
+
+Generate GitHub blob URLs for all documentation in the current repo, ready to paste into Google NotebookLM as sources.
+
+## When to Use
+
+- Creating a NotebookLM notebook about a project
+- Gathering all doc links for a repo
+- Exporting documentation URLs for any external tool
+
+## Usage
+
+```bash
+# Categorized output (default)
+bash .claude/skills/notebooklm/scripts/get-repo-sources.sh
+
+# Plain URLs only (for copy-paste)
+bash .claude/skills/notebooklm/scripts/get-repo-sources.sh --plain
+
+# Include plans and specs
+bash .claude/skills/notebooklm/scripts/get-repo-sources.sh --all
+
+# Override branch
+bash .claude/skills/notebooklm/scripts/get-repo-sources.sh --branch develop
+```
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--all` | off | Include plans, specs, and changelogs |
+| `--plain` | off | Output only URLs, one per line (no headers) |
+| `--branch NAME` | auto-detect | Override the git branch used in URLs |
+
+## Requirements
+
+- Must be run inside a git repository with a GitHub remote
+- `git` CLI available

--- a/.claude/skills/notebooklm/scripts/get-repo-sources.sh
+++ b/.claude/skills/notebooklm/scripts/get-repo-sources.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# get-repo-sources — Generate GitHub URLs for repo docs, ready for NotebookLM
+set -euo pipefail
+
+# --- Defaults ---
+INCLUDE_ALL=false
+PLAIN=false
+BRANCH=""
+
+# --- Parse args ---
+usage() {
+  echo "Usage: get-repo-sources.sh [--all] [--plain] [--branch NAME]"
+  echo "  --all      Include plans, specs, and changelogs"
+  echo "  --plain    Output plain URLs only (no headers)"
+  echo "  --branch   Override branch (default: auto-detect)"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)       INCLUDE_ALL=true; shift ;;
+    --plain)     PLAIN=true; shift ;;
+    --branch)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "Error: --branch requires a value" >&2
+        usage >&2
+        exit 1
+      fi
+      BRANCH="$2"
+      shift 2 ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# --- Detect repo root ---
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Error: not inside a git repository" >&2; exit 1
+}
+cd "$REPO_ROOT"
+
+# --- Detect GitHub URL ---
+REMOTE_URL="$(git remote get-url origin 2>/dev/null)" || {
+  echo "Error: no 'origin' remote found" >&2; exit 1
+}
+
+# Normalise to https://github.com/OWNER/REPO
+GITHUB_URL="$REMOTE_URL"
+GITHUB_URL="${GITHUB_URL%.git}"
+if [[ "$GITHUB_URL" == git@github.com:* ]]; then
+  GITHUB_URL="https://github.com/${GITHUB_URL#git@github.com:}"
+fi
+
+# --- Detect branch (handle detached HEAD) ---
+if [[ -z "$BRANCH" ]]; then
+  BRANCH="$(git branch --show-current 2>/dev/null || true)"
+fi
+if [[ -z "$BRANCH" ]]; then
+  echo "Error: cannot determine the current branch (detached HEAD?)." >&2
+  echo "Hint: pass --branch <name> with a branch that exists on origin." >&2
+  exit 1
+fi
+
+# --- Verify the remote ref exists locally ---
+REMOTE_REF="origin/${BRANCH}"
+if ! git show-ref --verify --quiet "refs/remotes/${REMOTE_REF}"; then
+  echo "Error: remote ref '${REMOTE_REF}' is not available locally." >&2
+  echo "Hint: run 'git fetch origin ${BRANCH}', push the branch first, or pass --branch with an existing remote branch name." >&2
+  exit 1
+fi
+
+BASE_URL="${GITHUB_URL}/blob/${BRANCH}"
+
+# --- Collect all .md files from remote branch (only files that exist on GitHub) ---
+ALL_FILES=$(git ls-tree -r --name-only "${REMOTE_REF}" \
+  | grep '\.md$' \
+  | grep -v -E '^(\.github/|\.claude/|\.pytest_cache/|node_modules/|\.venv/|__pycache__/|\.mypy_cache/)' \
+  | sort)
+
+# --- Filter ---
+filter_file() {
+  local f="$1"
+  # Always exclude dot-dirs and lock files
+  [[ "$f" == .github/* ]] && return 1
+
+  if [[ "$INCLUDE_ALL" == "false" ]]; then
+    # Exclude plans, specs, changelogs by default
+    [[ "$f" == *superpowers/plans/* ]] && return 1
+    [[ "$f" == *superpowers/specs/* ]] && return 1
+    [[ "$f" == CHANGELOG.md ]] && return 1
+  fi
+  return 0
+}
+
+FILTERED=()
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if filter_file "$f"; then
+    FILTERED+=("$f")
+  fi
+done <<< "$ALL_FILES"
+
+if [[ ${#FILTERED[@]} -eq 0 ]]; then
+  echo "No documentation files found." >&2
+  exit 1
+fi
+
+# --- Categorise ---
+declare -a CAT_CORE=() CAT_ARCH=() CAT_START=() CAT_FEATURES=() CAT_PROTOCOL=()
+declare -a CAT_CLIENTS=() CAT_USECASES=() CAT_PACKAGES=() CAT_PLANS=() CAT_SPECS=() CAT_OTHER=()
+
+categorise() {
+  local f="$1"
+  local base
+  base="$(basename "$f")"
+
+  # Path-based categories first (more specific)
+  case "$f" in
+    *protocol/*)         CAT_PROTOCOL+=("$f"); return ;;
+    *clients/*)          CAT_CLIENTS+=("$f"); return ;;
+    *use-cases/*)        CAT_USECASES+=("$f"); return ;;
+    *packages/*)         CAT_PACKAGES+=("$f"); return ;;
+    *superpowers/plans*) CAT_PLANS+=("$f"); return ;;
+    *superpowers/specs*) CAT_SPECS+=("$f"); return ;;
+    *plugins/*)          CAT_OTHER+=("$f"); return ;;
+    *skills/*)           CAT_OTHER+=("$f"); return ;;
+  esac
+
+  # Root-level core files (only match files at repo root)
+  case "$f" in
+    README.md|CLAUDE.md|index.md) CAT_CORE+=("$f"); return ;;
+    CHANGELOG.md)                 CAT_OTHER+=("$f"); return ;;
+  esac
+
+  # By filename keywords
+  case "$base" in
+    layer*|overview*|design*|server-architecture*|*-spec*)
+      CAT_ARCH+=("$f"); return ;;
+    getting-started*|cli*|grow-your-agent*)
+      CAT_START+=("$f"); return ;;
+    *) ;;
+  esac
+
+  # Docs directory features
+  if [[ "$f" == docs/* ]]; then
+    CAT_FEATURES+=("$f")
+  else
+    CAT_OTHER+=("$f")
+  fi
+}
+
+for f in "${FILTERED[@]}"; do
+  categorise "$f"
+done
+
+# --- Output ---
+print_urls() {
+  local label="$1"; shift
+  local -n arr=$1
+
+  if [[ ${#arr[@]} -eq 0 ]]; then return; fi
+
+  if [[ "$PLAIN" == "false" ]]; then
+    echo ""
+    echo "--- ${label} ---"
+  fi
+  for f in "${arr[@]}"; do
+    echo "${BASE_URL}/${f}"
+  done
+}
+
+if [[ "$PLAIN" == "false" ]]; then
+  echo "=== Documentation Links for NotebookLM ==="
+  echo "Repository: ${GITHUB_URL}"
+  echo "Branch: ${BRANCH}"
+  echo "Files: ${#FILTERED[@]}"
+fi
+
+print_urls "Core"           CAT_CORE
+print_urls "Architecture"   CAT_ARCH
+print_urls "Getting Started" CAT_START
+print_urls "Features"       CAT_FEATURES
+print_urls "Protocol"       CAT_PROTOCOL
+print_urls "Clients"        CAT_CLIENTS
+print_urls "Use Cases"      CAT_USECASES
+print_urls "Packages"       CAT_PACKAGES
+print_urls "Plans"          CAT_PLANS
+print_urls "Specs"          CAT_SPECS
+print_urls "Other"          CAT_OTHER
+
+if [[ "$PLAIN" == "false" ]]; then
+  echo ""
+  echo "=== Plain URLs (copy-paste block) ==="
+  echo ""
+  for f in "${FILTERED[@]}"; do
+    echo "${BASE_URL}/${f}"
+  done
+fi

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: pr-review
+description: >
+  Steward-specific PR workflow: branch, commit, push, PR, wait for Qodo/Copilot,
+  triage, fix, reply, resolve. Adds a portability lint (no absolute /home paths,
+  no per-user dotfile refs in committed docs), an alignment-delta check when
+  CLAUDE.md or culture.yaml change, and greenfield-aware test/version-bump
+  steps. Use when: creating PRs in steward, handling review feedback, or the
+  user says "create PR", "review comments", "address feedback", "resolve threads".
+---
+
+# PR Review — Steward edition
+
+Steward's PRs touch agent prompts, `culture.yaml` configs, and cross-project
+guidance. The generic `pr-review` skills don't know that, so they miss two
+classes of bugs Steward keeps producing:
+
+- **Path leaks** — committing absolute home-directory paths that work only on
+  the author's machine. (PR #1 had four of these.)
+- **Per-user config dependencies** — referencing a dotfile under the user's
+  home directory in repo guidance, breaking reproducibility for other
+  contributors and CI.
+
+This skill specializes Culture's `pr-review` to catch both up front, plus an
+alignment-delta step when Steward-affecting files change. The workflow is
+encapsulated in `scripts/workflow.sh` — follow that, not a manual checklist.
+
+## Prerequisites
+
+Hard requirements: `gh` (GitHub CLI), `jq`, `bash`, `python3` (stdlib only),
+`curl` (used by `pr-status.sh`).
+
+Soft requirement: `PyYAML` is needed **only for suffix mode** of the sibling
+`agent-config` skill, where it parses Culture's server manifest. Path mode
+and every `pr-review` script work without it. If suffix mode runs without
+PyYAML it exits with a clear install hint.
+
+Per-machine paths (sibling-project layout) live in
+`.claude/skills.local.yaml`; see the committed `.example` for the schema.
+
+## How to run
+
+`scripts/workflow.sh` is the entry point. Subcommands:
+
+| Command | Purpose |
+|---------|---------|
+| `workflow.sh lint` | Portability lint on the current diff (staged + unstaged). |
+| `workflow.sh poll <PR>` | Fetch and display all review comments. |
+| `workflow.sh delta` | Dump each sibling project's `CLAUDE.md` head + `culture.yaml`. |
+| `workflow.sh reply <PR>` | Batch reply (JSONL on stdin) and resolve threads. |
+| `workflow.sh help` | Print this list. |
+
+The vendored single-comment helpers — `pr-reply.sh`, `pr-status.sh` — live
+next to `workflow.sh` and are usable directly when batching isn't appropriate.
+
+## End-to-end flow
+
+```text
+git checkout -b <type>/<desc>
+# ... edit ...
+.claude/skills/pr-review/scripts/workflow.sh lint
+git commit -am "..." && git push -u origin <branch>
+gh pr create --title "..." --body "..."   # title <70 chars, body signed "- Claude"
+sleep 300                                  # wait for Qodo + Copilot
+.claude/skills/pr-review/scripts/workflow.sh poll <PR>
+# triage; if CLAUDE.md/culture.yaml/.claude/skills changed:
+.claude/skills/pr-review/scripts/workflow.sh delta
+# fix, re-lint, push
+.claude/skills/pr-review/scripts/workflow.sh reply <PR> < replies.jsonl
+gh pr checks <PR>
+# Wait for human merge — never merge yourself.
+```
+
+Branch naming: `fix/<desc>`, `feat/<desc>`, `docs/<desc>`, `skill/<name>`.
+Commit/PR signature: `- Claude` (workspace convention). The reply script
+auto-appends `- Claude` only if the body isn't already signed, so JSONL
+entries can include or omit it.
+
+## Triage rules
+
+For every comment, decide **FIX** or **PUSHBACK** with reasoning.
+
+Default to **FIX** for: portability complaints (always valid for Steward —
+recurring bug class), test or doc requests, style nits aligned with workspace
+conventions.
+
+Default to **PUSHBACK** for: architecture opinions that conflict with workspace
+`CLAUDE.md` or the all-backends rule; greenfield false-positives (e.g. "add
+tests" before there's any source — defer to a later PR, don't refuse).
+
+### Alignment-delta rule
+
+If the PR touches `CLAUDE.md`, `culture.yaml`, or anything under
+`.claude/skills/`, run `workflow.sh delta` **before** declaring FIX or
+PUSHBACK on each comment. The script dumps the head of every sibling
+project's `CLAUDE.md` plus the full `culture.yaml`, using `sibling_projects`
+from `skills.local.yaml`. Note any sibling that needs a follow-up PR and
+mention it in your reply.
+
+## Greenfield-aware steps
+
+The lint and the workflow script are always-on. Stack-specific steps are
+conditional and currently no-op (greenfield repo):
+
+```bash
+[ -d tests ] && [ -f pyproject.toml ] && uv run pytest tests/ -x -q
+[ -f pyproject.toml ] && bump_version_per_project_convention   # see project README
+[ -f .markdownlint-cli2.yaml ] && markdownlint-cli2 "$(git diff --name-only --cached '*.md')"
+```
+
+Revisit each line as the corresponding stack element actually lands.
+
+## Reply etiquette
+
+Every comment must get a reply — no silent fixes. Always pass `--resolve`
+when batch-replying so threads close automatically. Reference the
+review-comment IDs in the fix-up commit message. Steward currently has no
+SonarCloud integration and isn't a registered mesh agent, so skip the
+sonarclaude check and the post-merge IRC ping that Culture's `pr-review`
+includes — those will return when Steward joins those systems.

--- a/.claude/skills/pr-review/scripts/portability-lint.sh
+++ b/.claude/skills/pr-review/scripts/portability-lint.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Portability lint: catch path leaks and per-user config dependencies in
+# committed docs/configs before they ship in a PR. Steward's recurring bug
+# class.
+#
+# Usage: portability-lint.sh [--all]
+#   default: lint files modified vs HEAD (staged + unstaged)
+#   --all:   lint all tracked files
+#
+# Exits 0 if clean, 1 if any leak is found.
+
+set -euo pipefail
+
+mode="${1:-diff}"
+case "$mode" in
+    --all) files=$(git ls-files -- ':(exclude)*.lock') ;;
+    diff|--diff) files=$(git diff --diff-filter=AMR --name-only HEAD -- ':(exclude)*.lock') ;;
+    *) echo "Usage: $(basename "$0") [--all]" >&2; exit 2 ;;
+esac
+
+[ -z "$files" ] && { echo "(no files to check)"; exit 0; }
+
+# ----- Check 1: hard-coded /home/<user>/... paths -----
+hits1=$(echo "$files" | xargs -r grep -nE '/home/[a-z][a-z0-9_-]+/' 2>/dev/null || true)
+
+# ----- Check 2: per-user dotfile *config* refs in committed docs/configs -----
+# Carve-outs (allowed, NOT flagged):
+#   - ~/.claude/skills/<x>/scripts/   vendored tool calls
+#   - ~/.culture/                     Culture mesh data this skill is supposed to read
+md_yaml=$(echo "$files" | grep -E '\.(md|ya?ml|toml|json|jsonc)$' || true)
+if [ -n "$md_yaml" ]; then
+    hits2=$(echo "$md_yaml" | xargs -r grep -nE '~/\.[A-Za-z]' 2>/dev/null \
+        | grep -vE '~/\.claude/skills/[^[:space:]"]+/scripts/' \
+        | grep -vE '~/\.culture/' \
+        || true)
+else
+    hits2=""
+fi
+
+fail=0
+if [ -n "$hits1" ]; then
+    echo "❌ Hard-coded /home/<user>/ paths:"
+    echo "$hits1" | sed 's/^/    /'
+    echo "   Fix: use ../sibling, repo URL, or \$WORKSPACE/sibling instead."
+    fail=1
+fi
+if [ -n "$hits2" ]; then
+    [ "$fail" -eq 1 ] && echo
+    echo "❌ Per-user ~/.<dotfile> config refs in committed doc/config:"
+    echo "$hits2" | sed 's/^/    /'
+    echo "   Allowed carve-outs: ~/.claude/skills/.../scripts/ (tool calls), ~/.culture/ (mesh data)."
+    echo "   Otherwise: commit a repo-local config or document a portable lookup."
+    fail=1
+fi
+
+[ "$fail" -eq 0 ] && echo "✓ portability lint clean ($(echo "$files" | wc -l | tr -d ' ') files checked)"
+exit $fail

--- a/.claude/skills/pr-review/scripts/pr-batch.sh
+++ b/.claude/skills/pr-review/scripts/pr-batch.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Batch reply to PR review comments from JSONL on stdin.
+# Each line: {"comment_id": 123, "body": "reply text"}
+# Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl
+
+REPO=""
+RESOLVE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_FLAG=""
+if [[ "$RESOLVE" == true ]]; then
+    RESOLVE_FLAG="--resolve"
+fi
+
+SUCCESS=0
+FAIL=0
+
+while IFS= read -r line; do
+    # Skip empty lines
+    [[ -z "$line" ]] && continue
+
+    COMMENT_ID=$(echo "$line" | jq -r '.comment_id')
+    BODY=$(echo "$line" | jq -r '.body')
+
+    if [[ "$COMMENT_ID" == "null" || "$BODY" == "null" ]]; then
+        echo "SKIP: invalid line: $line"
+        ((FAIL++)) || true
+        continue
+    fi
+
+    echo "--- Comment $COMMENT_ID ---"
+    if bash "$SCRIPT_DIR/pr-reply.sh" --repo "$REPO" $RESOLVE_FLAG "$PR_NUMBER" "$COMMENT_ID" "$BODY"; then
+        ((SUCCESS++)) || true
+    else
+        echo "FAILED: comment $COMMENT_ID"
+        ((FAIL++)) || true
+    fi
+done
+
+echo ""
+echo "Done: $SUCCESS succeeded, $FAIL failed"

--- a/.claude/skills/pr-review/scripts/pr-comments.sh
+++ b/.claude/skills/pr-review/scripts/pr-comments.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch and display all PR feedback in one pass:
+#   1. Inline review comments (with thread resolve status)
+#   2. Issue comments (qodo summaries, sonarcloud, etc.)
+#   3. Top-level reviews with a non-empty body (copilot overview, etc.)
+#
+# Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER
+
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# ── Section 1: inline review comments ─────────────────────────────────────
+THREADS_JSON=$(gh api graphql -f query="
+{
+  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 100) {
+            nodes { databaseId }
+          }
+        }
+      }
+    }
+  }
+}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+# Build a map from every comment ID in every thread → its thread metadata,
+# so replies in a thread also show resolved status (not just the first comment).
+THREAD_MAP=$(echo "$THREADS_JSON" | jq -r '
+  [.[] as $t | $t.comments.nodes[] | {
+    comment_id: .databaseId,
+    thread_id: $t.id,
+    resolved: $t.isResolved
+  }]
+')
+
+INLINE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate)
+INLINE_COUNT=$(echo "$INLINE" | jq 'length')
+
+echo "════════════════ INLINE REVIEW COMMENTS ($INLINE_COUNT) ════════════════"
+echo "$INLINE" | jq -r --argjson threads "$THREAD_MAP" '
+  .[] | . as $c |
+  ($threads | map(select(.comment_id == $c.id)) | first // {resolved: "unknown", thread_id: "?"}) as $t |
+  "──────────────────────────────────────────────────",
+  "ID: \($c.id)  |  Thread: \(if $t.resolved == true then "RESOLVED" elif $t.resolved == false then "UNRESOLVED" else "?" end)  |  Reply-to: \($c.in_reply_to_id // "none")",
+  "File: \($c.path):\($c.original_line // $c.line // "?")",
+  "Thread ID: \($t.thread_id)",
+  "Author: \($c.user.login)",
+  "",
+  ($c.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'
+
+# ── Section 2: issue comments (general PR comments) ───────────────────────
+ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate)
+ISSUE_COUNT=$(echo "$ISSUE" | jq 'length')
+
+echo ""
+echo "════════════════ ISSUE COMMENTS ($ISSUE_COUNT) ════════════════"
+echo "$ISSUE" | jq -r '
+  .[] |
+  "──────────────────────────────────────────────────",
+  "ID: \(.id)  |  Author: \(.user.login)  |  Created: \(.created_at)",
+  "",
+  (.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'
+
+# ── Section 3: top-level reviews with a body ──────────────────────────────
+REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate)
+REVIEWS_WITH_BODY=$(echo "$REVIEWS" | jq '[.[] | select((.body // "") != "")]')
+REVIEW_COUNT=$(echo "$REVIEWS_WITH_BODY" | jq 'length')
+
+echo ""
+echo "════════════════ TOP-LEVEL REVIEWS ($REVIEW_COUNT) ════════════════"
+echo "$REVIEWS_WITH_BODY" | jq -r '
+  .[] |
+  "──────────────────────────────────────────────────",
+  "Review ID: \(.id)  |  Author: \(.user.login)  |  State: \(.state)  |  Submitted: \(.submitted_at)",
+  "",
+  (.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'

--- a/.claude/skills/pr-review/scripts/pr-reply.sh
+++ b/.claude/skills/pr-review/scripts/pr-reply.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reply to a PR review comment, optionally resolve its thread.
+# Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID "body"
+
+REPO=""
+RESOLVE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID \"body\"}"
+COMMENT_ID="${2:?Missing COMMENT_ID}"
+BODY="${3:?Missing reply body}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# Append signature only if the body isn't already signed.
+if ! printf '%s' "$BODY" | grep -qE '(^|\n)[[:space:]]*-[[:space:]]+Claude[[:space:]]*$'; then
+    BODY="${BODY}
+
+- Claude"
+fi
+
+# Post reply
+REPLY_URL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies" \
+    -f body="$BODY" \
+    --jq '.html_url')
+echo "Replied: $REPLY_URL"
+
+# Resolve thread if requested
+if [[ "$RESOLVE" == true ]]; then
+    # Find the thread ID for this comment
+    THREAD_ID=$(gh api graphql -f query="
+    {
+      repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+        pullRequest(number: $PR_NUMBER) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              comments(first: 100) {
+                nodes { databaseId }
+              }
+            }
+          }
+        }
+      }
+    }" --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select(any(.comments.nodes[]; .databaseId == $COMMENT_ID)) | .id")
+
+    if [[ -n "$THREAD_ID" ]]; then
+        RESOLVED=$(gh api graphql -f query="
+          mutation { resolveReviewThread(input: {threadId: \"$THREAD_ID\"}) { thread { isResolved } } }
+        " --jq '.data.resolveReviewThread.thread.isResolved')
+        echo "Resolved: $RESOLVED (thread $THREAD_ID)"
+    else
+        echo "Warning: could not find thread for comment $COMMENT_ID"
+    fi
+fi

--- a/.claude/skills/pr-review/scripts/pr-status.sh
+++ b/.claude/skills/pr-review/scripts/pr-status.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# pr-status.sh — one-shot status overview for a Steward PR.
+#
+# Combines five things review feedback usually scatters across:
+#   1. PR state (open / merged / closed) + branch + author
+#   2. CI checks (build / lint / unit / sonarcloud / cf-pages / etc.)
+#   3. Review-bot pipeline status (Copilot, qodo, SonarCloud, Cloudflare)
+#   4. SonarCloud quality gate + open-issue count
+#   5. Inline-thread resolved-vs-unresolved tally
+#
+# Usage: scripts/pr-status.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER
+#
+# Defaults:
+#   --repo           auto-detected via `gh repo view`
+#   --sonar-key      derived from repo as `<owner>_<name>` (SonarCloud convention)
+#
+# Requires: gh, jq, curl, python3.
+
+set -euo pipefail
+
+REPO=""
+SONAR_KEY=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --sonar-key) SONAR_KEY="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-status.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+if [[ -z "$SONAR_KEY" ]]; then
+    SONAR_KEY="${REPO%%/*}_${REPO##*/}"
+fi
+
+# ── 1. PR header ──────────────────────────────────────────────────────────
+PR_JSON=$(gh pr view "$PR_NUMBER" --json \
+    number,title,state,isDraft,mergedAt,mergedBy,baseRefName,headRefName,author,url)
+
+echo "════════════════════════════════════════════════════════════════════"
+echo "$PR_JSON" | jq -r '
+    "PR #\(.number) — \(.title)",
+    "  \(.url)",
+    "  Author:  \(.author.login)",
+    "  Branch:  \(.headRefName)  →  \(.baseRefName)",
+    "  State:   \(if .state == "MERGED" then "MERGED at \(.mergedAt) by \(.mergedBy.login)" elif .state == "OPEN" and .isDraft then "OPEN (draft)" else .state end)"
+'
+echo "════════════════════════════════════════════════════════════════════"
+
+# ── 2. CI checks ──────────────────────────────────────────────────────────
+echo
+echo "── CI checks ─────────────────────────────────────────────────────────"
+# `gh pr checks` exits non-zero when checks are still pending/failing.
+# We don't care about its exit code here; capture and pretty-print.
+CHECKS=$(gh pr checks "$PR_NUMBER" 2>/dev/null || true)
+if [[ -z "$CHECKS" ]]; then
+    echo "  (no checks reported)"
+else
+    echo "$CHECKS" | awk -F'\t' '
+        {
+            name  = $1
+            state = $2
+            dur   = $3
+            sym   = "?"
+            if (state == "pass")            sym = "✅"
+            else if (state == "fail")       sym = "❌"
+            else if (state == "skipping")   sym = "⏭"
+            else if (state == "pending"  || state == "queued"   || state == "in_progress") sym = "…"
+            printf "  %s %-22s %-10s %s\n", sym, name, state, dur
+        }
+    '
+fi
+
+# ── 3. Review bots & comment pipeline ────────────────────────────────────
+echo
+echo "── Review pipeline ───────────────────────────────────────────────────"
+
+# Inline-thread tally via GraphQL (resolved vs unresolved).
+THREADS_JSON=$(gh api graphql -f query="
+{
+  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes { id isResolved comments(first: 1) { nodes { author { login } } } }
+      }
+    }
+  }
+}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+INLINE_TOTAL=$(echo "$THREADS_JSON" | jq 'length')
+INLINE_RESOLVED=$(echo "$THREADS_JSON" | jq '[.[] | select(.isResolved)] | length')
+INLINE_PENDING=$((INLINE_TOTAL - INLINE_RESOLVED))
+
+# Per-bot inline counts.
+COPILOT_INLINE=$(echo "$THREADS_JSON" | jq '[.[] | select((.comments.nodes[0].author.login // "") | startswith("Copilot"))] | length')
+QODO_INLINE=$(echo "$THREADS_JSON" | jq '[.[] | select((.comments.nodes[0].author.login // "") | startswith("qodo"))] | length')
+
+# Issue-level comments (qodo summary, sonarcloud quality-gate body, cf-pages preview, etc.).
+# Skip --paginate to avoid array concatenation; per_page=100 covers typical PRs.
+ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100")
+QODO_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | startswith("qodo"))] | length')
+SONARQUBE_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | startswith("sonarqubecloud"))] | length')
+CFPAGES_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | test("cloudflare"))] | length')
+COPILOT_TOPLEVEL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
+    | jq '[.[] | select((.user.login // "") | startswith("copilot")) | select((.body // "") != "")] | length')
+
+# Cloudflare deploy URL hidden in issue-comment bodies (look for pages.dev).
+CF_URL=$(echo "$ISSUE" | jq -r '[.[].body // "" | scan("https?://[a-z0-9.-]+\\.pages\\.dev[^\\s)\"<]*")] | first // ""')
+
+printf "  %-12s %s\n"  "Copilot"     "$([[ "$COPILOT_TOPLEVEL" -gt 0 || "$COPILOT_INLINE" -gt 0 ]] && echo "✅ overview×$COPILOT_TOPLEVEL, inline×$COPILOT_INLINE" || echo "— no posts yet")"
+printf "  %-12s %s\n"  "qodo"        "$([[ "$QODO_ISSUE" -gt 0 || "$QODO_INLINE" -gt 0 ]] && echo "✅ summary×$QODO_ISSUE, inline×$QODO_INLINE" || echo "— no posts yet")"
+printf "  %-12s %s\n"  "Cloudflare"  "$([[ -n "$CF_URL" ]] && echo "✅ $CF_URL" || ([[ "$CFPAGES_ISSUE" -gt 0 ]] && echo "✅ ($CFPAGES_ISSUE comments)" || echo "— no deploy preview"))"
+
+# ── 4. SonarCloud quality gate + open issues ─────────────────────────────
+SONAR_QG=$(curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}")
+SONAR_QG_STATUS=$(echo "$SONAR_QG" | jq -r '.projectStatus.status // "UNKNOWN"')
+SONAR_OPEN=$(curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=1" \
+    | jq -r '.total // 0')
+SONAR_HOTSPOTS=$(curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}&status=TO_REVIEW&ps=1" \
+    | jq -r '.paging.total // 0')
+
+case "$SONAR_QG_STATUS" in
+    OK)    SONAR_SYM="✅" ;;
+    ERROR) SONAR_SYM="❌" ;;
+    WARN)  SONAR_SYM="⚠ " ;;
+    *)     SONAR_SYM="?" ;;
+esac
+printf "  %-12s %s Quality Gate %s, %d OPEN issue(s), %d hotspot(s)\n" \
+    "SonarCloud" "$SONAR_SYM" "$SONAR_QG_STATUS" "$SONAR_OPEN" "$SONAR_HOTSPOTS"
+
+# When SonarCloud has OPEN issues, list them — saves a follow-up curl.
+if [[ "$SONAR_OPEN" != "0" ]]; then
+    echo
+    echo "  SonarCloud OPEN issues:"
+    curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=20" \
+        | jq -r '.issues[] | "    • [\(.rule)] \(.component | sub("^[^:]+:"; ""))(:\(.line // "?")) (\(.severity)) — \(.message)"'
+fi
+
+# ── 5. Tally + summary ────────────────────────────────────────────────────
+echo
+echo "── Inline threads ────────────────────────────────────────────────────"
+printf "  Total: %d   Resolved: %d   Unresolved: %d\n" \
+    "$INLINE_TOTAL" "$INLINE_RESOLVED" "$INLINE_PENDING"
+
+if [[ "$INLINE_PENDING" -gt 0 ]]; then
+    echo
+    echo "  Unresolved threads:"
+    echo "$THREADS_JSON" | jq -r '
+        .[] | select(.isResolved == false) |
+        "    • \(.comments.nodes[0].author.login): thread \(.id)"
+    '
+fi
+
+echo
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "(For full comment bodies: bash \"$SCRIPT_DIR/pr-comments.sh\" $PR_NUMBER)"

--- a/.claude/skills/pr-review/scripts/workflow.sh
+++ b/.claude/skills/pr-review/scripts/workflow.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Steward pr-review workflow entry point.
+#
+# Subcommands:
+#   lint              run the portability lint on the current diff (staged + unstaged)
+#   poll <PR>         fetch and display review comments
+#   reply <PR>        batch reply to review comments (JSONL on stdin), --resolve
+#   delta             dump CLAUDE.md head + culture.yaml for each sibling project
+#                     listed in skills.local.yaml (alignment-delta check)
+#   help              print this message
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+
+CFG="$REPO_ROOT/.claude/skills.local.yaml"
+[ -f "$CFG" ] || CFG="$REPO_ROOT/.claude/skills.local.yaml.example"
+
+# Read a top-level YAML list from CFG. Schema is intentionally tiny:
+#   <key>:
+#     - item
+#     - item
+# Stops at the next top-level key. No PyYAML dependency.
+read_list() {
+    awk -v key="$1" '
+        function trim(s) { sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s); return s }
+        {
+            line = $0
+            sub(/[[:space:]]+#.*$/, "", line)
+        }
+        in_list && line ~ /^[[:space:]]*-[[:space:]]*/ {
+            item = line
+            sub(/^[[:space:]]*-[[:space:]]*/, "", item)
+            item = trim(item)
+            sub(/^["\047]/, "", item); sub(/["\047]$/, "", item)
+            if (item != "") print item
+            next
+        }
+        in_list && line ~ /^[^[:space:]#]/ { exit }
+        line ~ ("^" key ":[[:space:]]*($|#)") { in_list = 1 }
+    ' "$CFG"
+}
+
+cmd="${1:-help}"
+shift || true
+
+case "$cmd" in
+    lint)
+        bash "$SCRIPT_DIR/portability-lint.sh"
+        ;;
+    poll)
+        PR="${1:?Usage: workflow.sh poll <PR>}"
+        bash "$SCRIPT_DIR/pr-comments.sh" "$PR"
+        ;;
+    reply)
+        PR="${1:?Usage: workflow.sh reply <PR>  (JSONL on stdin)}"
+        bash "$SCRIPT_DIR/pr-batch.sh" --resolve "$PR"
+        ;;
+    delta)
+        any=0
+        while IFS= read -r sibling; do
+            [ -z "$sibling" ] && continue
+            any=1
+            sibling_abs="$REPO_ROOT/$sibling"
+            if [ ! -d "$sibling_abs" ] && [ ! -d "$sibling" ]; then
+                echo "=== $sibling ==="
+                echo "(not present on disk — skipped)"
+                continue
+            fi
+            target="$sibling_abs"
+            [ -d "$target" ] || target="$sibling"
+            echo "=== $target ==="
+            if [ -f "$target/CLAUDE.md" ]; then
+                head -40 "$target/CLAUDE.md"
+                echo "..."
+            else
+                echo "(no CLAUDE.md)"
+            fi
+            echo "--- culture.yaml ---"
+            if [ -f "$target/culture.yaml" ]; then
+                cat "$target/culture.yaml"
+            else
+                echo "(no culture.yaml)"
+            fi
+            echo
+        done < <(read_list sibling_projects)
+        [ "$any" -eq 0 ] && echo "(no sibling_projects configured in $CFG)"
+        ;;
+    help|--help|-h)
+        sed -n '2,11p' "${BASH_SOURCE[0]}" | sed 's/^# *//'
+        ;;
+    *)
+        echo "unknown subcommand: $cmd" >&2
+        echo "run '$(basename "$0") help' for usage." >&2
+        exit 2
+        ;;
+esac

--- a/.claude/skills/pypi-maintainer/SKILL.md
+++ b/.claude/skills/pypi-maintainer/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pypi-maintainer
+description: >
+  Switch a PyPI package install between the production index, TestPyPI
+  pre-release builds, and a local editable checkout. Use when an agent
+  maintains a package and needs to verify a TestPyPI dev build before
+  promoting to production, or when the user says "install from
+  test-pypi", "switch to local", "change package source", or
+  "install from pypi".
+---
+
+# PyPI Maintainer
+
+Switch the install source for a package the agent maintains. Three sources
+are supported: production PyPI, TestPyPI (pre-release / dev builds), and a
+local editable checkout. The same script works for any package an
+AgentCulture sibling publishes — pass the package name as the first
+argument.
+
+## When to use
+
+- Verifying a PR's TestPyPI dev build before merging.
+- Reproducing a user-reported bug against the published version.
+- Hot-patching against a local checkout while a fix is in flight.
+- Restoring the production install after local-mode debugging.
+
+## Usage
+
+```bash
+# Production PyPI
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> pypi
+
+# TestPyPI (pre-release dev builds)
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> test-pypi
+
+# TestPyPI, pinned to a specific dev version
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> test-pypi --version 0.4.0.dev42
+
+# Local editable checkout (defaults to current directory)
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> local
+
+# Local editable from an explicit path
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> local --path ../<package>
+```
+
+## Prerequisites
+
+The script requires the following tools on `PATH`:
+
+- `bash`
+- `uv` — the script delegates to `uv tool install` and `uv tool list`
+  (or `uv pip install` for `local`).
+
+## Why TestPyPI needs special flags
+
+When a package is published to **both** PyPI and TestPyPI, `uv tool install`
+finds the production version on PyPI first and never looks at TestPyPI.
+The script passes `--index-strategy unsafe-best-match` so uv compares the
+two index sets and picks the highest version, plus `--prerelease=allow`
+because TestPyPI builds carry dev suffixes (e.g. `0.4.0.dev42`).
+
+## After running
+
+The script prints the resolved version once install completes — cross-check
+that against the expected version (PR run number, local `pyproject.toml`)
+before continuing.
+
+## Arguments
+
+| Position / flag | Meaning |
+|-----------------|---------|
+| `<package>` (required) | The PyPI distribution name, e.g. `steward-cli`, `culture`, `daria-cli`. |
+| `<source>` (required)  | One of `pypi`, `test-pypi`, `local`. |
+| `--version VERSION`    | Pin to a specific version (TestPyPI builds typically need this). |
+| `--path PATH`          | Local-source-only: path to the editable checkout (default: cwd). |

--- a/.claude/skills/pypi-maintainer/scripts/switch-source.sh
+++ b/.claude/skills/pypi-maintainer/scripts/switch-source.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# switch-source.sh — Switch a PyPI package install between pypi / test-pypi / local.
+#
+# Usage:
+#   switch-source.sh <package> pypi
+#   switch-source.sh <package> test-pypi [--version VERSION]
+#   switch-source.sh <package> local [--path PATH]
+#
+# Generalised from the original culture-specific change-package skill so any
+# AgentCulture sibling that publishes a PyPI package can vendor and use it.
+
+set -euo pipefail
+
+PACKAGE=""
+SOURCE=""
+VERSION=""
+LOCAL_PATH=""
+
+usage() {
+  cat <<EOF >&2
+Usage: switch-source.sh <package> <pypi|test-pypi|local> [options]
+
+Options:
+  --version VERSION   Pin to a specific version (most useful for test-pypi
+                      dev builds, e.g. --version 0.4.0.dev42).
+  --path PATH         Local source only: path to editable checkout
+                      (default: current directory).
+  -h, --help          Show this help.
+EOF
+}
+
+# --- Parse args ---
+require_value() {
+  local flag="$1" remaining="$2"
+  if [[ "$remaining" -lt 2 ]]; then
+    echo "Error: $flag requires a value" >&2
+    usage
+    exit 1
+  fi
+}
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) require_value "$1" "$#"; VERSION="$2"; shift 2 ;;
+    --path)    require_value "$1" "$#"; LOCAL_PATH="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    --*)       echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    *)         POSITIONAL+=("$1"); shift ;;
+  esac
+done
+
+if [[ ${#POSITIONAL[@]} -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+PACKAGE="${POSITIONAL[0]}"
+SOURCE="${POSITIONAL[1]}"
+
+# --- Resolve install spec for pinned versions ---
+SPEC="$PACKAGE"
+if [[ -n "$VERSION" ]]; then
+  SPEC="${PACKAGE}==${VERSION}"
+fi
+
+case "$SOURCE" in
+  pypi)
+    echo "Installing $SPEC from production PyPI..."
+    uv tool install "$SPEC" --force
+    ;;
+  test-pypi)
+    echo "Installing $SPEC from TestPyPI..."
+    uv tool install "$SPEC" \
+      --index-url https://test.pypi.org/simple/ \
+      --extra-index-url https://pypi.org/simple/ \
+      --index-strategy unsafe-best-match \
+      --prerelease=allow \
+      --force
+    ;;
+  local)
+    if [[ -z "$LOCAL_PATH" ]]; then
+      LOCAL_PATH="$(pwd)"
+    fi
+    if [[ ! -f "$LOCAL_PATH/pyproject.toml" ]]; then
+      echo "Error: $LOCAL_PATH does not contain a pyproject.toml" >&2
+      exit 1
+    fi
+    echo "Installing $PACKAGE in editable mode from $LOCAL_PATH..."
+    uv tool install --from "$LOCAL_PATH" --editable "$PACKAGE" --force
+    ;;
+  *)
+    echo "Unknown source: $SOURCE (expected pypi, test-pypi, or local)" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+# --- Report what is now active ---
+echo
+echo "Installed tools matching '$PACKAGE':"
+uv tool list 2>/dev/null | awk -v pkg="$PACKAGE" 'tolower($1) == tolower(pkg) {print "  " $0}'

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: run-tests
+description: Run pytest with parallel execution and coverage. Use when running tests, verifying changes, or the user says "run tests", "test", or "pytest".
+---
+
+# Run Tests
+
+Run the project's pytest suite with optional parallelism (pytest-xdist) and coverage.
+Coverage targets are read from `pyproject.toml`'s `[tool.coverage.run]` section,
+so the same script works in any sibling repo without modification.
+
+## Usage
+
+```bash
+# Default: parallel + verbose (recommended)
+bash .claude/skills/run-tests/scripts/test.sh -p
+
+# Quick check: parallel + quiet
+bash .claude/skills/run-tests/scripts/test.sh -p -q
+
+# Full CI mode: parallel + coverage + xml report
+bash .claude/skills/run-tests/scripts/test.sh --ci
+
+# Specific test file
+bash .claude/skills/run-tests/scripts/test.sh -p tests/test_socket_server.py
+
+# Without parallelism (for debugging test ordering issues)
+bash .claude/skills/run-tests/scripts/test.sh tests/test_rooms.py
+
+# With coverage
+bash .claude/skills/run-tests/scripts/test.sh -p -c
+```
+
+## Options
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--parallel` | `-p` | Run with `-n auto` (pytest-xdist, uses all CPU cores) |
+| `--coverage` | `-c` | Enable coverage reporting to terminal |
+| `--ci` | | Full CI mode: parallel + coverage + XML report + verbose |
+| `--quick` | `-q` | Quiet output (no verbose, no coverage) |
+
+Extra arguments are passed through to pytest (e.g., `-x` for stop-on-first-failure, `-k "pattern"` for filtering).
+
+## When to Use Which Mode
+
+- **After code changes:** `bash test.sh -p` — fast parallel run, verbose output
+- **Quick sanity check:** `bash test.sh -p -q` — minimal output
+- **Before PR / release:** `bash test.sh --ci` — matches CI exactly
+- **Debugging flaky test:** `bash test.sh tests/test_flaky.py` — sequential, single file

--- a/.claude/skills/run-tests/scripts/test.sh
+++ b/.claude/skills/run-tests/scripts/test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Run pytest with optional parallelism and coverage.
+# Usage: bash test.sh [OPTIONS] [PYTEST_ARGS...]
+#
+# Options:
+#   --parallel, -p    Run with -n auto (pytest-xdist)
+#   --coverage, -c    Enable coverage reporting
+#   --ci              Mimic full CI invocation (-n auto + coverage + xml)
+#   --quick, -q       Quick mode: no coverage, quiet output
+#
+# When --coverage or --ci is passed, this script invokes pytest-cov with --cov
+# (no module spec). pytest-cov / coverage.py then resolve the source set via
+# the standard config lookup — typically [tool.coverage.run] source in
+# pyproject.toml — so the same script works in any sibling without edits.
+#
+# Extra args are passed through to pytest.
+
+set -euo pipefail
+
+PARALLEL=""
+COVERAGE=""
+CI_MODE=""
+QUIET=""
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --parallel|-p) PARALLEL=1; shift ;;
+        --coverage|-c) COVERAGE=1; shift ;;
+        --ci)          CI_MODE=1; shift ;;
+        --quick|-q)    QUIET=1; shift ;;
+        *)             EXTRA_ARGS+=("$1"); shift ;;
+    esac
+done
+
+CMD=(uv run pytest)
+
+if [[ -n "$CI_MODE" ]]; then
+    CMD+=(-n auto --cov --cov-report=xml:coverage.xml --cov-report=term -v)
+elif [[ -n "$QUIET" ]]; then
+    CMD+=(-q)
+    [[ -n "$PARALLEL" ]] && CMD+=(-n auto)
+else
+    [[ -n "$PARALLEL" ]] && CMD+=(-n auto)
+    [[ -n "$COVERAGE" ]] && CMD+=(--cov --cov-report=term)
+    CMD+=(-v)
+fi
+
+CMD+=("${EXTRA_ARGS[@]}")
+
+echo "Running: ${CMD[*]}"
+exec "${CMD[@]}"

--- a/.claude/skills/sonarclaude/SKILL.md
+++ b/.claude/skills/sonarclaude/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: sonarclaude
+description: >
+  Query SonarCloud API for code quality data. Use when: checking quality gate status,
+  fetching code issues or security hotspots, reviewing metrics (coverage, bugs, code smells),
+  or the user says "sonar", "quality gate", "code quality", "sonarclaude".
+---
+
+# SonarClaude
+
+Query SonarCloud projects for quality gate status, issues, metrics, and security hotspots.
+
+## Prerequisites
+
+The script requires the following tools on `PATH`:
+
+- `bash`
+- `curl` — talks to the SonarCloud REST API
+- `jq` — parses responses and URL-encodes accept comments
+
+## Environment
+
+Requires `SONAR_TOKEN` environment variable. Set the project key per-repo via
+the `SONAR_PROJECT` environment variable (or pass `--project KEY` on each
+invocation).
+
+## Usage
+
+```bash
+# Quality gate status (pass/fail)
+bash .claude/skills/sonarclaude/scripts/sonar.sh status
+
+# List issues (bugs, vulnerabilities, code smells)
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues
+
+# Filter issues by severity and type
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues --severity CRITICAL --type BUG
+
+# Key metrics (coverage, bugs, code smells, duplication, LOC)
+bash .claude/skills/sonarclaude/scripts/sonar.sh metrics
+
+# Security hotspots
+bash .claude/skills/sonarclaude/scripts/sonar.sh hotspots
+
+# Accept (won't-fix) an OPEN issue with a rationale comment
+bash .claude/skills/sonarclaude/scripts/sonar.sh accept \
+  --issue AZ3Ep83i4ywi8V_l99p0 \
+  --comment "Pushback: rule premise doesn't fit our test fixture pattern."
+
+# Different project
+bash .claude/skills/sonarclaude/scripts/sonar.sh status --project OtherOrg_OtherProject
+
+# Raw JSON output
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues --raw
+
+# Limit results
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues --limit 10
+```
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--project` | `$SONAR_PROJECT` | SonarCloud project key |
+| `--severity` | all | Filter: `BLOCKER`, `CRITICAL`, `MAJOR`, `MINOR`, `INFO` |
+| `--type` | all | Filter: `BUG`, `VULNERABILITY`, `CODE_SMELL` |
+| `--limit` | `25` | Max results returned |
+| `--raw` | off | Output raw JSON instead of formatted summary |
+| `--issue` | — | Issue key (required for `accept`) |
+| `--comment` | — | Rationale comment (required for `accept`) |
+
+## When to use `accept`
+
+Sonar rules occasionally flag patterns where the rule's premise does not fit the
+code (e.g. test fixtures with intentional bad-password literals, contradictory
+rule pairs like S7494 vs S7500). After deciding pushback in PR review, run
+`sonar.sh accept` with a rationale comment instead of leaving the issue OPEN —
+this moves it to ACCEPTED/WONTFIX in SonarCloud history (visible to future
+maintainers) while clearing the quality-gate signal. Always include a `--comment`
+explaining why; silent dismissals are not acceptable curation.
+
+Do not call SonarCloud's HTTP API directly from other skills or one-off
+scripts — `sonar.sh accept` is the supported entry point so the rationale
+flow stays consistent.

--- a/.claude/skills/sonarclaude/scripts/sonar.sh
+++ b/.claude/skills/sonarclaude/scripts/sonar.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SonarCloud API client for Claude Code.
+# Requires SONAR_TOKEN environment variable.
+# Project key resolves from --project flag, then $SONAR_PROJECT.
+
+BASE_URL="https://sonarcloud.io"
+
+# --- Defaults ---
+PROJECT="${SONAR_PROJECT:-}"
+SEVERITY=""
+TYPE=""
+LIMIT=25
+RAW=false
+COMMAND=""
+ISSUE_KEY=""
+ACCEPT_COMMENT=""
+
+require_value() {
+  local flag="$1" remaining="$2"
+  if [[ "$remaining" -lt 2 ]]; then
+    echo "Error: $flag requires a value" >&2
+    echo "Run sonar.sh --help for usage." >&2
+    exit 1
+  fi
+}
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    status|issues|metrics|hotspots|accept)
+      COMMAND="$1"; shift ;;
+    --project|-p)   require_value "$1" "$#"; PROJECT="$2";        shift 2 ;;
+    --severity|-s)  require_value "$1" "$#"; SEVERITY="$2";       shift 2 ;;
+    --type|-t)      require_value "$1" "$#"; TYPE="$2";           shift 2 ;;
+    --limit|-l)     require_value "$1" "$#"; LIMIT="$2";          shift 2 ;;
+    --raw|-r)       RAW=true;                                     shift ;;
+    --issue|-i)     require_value "$1" "$#"; ISSUE_KEY="$2";      shift 2 ;;
+    --comment|-c)   require_value "$1" "$#"; ACCEPT_COMMENT="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: sonar.sh <command> [options]"
+      echo ""
+      echo "Commands:"
+      echo "  status    Quality gate status (pass/fail)"
+      echo "  issues    List code issues (bugs, vulnerabilities, code smells)"
+      echo "  metrics   Key code metrics (coverage, bugs, duplication, LOC)"
+      echo "  hotspots  Security hotspots"
+      echo "  accept    Mark an OPEN issue as ACCEPTED with a rationale comment"
+      echo ""
+      echo "Options:"
+      echo "  --project, -p KEY       Project key (default: \$SONAR_PROJECT)"
+      echo "  --severity, -s LEVEL    Filter: BLOCKER, CRITICAL, MAJOR, MINOR, INFO"
+      echo "  --type, -t TYPE         Filter: BUG, VULNERABILITY, CODE_SMELL"
+      echo "  --limit, -l N           Max results (default: 25)"
+      echo "  --raw, -r               Output raw JSON"
+      echo "  --issue, -i KEY         Issue key (required for 'accept')"
+      echo "  --comment, -c TEXT      Rationale comment (required for 'accept')"
+      echo "  --help, -h              Show this help"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# --- Validate ---
+if [[ -z "${SONAR_TOKEN:-}" ]]; then
+  echo "Error: SONAR_TOKEN environment variable is not set." >&2
+  exit 1
+fi
+
+if [[ -z "$COMMAND" ]]; then
+  echo "Error: No command provided." >&2
+  echo "Usage: sonar.sh <status|issues|metrics|hotspots|accept> [options]" >&2
+  exit 1
+fi
+
+if [[ -z "$PROJECT" ]]; then
+  echo "Error: No project key. Set \$SONAR_PROJECT or pass --project KEY." >&2
+  exit 1
+fi
+
+# --- API helper ---
+api_get() {
+  local endpoint="$1"
+  curl -s -f -H "Authorization: Bearer $SONAR_TOKEN" "${BASE_URL}${endpoint}"
+}
+
+# --- Commands ---
+
+cmd_status() {
+  local response
+  response=$(api_get "/api/qualitygates/project_status?projectKey=${PROJECT}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  local status conditions
+  status=$(echo "$response" | jq -r '.projectStatus.status')
+  conditions=$(echo "$response" | jq -r '.projectStatus.conditions[]? | "  \(.metricKey): \(.actualValue) (threshold: \(.errorThreshold), status: \(.status))"')
+
+  if [[ "$status" == "OK" ]]; then
+    echo "Quality Gate: PASSED"
+  elif [[ "$status" == "ERROR" ]]; then
+    echo "Quality Gate: FAILED"
+  else
+    echo "Quality Gate: $status"
+  fi
+
+  if [[ -n "$conditions" ]]; then
+    echo ""
+    echo "Conditions:"
+    echo "$conditions"
+  fi
+}
+
+cmd_issues() {
+  local params="componentKeys=${PROJECT}&ps=${LIMIT}"
+  [[ -n "$SEVERITY" ]] && params="${params}&severities=${SEVERITY}"
+  [[ -n "$TYPE" ]] && params="${params}&types=${TYPE}"
+
+  local response
+  response=$(api_get "/api/issues/search?${params}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  local total
+  total=$(echo "$response" | jq -r '.total')
+  echo "Issues: $total total (showing up to $LIMIT)"
+  echo ""
+
+  echo "$response" | jq -r '.issues[]? | "[\(.severity)] \(.type) — \(.message)\n  File: \(.component | split(":")[1]? // .component)\n  Line: \(.line // "n/a")  Rule: \(.rule)\n"'
+}
+
+# Convert SonarCloud numeric rating to letter grade
+rating_letter() {
+  case "$1" in
+    1|1.0) echo "A" ;;
+    2|2.0) echo "B" ;;
+    3|3.0) echo "C" ;;
+    4|4.0) echo "D" ;;
+    5|5.0) echo "E" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+cmd_metrics() {
+  local metric_keys="bugs,vulnerabilities,code_smells,coverage,duplicated_lines_density,ncloc,sqale_rating,reliability_rating,security_rating,alert_status"
+
+  local response
+  response=$(api_get "/api/measures/component?component=${PROJECT}&metricKeys=${metric_keys}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  echo "Metrics for: $PROJECT"
+  echo ""
+
+  echo "$response" | jq -r '.component.measures[]? | "\(.metric): \(.value)"' | while IFS=: read -r key val; do
+    key=$(echo "$key" | xargs)
+    val=$(echo "$val" | xargs)
+    case "$key" in
+      alert_status)
+        echo "  Quality Gate:     $val" ;;
+      bugs)
+        echo "  Bugs:             $val" ;;
+      vulnerabilities)
+        echo "  Vulnerabilities:  $val" ;;
+      code_smells)
+        echo "  Code Smells:      $val" ;;
+      coverage)
+        echo "  Coverage:         ${val}%" ;;
+      duplicated_lines_density)
+        echo "  Duplication:      ${val}%" ;;
+      ncloc)
+        echo "  Lines of Code:    $val" ;;
+      sqale_rating)
+        echo "  Maintainability:  $(rating_letter "$val")" ;;
+      reliability_rating)
+        echo "  Reliability:      $(rating_letter "$val")" ;;
+      security_rating)
+        echo "  Security:         $(rating_letter "$val")" ;;
+      *)
+        echo "  $key: $val" ;;
+    esac
+  done
+}
+
+cmd_hotspots() {
+  local params="projectKey=${PROJECT}&ps=${LIMIT}"
+
+  local response
+  response=$(api_get "/api/hotspots/search?${params}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  local total
+  total=$(echo "$response" | jq -r '.paging.total')
+  echo "Security Hotspots: $total total (showing up to $LIMIT)"
+  echo ""
+
+  echo "$response" | jq -r '.hotspots[]? | "[\(.vulnerabilityProbability)] \(.message)\n  File: \(.component | split(":")[1]? // .component)\n  Line: \(.line // "n/a")  Status: \(.status)\n"'
+}
+
+cmd_accept() {
+  if [[ -z "$ISSUE_KEY" ]]; then
+    echo "Error: 'accept' requires --issue KEY" >&2
+    exit 1
+  fi
+  if [[ -z "$ACCEPT_COMMENT" ]]; then
+    echo "Error: 'accept' requires --comment 'rationale text'" >&2
+    exit 1
+  fi
+
+  # 1. Transition issue to ACCEPTED.
+  local transition_resp
+  transition_resp=$(curl -s -H "Authorization: Bearer $SONAR_TOKEN" \
+    -X POST "${BASE_URL}/api/issues/do_transition" \
+    -d "issue=${ISSUE_KEY}&transition=accept")
+
+  local status
+  status=$(echo "$transition_resp" | jq -r '.issue.issueStatus // "UNKNOWN"')
+
+  # 2. Attach rationale comment (URL-encode via jq).
+  local encoded comment_resp comment_status
+  encoded=$(jq -rn --arg s "$ACCEPT_COMMENT" '$s|@uri')
+  comment_resp=$(curl -sS -w $'\n%{http_code}' -H "Authorization: Bearer $SONAR_TOKEN" \
+    -X POST "${BASE_URL}/api/issues/add_comment" \
+    -d "issue=${ISSUE_KEY}&text=${encoded}")
+  comment_status=$(printf '%s\n' "$comment_resp" | tail -n 1)
+  if [[ "$comment_status" -lt 200 || "$comment_status" -ge 300 ]]; then
+    echo "Error: failed to attach rationale comment (HTTP $comment_status)" >&2
+    echo "Response body:" >&2
+    printf '%s\n' "$comment_resp" | sed '$d' >&2
+    exit 1
+  fi
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$transition_resp" | jq .
+  else
+    echo "Issue $ISSUE_KEY -> $status"
+  fi
+}
+
+# --- Dispatch ---
+case "$COMMAND" in
+  status)   cmd_status   ;;
+  issues)   cmd_issues   ;;
+  metrics)  cmd_metrics  ;;
+  hotspots) cmd_hotspots ;;
+  accept)   cmd_accept   ;;
+  *)        echo "Unknown command: $COMMAND" >&2; exit 1 ;;
+esac

--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: version-bump
+description: >
+  Bump the semver version in pyproject.toml (major, minor, or patch) and
+  prepend a Keep-a-Changelog entry to CHANGELOG.md. Use when preparing a
+  release, before creating a PR (the version-check CI job blocks merge if
+  you don't), or when the user says "bump version", "release", or
+  "increment version".
+---
+
+# Version Bump
+
+Bump the semver version in `pyproject.toml` and prepend a new entry to
+`CHANGELOG.md`. Mirrors the AgentCulture workflow used by `culture`,
+`afi-cli`, `cfafi`, and other org repos; vendored here so the repo is
+self-contained.
+
+## Usage
+
+Run from the repo root.
+
+```bash
+# With changelog content (pipe JSON via stdin):
+echo '{"added":["New X"],"changed":["Refactored Y"],"fixed":["Bug in Z"]}' \
+  | python3 .claude/skills/version-bump/scripts/bump.py minor
+
+# Without changelog content (inserts empty ### Added/Changed/Fixed stubs):
+python3 .claude/skills/version-bump/scripts/bump.py patch
+
+# Check current version without bumping:
+python3 .claude/skills/version-bump/scripts/bump.py show
+```
+
+## Bump Types
+
+| Type    | Example        | When to use                                                       |
+|---------|----------------|-------------------------------------------------------------------|
+| `major` | 0.1.0 → 1.0.0  | Breaking changes, namespace restructures, CLI surface breaks      |
+| `minor` | 0.1.0 → 0.2.0  | New features, new commands, new modules                           |
+| `patch` | 0.1.0 → 0.1.1  | Bug fixes, doc updates, dependency bumps, CI-only changes         |
+| `show`  | prints `0.1.0` | Read-only — no files changed                                      |
+
+## Changelog JSON Format
+
+Pass via stdin. All fields are optional — only non-empty sections are rendered.
+
+```json
+{
+  "added":   ["List of new features"],
+  "changed": ["List of changes to existing functionality"],
+  "fixed":   ["List of bug fixes"]
+}
+```
+
+## What it touches
+
+- `pyproject.toml` — the `version = "x.y.z"` field (single source of truth;
+  `steward/__init__.py` reads it via `importlib.metadata`, so there's no
+  separate `__version__` literal to keep in sync).
+- `CHANGELOG.md` — inserts a new `## [x.y.z] - YYYY-MM-DD` entry at the top.
+
+The script does the rest. Pick a bump type from the diff (patch for fixes,
+minor for new features, major for breaking changes), summarize the diff into
+`added` / `changed` / `fixed` lists, pipe as JSON, and commit the resulting
+`pyproject.toml` + `CHANGELOG.md` alongside the code change so the
+`version-check` CI job sees a consistent bump.

--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -54,9 +54,9 @@ Pass via stdin. All fields are optional — only non-empty sections are rendered
 
 ## What it touches
 
-- `pyproject.toml` — the `version = "x.y.z"` field (single source of truth;
-  `steward/__init__.py` reads it via `importlib.metadata`, so there's no
-  separate `__version__` literal to keep in sync).
+- `pyproject.toml` — the `version = "x.y.z"` field (single source of truth
+  for the package version; the package reads it via `importlib.metadata`,
+  so there's no separate `__version__` literal to keep in sync).
 - `CHANGELOG.md` — inserts a new `## [x.y.z] - YYYY-MM-DD` entry at the top.
 
 The script does the rest. Pick a bump type from the diff (patch for fixes,

--- a/.claude/skills/version-bump/scripts/bump.py
+++ b/.claude/skills/version-bump/scripts/bump.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Bump the version in pyproject.toml and CHANGELOG.md.
+
+If the package's ``__init__.py`` contains a literal ``__version__ = "..."``
+assignment, the script also rewrites that value. In repos that read
+``__version__`` from package metadata (the steward-cli convention), the
+``__init__.py`` step is a no-op.
+
+Usage:
+    bump.py major    # 0.1.0 -> 1.0.0
+    bump.py minor    # 0.1.0 -> 0.2.0
+    bump.py patch    # 0.1.0 -> 0.1.1
+    bump.py show     # print current version
+
+Changelog entries are passed via stdin as a JSON object:
+    {
+      "added": ["New CLI command", "Observer module"],
+      "changed": ["Restructured namespace"],
+      "fixed": ["WHO reply index bug"]
+    }
+
+If no stdin is provided, an empty stub is inserted.
+"""
+
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+
+def find_pyproject() -> Path:
+    """Walk up from cwd to find pyproject.toml."""
+    current = Path.cwd()
+    while current != current.parent:
+        candidate = current / "pyproject.toml"
+        if candidate.exists():
+            return candidate
+        current = current.parent
+    print("ERROR: pyproject.toml not found", file=sys.stderr)
+    sys.exit(1)
+
+
+def read_version(path: Path) -> str:
+    """Extract version string from pyproject.toml."""
+    text = path.read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        print("ERROR: version field not found in pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+    return match.group(1)
+
+
+def bump(version: str, part: str) -> str:
+    """Bump the specified part of a semver version."""
+    parts = version.split(".")
+    if len(parts) != 3:
+        print(f"ERROR: version '{version}' is not semver (x.y.z)", file=sys.stderr)
+        sys.exit(1)
+
+    major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
+
+    if part == "major":
+        return f"{major + 1}.0.0"
+    elif part == "minor":
+        return f"{major}.{minor + 1}.0"
+    elif part == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    else:
+        print(f"ERROR: unknown bump type '{part}' (use major, minor, or patch)", file=sys.stderr)
+        sys.exit(1)
+
+
+def write_version(path: Path, old: str, new: str) -> None:
+    """Replace old version with new in pyproject.toml."""
+    text = path.read_text()
+    updated = text.replace(f'version = "{old}"', f'version = "{new}"', 1)
+    path.write_text(updated)
+
+
+def read_changelog_entries() -> dict:
+    """Read changelog entries from stdin as JSON."""
+    if sys.stdin.isatty():
+        return {}
+    try:
+        raw = sys.stdin.read().strip()
+        if not raw:
+            return {}
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        print("WARNING: could not parse changelog JSON from stdin, using empty stub", file=sys.stderr)
+        return {}
+
+
+def format_changelog_section(new: str, entries: dict) -> str:
+    """Format a changelog section from entries dict.
+
+    Output uses single blank lines between elements (markdownlint MD012
+    compliant). Trailing blank line before the next existing entry is
+    included.
+    """
+    today = date.today().isoformat()
+    chunks = [f"## [{new}] - {today}\n"]
+
+    for section in ("added", "changed", "fixed"):
+        items = entries.get(section, [])
+        if items:
+            chunks.append(f"\n### {section.capitalize()}\n\n")
+            chunks.extend(f"- {item}\n" for item in items)
+
+    # If no entries at all, emit empty section stubs.
+    if not any(entries.get(s) for s in ("added", "changed", "fixed")):
+        chunks.append("\n### Added\n\n### Changed\n\n### Fixed\n")
+
+    chunks.append("\n")  # blank line before the next existing entry
+    return "".join(chunks)
+
+
+def update_changelog(project_root: Path, new: str, entries: dict) -> None:
+    """Insert a new changelog entry into CHANGELOG.md."""
+    changelog = project_root / "CHANGELOG.md"
+    if not changelog.exists():
+        print("No CHANGELOG.md found — skipping")
+        return
+
+    text = changelog.read_text()
+    new_entry = format_changelog_section(new, entries)
+
+    marker = "## ["
+    idx = text.find(marker)
+    if idx > 0:
+        changelog.write_text(text[:idx] + new_entry + text[idx:])
+        print(f"Updated CHANGELOG.md with [{new}]")
+    else:
+        print("WARNING: could not find insertion point in CHANGELOG.md", file=sys.stderr)
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print(__doc__.strip())
+        sys.exit(0)
+
+    part = sys.argv[1].lower()
+    path = find_pyproject()
+    current = read_version(path)
+
+    if part == "show":
+        print(current)
+        sys.exit(0)
+
+    # Read changelog entries before bumping
+    entries = read_changelog_entries()
+
+    new = bump(current, part)
+    write_version(path, current, new)
+
+    # Also update __init__.py if it has __version__
+    init_candidates = [
+        path.parent / path.parent.name / "__init__.py",
+    ]
+    for init in init_candidates:
+        if init.exists():
+            init_text = init.read_text()
+            if f'__version__ = "{current}"' in init_text:
+                init.write_text(init_text.replace(
+                    f'__version__ = "{current}"',
+                    f'__version__ = "{new}"',
+                ))
+                print(f"Updated {init.relative_to(path.parent)}")
+
+    # Update changelog
+    update_changelog(path.parent, new, entries)
+
+    print(f"{current} -> {new}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+# Match black's line length so flake8 and black agree.
+max-line-length = 100
+
+# E203: whitespace before ':' — conflicts with black's slice formatting.
+# W503: line break before binary operator — black does the opposite (W504-style).
+extend-ignore = E203, W503

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,88 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "office_cli/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "office_cli/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - run: uv run pytest -n auto -v
+
+  test-publish:
+    # Skip on fork PRs — no OIDC/environment context is available there, so
+    # the publish step would fail and block external contributor CI.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    needs: test
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - name: Set dev version
+        run: |
+          BASE=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          DEV_VERSION="${BASE}.dev${{ github.run_number }}"
+          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
+          echo "DEV_VERSION=${DEV_VERSION}" >> "$GITHUB_ENV"
+          echo "Publishing ${DEV_VERSION} to TestPyPI"
+
+      - name: Build and publish to TestPyPI
+        run: |
+          uv build
+          uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always --check-url https://test.pypi.org/simple/
+
+      - name: Print install commands
+        if: always()
+        run: |
+          echo "::notice::Test with: uv tool install --index-url https://test.pypi.org/simple/ --index-strategy unsafe-best-match office-cli==${DEV_VERSION}"
+
+  publish:
+    if: github.event_name == 'push'
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - name: Build and publish to PyPI
+        run: |
+          uv build
+          uv publish --trusted-publishing always --check-url https://pypi.org/simple/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,114 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - run: uv run pytest -n auto --cov=office_cli --cov-report=xml:coverage.xml --cov-report=term -v
+
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - run: uv python install 3.12
+
+      - run: uv sync
+
+      - name: black --check
+        run: uv run black --check office_cli tests
+
+      - name: isort --check
+        run: uv run isort --check-only office_cli tests
+
+      - name: flake8
+        run: uv run flake8 office_cli tests
+
+      - name: bandit
+        run: uv run bandit -c pyproject.toml -r office_cli
+
+      - name: markdownlint-cli2
+        run: |
+          npm install -g markdownlint-cli2@0.21.0
+          markdownlint-cli2 "**/*.md" "#node_modules" "#.local"
+
+  version-check:
+    # Only run on PR events. On push to main after a merged PR, the
+    # comparison would always fail (PR_VERSION == MAIN_VERSION because HEAD
+    # and origin/main point at the same commit) and `gh pr comment` would be
+    # empty on push. Restricting the trigger avoids both.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - run: git fetch origin main
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Check version bump
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # AgentCulture rule: every PR bumps the version — even docs/config/CI.
+          # See CLAUDE.md and the version-bump skill for rationale.
+          PR_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          MAIN_VERSION=$(git show origin/main:pyproject.toml 2>/dev/null | python3 -c "import sys,tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])" 2>/dev/null || echo "")
+
+          if [ -z "$MAIN_VERSION" ]; then
+            echo "No pyproject.toml on main yet — skipping version check (initial scaffold)."
+            exit 0
+          fi
+
+          if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
+            MARKER="<!-- version-check -->"
+            BODY="⚠️ **Version not bumped** — \`pyproject.toml\` still has \`$PR_VERSION\` (same as main). Bump before merging to avoid a failed PyPI publish.
+
+          $MARKER"
+
+            EXISTING=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+              --jq '.[] | select(.body | contains("<!-- version-check -->")) | .id' | head -1)
+
+            if [ -n "$EXISTING" ]; then
+              gh api repos/${{ github.repository }}/issues/comments/$EXISTING \
+                -X PATCH -f body="$BODY" > /dev/null
+            else
+              gh pr comment ${{ github.event.pull_request.number }} --body "$BODY" || true
+            fi
+
+            echo "::error::Version $PR_VERSION matches main. Bump before merging."
+            exit 1
+          else
+            echo "Version bumped: $MAIN_VERSION -> $PR_VERSION"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,5 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+.afi/
+.claude/skills.local.yaml

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,4 +1,4 @@
-# markdownlint-cli2 config for steward.
+# markdownlint-cli2 config for this repository.
 # markdownlint-cli2 stops walking at the git root, so a per-user global
 # config in the home directory isn't picked up from inside the repo.
 # Mirrors the afi-cli / cfafi preset for workspace consistency.

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,19 @@
+# markdownlint-cli2 config for steward.
+# markdownlint-cli2 stops walking at the git root, so a per-user global
+# config in the home directory isn't picked up from inside the repo.
+# Mirrors the afi-cli / cfafi preset for workspace consistency.
+
+config:
+  default: true
+  # MD013: Line length — disabled. Prose lines wrap at the reader.
+  MD013: false
+  # MD060: Table pipe spacing — disabled (stylistic preference).
+  MD060: false
+  # MD024: Duplicate headings — allow under different parents so Keep a
+  # Changelog entries can each have ### Added / ### Changed / ### Fixed.
+  MD024:
+    siblings_only: true
+
+ignores:
+  - "node_modules/**"
+  - ".local/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/). This project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1] - 2026-05-01
+
+### Added
+
+- Initial scaffold: `office learn`, `office explain`, `office whoami` verbs
+  on the agent-first CLI structure from `agentculture/afi-cli`
+  (`cli/_errors.py`, `cli/_output.py`, `cli/_commands/`, `explain/`).
+- `pyproject.toml` configured for PyPI distribution `office-cli`, Python
+  package `office_cli`, CLI binary `office`, version `0.0.1`. Zero runtime
+  dependencies.
+- CI workflows: `tests.yml` (pytest with coverage, black/isort/flake8/bandit,
+  markdownlint-cli2, version-check enforcing per-PR version bump);
+  `publish.yml` (PyPI Trusted Publishing, TestPyPI dev-build smoke on PRs).
+- Vendored skills from `agentculture/steward`: `version-bump`, `pr-review`,
+  `run-tests`, `gh-issues`, `pypi-maintainer`, `notebooklm`, `sonarclaude`.
+- Lint config: `.flake8`, `.markdownlint-cli2.yaml`.
+- Per-machine skill config: `.claude/skills.local.yaml.example` (the active
+  `.claude/skills.local.yaml` is git-ignored).
+- `CLAUDE.md` updated to cover the post-bootstrap conventions while
+  preserving the SVG ID contract and architectural guardrails for the v1
+  seating system (issue #1).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ office-agent/
 │   ├── __main__.py              # `python -m office_cli`
 │   ├── cli/
 │   │   ├── __init__.py          # argparse main(); _ArgumentParser override
-│   │   ├── _errors.py           # OfficeError + EXIT_SUCCESS / _USER_ERROR / _ENV_ERROR
+│   │   ├── _errors.py           # OfficeError + EXIT_SUCCESS / _USER_ERROR / _ENV_ERROR / _INTERNAL_ERROR
 │   │   ├── _output.py           # emit_result / emit_error / emit_diagnostic
 │   │   └── _commands/           # learn, explain, whoami (and future verbs)
 │   └── explain/                 # Markdown catalog for `office explain <path>`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,22 +2,18 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Status
-
-Pre-bootstrap. No source code yet — only this file plus `LICENSE` and `.gitignore`. The full v1 design lives in two GitHub issues — read them before doing any non-trivial work:
-
-- [agentculture/office-agent#2](https://github.com/agentculture/office-agent/issues/2) — Bootstrap office-cli (0.0.1) from the AgentCulture sibling pattern. End-to-end recipe with exact files to fetch from `agentculture/steward` and `agentculture/afi-cli`.
-- [agentculture/office-agent#1](https://github.com/agentculture/office-agent/issues/1) — v1 floor-plan seating system. Splits work between human (Inkscape SVG tracing) and agent (backend, search, Slack `/whereis`).
-
-Issue #2 is the next step. Issue #1 is the product on top of it.
-
 ## What this is
 
 Office — a CLI and backend for managing seat assignments and meeting rooms across office floor plans. Floors are hand-traced SVGs with stable, conformant IDs; assignments are stored in a Google Sheet (v1) or DynamoDB (v2); people are pulled live from BambooHR (never stored locally). Slack `/whereis @user` is the primary user surface; a search-first web map is the secondary one.
 
+The full v1 design lives in two GitHub issues — read them before doing any non-trivial work:
+
+- [agentculture/office-agent#2](https://github.com/agentculture/office-agent/issues/2) — Bootstrap office-cli (0.0.1) from the AgentCulture sibling pattern. **Implemented in this repo.**
+- [agentculture/office-agent#1](https://github.com/agentculture/office-agent/issues/1) — v1 floor-plan seating system. The product on top of this scaffold.
+
 ## Naming surfaces (don't conflate)
 
-The bootstrap issue uses several similar-looking identifiers across surfaces — mixing them silently breaks imports or PyPI:
+The project uses several similar-looking identifiers across surfaces — mixing them silently breaks imports or PyPI:
 
 | Surface             | Value         | Notes                                                  |
 | ------------------- | ------------- | ------------------------------------------------------ |
@@ -27,9 +23,93 @@ The bootstrap issue uses several similar-looking identifiers across surfaces —
 | CLI binary          | `office`      | `[project.scripts]` entry point                        |
 | Error class prefix  | `Office`      | `OfficeError`, not `Office_cliError`                   |
 
-Do **not** blanket-replace `tipalti` or `steward` when porting from sibling repos — substitute per-surface using the table above. Some `steward` references in CI workflows point at the upstream skill source (`raw.githubusercontent.com/agentculture/steward/main/...`) and must stay as-is.
+Do **not** blanket-replace `tipalti` or `steward` when porting from sibling repos — substitute per-surface using the table above. Some `steward` references in CI workflows or skill scripts point at the upstream source (`raw.githubusercontent.com/agentculture/steward/main/...`) and must stay as-is.
 
-## SVG ID contract (the human deliverable)
+## Project shape
+
+```text
+office-agent/
+├── office_cli/                  # Python package (import name)
+│   ├── __init__.py              # __version__ via importlib.metadata("office-cli")
+│   ├── __main__.py              # `python -m office_cli`
+│   ├── cli/
+│   │   ├── __init__.py          # argparse main(); _ArgumentParser override
+│   │   ├── _errors.py           # OfficeError + EXIT_SUCCESS / _USER_ERROR / _ENV_ERROR
+│   │   ├── _output.py           # emit_result / emit_error / emit_diagnostic
+│   │   └── _commands/           # learn, explain, whoami (and future verbs)
+│   └── explain/                 # Markdown catalog for `office explain <path>`
+├── tests/                       # pytest suite (smoke / learn / whoami)
+├── .github/workflows/           # tests.yml, publish.yml
+├── .claude/skills/              # vendored from agentculture/steward
+└── pyproject.toml               # SSoT for version; [project.scripts] entry
+```
+
+Future surfaces (issue #1):
+
+- `floors/<office>-<floor>.svg` — human-traced floor plans (Inkscape)
+- `data/offices.yaml` — office / floor / cluster metadata (capacity, etc.)
+- `seats/assignments.example.csv` — schema example (real data lives in Sheets/DB)
+
+## Build / test / publish
+
+```bash
+uv sync                           # install runtime + dev deps
+uv run pytest -n auto -v          # full suite, parallel
+uv run office --version           # 0.0.1
+uv run office learn               # agent affordance
+uv run office whoami              # auth probe stub
+uv run python -m office_cli       # equivalent to `office`
+
+uv run black --check office_cli tests
+uv run isort --check-only office_cli tests
+uv run flake8 office_cli tests
+uv run bandit -c pyproject.toml -r office_cli
+markdownlint-cli2 "**/*.md" "#node_modules"
+
+steward doctor . --scope self     # portability + skills convention check
+
+uv build                          # produce wheel + sdist
+```
+
+PyPI publishing happens automatically via `.github/workflows/publish.yml`
+on push to `main` (Trusted Publishing — no API tokens). PRs publish a
+`<version>.dev<run>` to TestPyPI for smoke-testing.
+
+**Every PR must bump `pyproject.toml` `version`** — the `version-check` CI
+job fails otherwise. Use the `version-bump` skill:
+
+```bash
+python3 .claude/skills/version-bump/scripts/bump.py patch
+```
+
+## Conventions
+
+- **uv** for dependency and tool management; **hatchling** as the build backend.
+- **pytest-xdist** (`uv run pytest -n auto -v`); coverage via `pytest-cov`; `fail_under = 60`.
+- **black** + **isort** + **flake8** + **bandit** configured in `pyproject.toml` and `.flake8`.
+- **markdownlint-cli2** with repo-local `.markdownlint-cli2.yaml`.
+- **PyPI Trusted Publishing** via `.github/workflows/publish.yml`. The `version-check` CI job enforces a per-PR version bump against `origin/main`.
+- **Keep a Changelog** format in `CHANGELOG.md`; the `version-bump` skill prepends entries automatically.
+
+## Skills convention
+
+`.claude/skills/<name>/` — each skill must have:
+
+1. `SKILL.md` (frontmatter `name` matches directory name)
+2. A sibling `scripts/` directory with the skill's executables
+3. No path dependencies on external checkouts (skill scripts must work on a fresh `git clone`)
+
+`steward doctor . --scope self` enforces all three rules.
+
+Vendored skills (from `agentculture/steward`):
+
+- **Required** (CI- or contract-load-bearing): `version-bump`, `pr-review`, `run-tests`, `gh-issues`
+- **Recommended**: `pypi-maintainer`, `notebooklm`, `sonarclaude`
+
+Per-machine overrides live in `.claude/skills.local.yaml` (git-ignored;
+`.claude/skills.local.yaml.example` is the template).
+
+## SVG ID contract (issue #1 — the human deliverable)
 
 Floor SVGs in `floors/` are the integration boundary between Ori's Inkscape work and the agent's backend. The backend reads `id` attributes off `<rect>` and `<polygon>` elements; nothing else.
 
@@ -44,17 +124,7 @@ Rules: IDs unique within a file; floor number first; cluster letter uppercase; s
 
 `data/offices.yaml` declares cluster capacity per floor; the build should warn if the count of seat IDs in the SVG doesn't match.
 
-## Conventions (incoming, from the sibling pattern)
-
-Once issue #2 lands, the project will use:
-
-- **uv** for dependency and tool management; **hatchling** as the build backend.
-- **pytest-xdist** (`uv run pytest -n auto -v`); flake8 / black / isort / bandit; markdownlint-cli2 with a repo-local `.markdownlint-cli2.yaml`.
-- **PyPI Trusted Publishing** via `.github/workflows/publish.yml`; `version-check` CI job enforces a version bump on every PR against `origin/main`.
-- **Skills** under `.claude/skills/<name>/` — each must have `SKILL.md` and a sibling `scripts/` directory, with no path dependencies on external checkouts. Required skills: `version-bump`, `pr-review`, `run-tests`, `gh-issues`. `steward doctor . --scope self` enforces the convention.
-- **afi-cli** scaffold under `office_cli/cli/` — `_errors.py`, `_output.py`, and `_commands/{learn,explain,whoami}.py` follow a stable contract; copy verbatim with token substitution rather than rewriting.
-
-## Architectural guardrails (from issue #1)
+## Architectural guardrails (issue #1)
 
 Lessons paid for in advance — don't relitigate without a reason:
 
@@ -66,8 +136,11 @@ Lessons paid for in advance — don't relitigate without a reason:
 - **`hidden=TRUE`** rows show as "occupied (private)" to viewers; full details only to the `editor` / `planning` roles.
 - **Out of scope for v1**: hot-desking / desk booking, native mobile app, visitor/badge/sensor integration, in-app SVG editor.
 
-## When picking up issue #2
+## Picking up issue #1
 
-The issue is written to be runnable on any machine — it does not assume sibling checkouts at `../steward` or `../afi-cli`. Fetch from GitHub raw URLs or install the published CLIs (`uv tool install steward-cli afi-cli`). Work on a single feature branch (`bootstrap/sibling-pattern`), open one PR, then run the `pr-review` skill.
-
-Three post-merge tasks must be called out in the PR body for the human (they require UI clicks Claude can't do): configure PyPI + TestPyPI Trusted Publishers for `office-cli`, create the `pypi` and `testpypi` GitHub Environments, and enable branch protection requiring `tests` and `version-check` on `main`.
+The scaffold is in place. New verbs land under `office_cli/cli/_commands/`
+following the same pattern as `whoami` / `learn`: each module exports
+`register(sub)` and a `cmd_<name>(args)` handler returning an `int` exit
+code. Add a corresponding `office_cli/explain/catalog.py` entry and a
+test file under `tests/`. Bump `pyproject.toml` and `CHANGELOG.md` per
+PR (or run the `version-bump` skill).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# office
+
+Agent-first CLI for managing seat assignments and meeting rooms across
+office floor plans. Floor layouts are hand-traced SVGs; people come from
+BambooHR; assignments live in a Google Sheet (v1) or DynamoDB (v2). The
+CLI exposes the same operations as the Slack `/whereis` command and the
+web map.
+
+> **Status — v0.0.1.** This release ships only the agent-first scaffold
+> (`learn`, `explain`, `whoami`). Real verbs (seat assign, room book,
+> where, …) land in later versions on top of the SVG floor-plan contract
+> defined in [issue #1](https://github.com/agentculture/office-agent/issues/1).
+
+## Naming surfaces
+
+`office` uses three different identifiers across packaging surfaces. Mind
+the split — do not blanket-replace one token across the codebase.
+
+| Surface             | Value         |
+| ------------------- | ------------- |
+| GitHub repo         | `office-agent`|
+| PyPI distribution   | `office-cli`  |
+| Python package      | `office_cli`  |
+| CLI binary          | `office`      |
+| Error class prefix  | `Office`      |
+
+## Install
+
+```bash
+uv tool install office-cli
+office --version
+```
+
+## Use
+
+```bash
+office learn              # structured self-teaching prompt
+office learn --json       # same, JSON-shaped
+office explain office     # markdown root entry
+office explain whoami     # docs for any verb
+office whoami             # auth probe (returns "unauthenticated" in v0.0.1)
+office whoami --json      # JSON: {status, user, backends}
+```
+
+## Develop
+
+```bash
+uv sync
+uv run pytest -n auto -v
+uv run office --version
+uv run python -m office_cli
+```
+
+## License
+
+MIT — see `LICENSE`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ the split — do not blanket-replace one token across the codebase.
 
 | Surface             | Value         |
 | ------------------- | ------------- |
-| GitHub repo         | `office-agent`|
+| GitHub repo         | `agentculture/office-agent` |
 | PyPI distribution   | `office-cli`  |
 | Python package      | `office_cli`  |
 | CLI binary          | `office`      |

--- a/office_cli/__init__.py
+++ b/office_cli/__init__.py
@@ -1,0 +1,13 @@
+"""office — agent-first CLI package."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+try:
+    __version__ = _pkg_version("office-cli")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"
+
+__all__ = ["__version__"]

--- a/office_cli/__main__.py
+++ b/office_cli/__main__.py
@@ -1,0 +1,10 @@
+"""Entry point for ``python -m office_cli``."""
+
+from __future__ import annotations
+
+import sys
+
+from office_cli.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/office_cli/cli/__init__.py
+++ b/office_cli/cli/__init__.py
@@ -1,0 +1,84 @@
+"""Unified CLI entry point for office.
+
+Noun-based command groups and globals are registered here. Top-level globals
+(``learn``, ``explain``, ``whoami``) live under
+:mod:`office_cli.cli._commands`; per-noun groups follow the same pattern.
+
+Error-propagation contract: every handler raises
+:class:`office_cli.cli._errors.OfficeError` on failure; :func:`main` catches
+it via :func:`_dispatch` and routes through :mod:`office_cli.cli._output`.
+Unknown exceptions are wrapped so no Python traceback leaks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from office_cli import __version__
+from office_cli.cli._commands import explain as _explain_cmd
+from office_cli.cli._commands import learn as _learn_cmd
+from office_cli.cli._commands import whoami as _whoami_cmd
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+from office_cli.cli._output import emit_error
+
+
+class _ArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that emits errors via our structured format."""
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        err = OfficeError(
+            code=EXIT_USER_ERROR,
+            message=message,
+            remediation=f"run '{self.prog} --help' to see valid arguments",
+        )
+        emit_error(err, json_mode=False)
+        raise SystemExit(err.code)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = _ArgumentParser(
+        prog="office",
+        description="office — CLI to manage sittings and meeting rooms in office maps.",
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    sub = parser.add_subparsers(dest="command")
+
+    _learn_cmd.register(sub)
+    _explain_cmd.register(sub)
+    _whoami_cmd.register(sub)
+    # Register noun groups here:
+    #   from office_cli.cli._commands import seat as _seat_group
+    #   _seat_group.register(sub)
+
+    return parser
+
+
+def _dispatch(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    try:
+        return args.func(args)
+    except OfficeError as err:
+        emit_error(err, json_mode=json_mode)
+        return err.code
+    except Exception as err:  # noqa: BLE001 - last-resort
+        wrapped = OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"unexpected: {err.__class__.__name__}: {err}",
+            remediation="file a bug at https://github.com/agentculture/office-agent/issues",
+        )
+        emit_error(wrapped, json_mode=json_mode)
+        return wrapped.code
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command is None:
+        parser.print_help()
+        return 0
+    return _dispatch(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/office_cli/cli/__init__.py
+++ b/office_cli/cli/__init__.py
@@ -19,7 +19,7 @@ from office_cli import __version__
 from office_cli.cli._commands import explain as _explain_cmd
 from office_cli.cli._commands import learn as _learn_cmd
 from office_cli.cli._commands import whoami as _whoami_cmd
-from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+from office_cli.cli._errors import EXIT_INTERNAL_ERROR, EXIT_USER_ERROR, OfficeError
 from office_cli.cli._output import emit_error
 
 
@@ -63,7 +63,7 @@ def _dispatch(args: argparse.Namespace) -> int:
         return err.code
     except Exception as err:  # noqa: BLE001 - last-resort
         wrapped = OfficeError(
-            code=EXIT_USER_ERROR,
+            code=EXIT_INTERNAL_ERROR,
             message=f"unexpected: {err.__class__.__name__}: {err}",
             remediation="file a bug at https://github.com/agentculture/office-agent/issues",
         )

--- a/office_cli/cli/_commands/explain.py
+++ b/office_cli/cli/_commands/explain.py
@@ -1,0 +1,38 @@
+"""``office explain <path>...`` — global markdown catalog lookup (stable-contract).
+
+``explain`` is global (not nested under a noun). It takes zero or more path
+tokens and resolves them via the catalog in :mod:`office_cli.explain`.
+Unknown paths raise :class:`OfficeError` with a remediation hint.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from office_cli.cli._output import emit_result
+from office_cli.explain import resolve
+
+
+def cmd_explain(args: argparse.Namespace) -> int:
+    path = tuple(args.path) if args.path else ()
+    markdown = resolve(path)
+    json_mode = bool(getattr(args, "json", False))
+    if json_mode:
+        emit_result({"path": list(path), "markdown": markdown}, json_mode=True)
+    else:
+        emit_result(markdown, json_mode=False)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "explain",
+        help="Print markdown docs for a noun/verb path (e.g. 'office explain whoami').",
+    )
+    p.add_argument(
+        "path",
+        nargs="*",
+        help="Command path tokens; empty = root (same as 'office').",
+    )
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_explain)

--- a/office_cli/cli/_commands/learn.py
+++ b/office_cli/cli/_commands/learn.py
@@ -42,7 +42,8 @@ Exit-code policy
   0 success
   1 user-input error (bad flag, bad path, missing arg)
   2 environment / setup error
-  3+ reserved
+  3 internal error (unexpected exception)
+  4+ reserved
 
 More detail
 -----------
@@ -64,6 +65,7 @@ def _as_json_payload() -> dict[str, object]:
             "0": "success",
             "1": "user-input error",
             "2": "environment/setup error",
+            "3": "internal error",
         },
         "json_support": True,
         "explain_pointer": "office explain <path>",

--- a/office_cli/cli/_commands/learn.py
+++ b/office_cli/cli/_commands/learn.py
@@ -1,0 +1,87 @@
+"""``office learn`` — the learnability affordance.
+
+Satisfies the agent-first rubric: >=200 chars and mentions purpose, command
+map, exit codes, --json, explain.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from office_cli import __version__
+from office_cli.cli._output import emit_result
+
+_TEXT = """\
+office — CLI to manage sittings and meeting rooms in office maps.
+
+Purpose
+-------
+office is the operational surface for AgentCulture's office-agent: it owns
+seat assignments and meeting-room metadata across multiple offices and
+floors. Floor plans are SVGs (hand-traced from architect plans) with stable
+IDs; people come from BambooHR; assignments live in a Google Sheet (v1) or
+DynamoDB (v2). The CLI exposes the same operations as the Slack `/whereis`
+command and the web map.
+
+Commands
+--------
+  office learn              Print this self-teaching prompt. Supports --json.
+  office explain <path>...  Print markdown docs for any noun/verb path.
+                            Supports --json.
+  office whoami             Probe authentication state. Supports --json.
+  # Real verbs (seat assign, room book, where, ...) land in later versions.
+
+Machine-readable output
+-----------------------
+Every command that produces a listing or report supports --json. Errors in
+JSON mode emit {"code", "message", "remediation"} to stderr. Stdout and
+stderr are never mixed.
+
+Exit-code policy
+----------------
+  0 success
+  1 user-input error (bad flag, bad path, missing arg)
+  2 environment / setup error
+  3+ reserved
+
+More detail
+-----------
+  office explain office
+"""
+
+
+def _as_json_payload() -> dict[str, object]:
+    return {
+        "tool": "office",
+        "version": __version__,
+        "purpose": "Manage seat assignments and meeting rooms across office floor plans.",
+        "commands": [
+            {"path": ["learn"], "summary": "Self-teaching prompt."},
+            {"path": ["explain"], "summary": "Markdown docs by path."},
+            {"path": ["whoami"], "summary": "Probe authentication state."},
+        ],
+        "exit_codes": {
+            "0": "success",
+            "1": "user-input error",
+            "2": "environment/setup error",
+        },
+        "json_support": True,
+        "explain_pointer": "office explain <path>",
+    }
+
+
+def cmd_learn(args: argparse.Namespace) -> int:
+    if getattr(args, "json", False):
+        emit_result(_as_json_payload(), json_mode=True)
+    else:
+        emit_result(_TEXT, json_mode=False)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "learn",
+        help="Print a structured self-teaching prompt for agent consumers.",
+    )
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_learn)

--- a/office_cli/cli/_commands/whoami.py
+++ b/office_cli/cli/_commands/whoami.py
@@ -1,0 +1,43 @@
+"""``office whoami`` — auth probe stub.
+
+v0.0.1 always reports ``unauthenticated``. Real auth lands when whichever
+back-end (BambooHR, Google Sheets, DynamoDB, Slack) gets wired up.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from office_cli.cli._output import emit_result
+
+_STATUS = "unauthenticated"
+
+
+def _as_json_payload() -> dict[str, object]:
+    return {
+        "status": _STATUS,
+        "user": None,
+        "backends": {
+            "bamboohr": "unconfigured",
+            "google_sheets": "unconfigured",
+            "slack": "unconfigured",
+        },
+    }
+
+
+def cmd_whoami(args: argparse.Namespace) -> int:
+    if getattr(args, "json", False):
+        emit_result(_as_json_payload(), json_mode=True)
+    else:
+        emit_result(_STATUS, json_mode=False)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "whoami",
+        help="Probe authentication state across configured back-ends.",
+        description="Probe authentication state across configured back-ends.",
+    )
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    p.set_defaults(func=cmd_whoami)

--- a/office_cli/cli/_errors.py
+++ b/office_cli/cli/_errors.py
@@ -16,10 +16,12 @@ from dataclasses import dataclass
 # 0  = success
 # 1  = user-input error (bad flag, bad path, missing arg)
 # 2  = environment / setup error
-# 3+ = reserved
+# 3  = internal error (unexpected exception not classified above)
+# 4+ = reserved
 EXIT_SUCCESS = 0
 EXIT_USER_ERROR = 1
 EXIT_ENV_ERROR = 2
+EXIT_INTERNAL_ERROR = 3
 
 
 @dataclass

--- a/office_cli/cli/_errors.py
+++ b/office_cli/cli/_errors.py
@@ -1,0 +1,41 @@
+"""OfficeError and exit-code policy (stable-contract from afi-cli).
+
+Every failure inside office raises :class:`OfficeError`. The CLI entry
+point catches it and exits with :attr:`OfficeError.code`. Guarantees:
+
+* no Python traceback leaks to stderr;
+* every error has shape ``{code, message, remediation}``;
+* the exit-code policy is centralised.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Exit-code policy (documented in ``office learn`` output).
+# 0  = success
+# 1  = user-input error (bad flag, bad path, missing arg)
+# 2  = environment / setup error
+# 3+ = reserved
+EXIT_SUCCESS = 0
+EXIT_USER_ERROR = 1
+EXIT_ENV_ERROR = 2
+
+
+@dataclass
+class OfficeError(Exception):
+    """Structured error with a remediation hint for agents."""
+
+    code: int
+    message: str
+    remediation: str = ""
+
+    def __post_init__(self) -> None:
+        super().__init__(self.message)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "remediation": self.remediation,
+        }

--- a/office_cli/cli/_output.py
+++ b/office_cli/cli/_output.py
@@ -1,0 +1,53 @@
+"""stdout / stderr helpers with a strict split (stable-contract from afi-cli).
+
+Rule: **results go to stdout, diagnostics and errors go to stderr.** Agents
+parsing output can rely on this invariant. JSON mode routes structured
+payloads to the same streams — never mixes them.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, TextIO
+
+from office_cli.cli._errors import OfficeError
+
+
+def emit_result(data: Any, *, json_mode: bool, stream: TextIO | None = None) -> None:
+    """Write a command result to stdout (or ``stream``)."""
+    s = stream if stream is not None else sys.stdout
+    if json_mode:
+        json.dump(data, s, ensure_ascii=False)
+        s.write("\n")
+        return
+    text = data if isinstance(data, str) else str(data)
+    s.write(text)
+    if not text.endswith("\n"):
+        s.write("\n")
+
+
+def emit_error(err: OfficeError, *, json_mode: bool, stream: TextIO | None = None) -> None:
+    """Write an :class:`OfficeError` to stderr.
+
+    Text mode renders as two lines when a remediation is present::
+
+        error: <message>
+        hint: <remediation>
+
+    The ``hint:`` prefix is required by the agent-first error rubric.
+    """
+    s = stream if stream is not None else sys.stderr
+    if json_mode:
+        json.dump(err.to_dict(), s, ensure_ascii=False)
+        s.write("\n")
+        return
+    s.write(f"error: {err.message}\n")
+    if err.remediation:
+        s.write(f"hint: {err.remediation}\n")
+
+
+def emit_diagnostic(message: str, *, stream: TextIO | None = None) -> None:
+    """Write a human diagnostic (progress, summary) to stderr."""
+    s = stream if stream is not None else sys.stderr
+    s.write(message if message.endswith("\n") else message + "\n")

--- a/office_cli/explain/__init__.py
+++ b/office_cli/explain/__init__.py
@@ -1,0 +1,21 @@
+"""Explain catalog resolver — markdown keyed by command-path tuples (stable-contract)."""
+
+from __future__ import annotations
+
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+from office_cli.explain.catalog import ENTRIES
+
+
+def resolve(path: tuple[str, ...]) -> str:
+    if path in ENTRIES:
+        return ENTRIES[path]
+    display = " ".join(path) if path else "<root>"
+    raise OfficeError(
+        code=EXIT_USER_ERROR,
+        message=f"no explain entry for: {display}",
+        remediation="list known entries with: office explain office",
+    )
+
+
+def known_paths() -> list[tuple[str, ...]]:
+    return list(ENTRIES.keys())

--- a/office_cli/explain/catalog.py
+++ b/office_cli/explain/catalog.py
@@ -1,0 +1,94 @@
+"""Markdown catalog for ``office explain <path>``.
+
+Each entry is verbatim markdown. Keys are command-path tuples. The empty
+tuple and ``("office",)`` both resolve to the root entry.
+
+Keep bodies self-contained: an agent reading one entry should get enough
+context without chaining reads.
+"""
+
+from __future__ import annotations
+
+_ROOT = """\
+# office
+
+office is AgentCulture's CLI for seat assignments and meeting-room
+operations across multiple office floors. v0.0.1 ships only the agent-first
+scaffold (`learn`, `explain`, `whoami`); real verbs (seat assign, room book,
+where, etc.) land in later versions on top of the SVG-based floor plan
+contract.
+
+## Verbs
+
+- `office learn` — structured self-teaching prompt.
+- `office explain <path>` — markdown docs for any noun/verb.
+- `office whoami` — auth probe stub.
+
+## Exit-code policy
+
+- `0` success
+- `1` user-input error
+- `2` environment / setup error
+- `3+` reserved
+
+## See also
+
+- `office explain learn`
+- `office explain explain`
+- `office explain whoami`
+"""
+
+_LEARN = """\
+# office learn
+
+Prints a structured self-teaching prompt covering office's purpose,
+command map, exit-code policy, `--json` support, and `explain` pointer.
+
+## Usage
+
+    office learn
+    office learn --json
+"""
+
+_EXPLAIN = """\
+# office explain <path>
+
+Prints markdown documentation for any noun/verb path. Unlike `--help`
+(terse, positional), `explain` is global and addressable by path.
+
+## Usage
+
+    office explain office
+    office explain learn
+    office explain whoami
+    office explain --json <path>
+"""
+
+_WHOAMI = """\
+# office whoami
+
+Probes authentication state across configured back-ends (BambooHR, Google
+Sheets, Slack). In v0.0.1 this is a stub that always reports
+`unauthenticated` — real auth wiring lands when the back-ends do.
+
+## Usage
+
+    office whoami
+    office whoami --json
+
+## Output
+
+Text mode: a single status line (`unauthenticated`).
+
+JSON mode: `{"status", "user", "backends": {...}}`. Field shapes are
+stable; values evolve as back-ends come online.
+"""
+
+
+ENTRIES: dict[tuple[str, ...], str] = {
+    (): _ROOT,
+    ("office",): _ROOT,
+    ("learn",): _LEARN,
+    ("explain",): _EXPLAIN,
+    ("whoami",): _WHOAMI,
+}

--- a/office_cli/explain/catalog.py
+++ b/office_cli/explain/catalog.py
@@ -29,7 +29,8 @@ contract.
 - `0` success
 - `1` user-input error
 - `2` environment / setup error
-- `3+` reserved
+- `3` internal error (unexpected exception)
+- `4+` reserved
 
 ## See also
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,71 @@
+[project]
+name = "office-cli"
+version = "0.0.1"
+description = "Office — CLI to manage sittings and meeting rooms in office maps."
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.12"
+authors = [{name = "AgentCulture"}]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Software Development",
+    "Intended Audience :: Developers",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/agentculture/office-agent"
+Issues = "https://github.com/agentculture/office-agent/issues"
+
+[project.scripts]
+office = "office_cli.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["office_cli"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-xdist>=3.0",
+    "pytest-cov>=4.1",
+    "bandit>=1.7.5",
+    "flake8>=6.1",
+    "isort>=5.12.0",
+    "black>=23.7.0",
+]
+
+[tool.coverage.run]
+source = ["office_cli"]
+omit = ["office_cli/__pycache__/*"]
+
+[tool.coverage.report]
+fail_under = 60
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+known_first_party = ["office_cli"]
+
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = ["B101", "B404", "B603"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/tests/test_cli_learn.py
+++ b/tests/test_cli_learn.py
@@ -1,0 +1,36 @@
+"""Tests for ``office learn`` (text + JSON output)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from office_cli.cli import main
+
+
+def test_learn_exits_zero_and_meets_rubric(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["learn"]) == 0
+    out = capsys.readouterr().out
+    assert len(out) >= 200
+    for marker in ["purpose", "commands", "exit", "--json", "explain"]:
+        assert marker.lower() in out.lower()
+
+
+def test_learn_json_parseable(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["learn", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tool"] == "office"
+    assert payload["json_support"] is True
+    assert any(cmd["path"] == ["whoami"] for cmd in payload["commands"])
+
+
+def test_explain_self(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["explain", "office"]) == 0
+    assert capsys.readouterr().out.startswith("#")
+
+
+def test_explain_root_no_path(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["explain"]) == 0
+    out = capsys.readouterr().out
+    assert "# office" in out

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,43 @@
+"""Smoke tests for office's CLI."""
+
+from __future__ import annotations
+
+import pytest
+
+from office_cli import __version__
+from office_cli.cli import main
+
+
+def test_version_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["--version"])
+    assert exc.value.code == 0
+    assert __version__ in capsys.readouterr().out
+
+
+def test_no_args_prints_help_and_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main([]) == 0
+    out = capsys.readouterr().out
+    assert "office" in out
+    assert "learn" in out
+    assert "explain" in out
+    assert "whoami" in out
+
+
+def test_unknown_verb_emits_hint(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["zzz-not-a-real-verb"])
+    assert exc.value.code != 0
+    err = capsys.readouterr().err
+    assert "error:" in err
+    assert "hint:" in err
+
+
+def test_explain_unknown_path_fails_with_hint(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = main(["explain", "zzz-not-a-real-noun"])
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "error:" in err
+    assert "hint:" in err

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -41,3 +41,21 @@ def test_explain_unknown_path_fails_with_hint(
     err = capsys.readouterr().err
     assert "error:" in err
     assert "hint:" in err
+
+
+def test_unexpected_exception_routed_to_internal_error(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Last-resort wrapper must use EXIT_INTERNAL_ERROR (3), not EXIT_USER_ERROR (1)."""
+    from office_cli.cli import _commands
+
+    def boom(_args: object) -> int:
+        raise RuntimeError("simulated internal failure")
+
+    monkeypatch.setattr(_commands.whoami, "cmd_whoami", boom)
+    rc = main(["whoami"])
+    assert rc == 3
+    err = capsys.readouterr().err
+    assert "error:" in err
+    assert "unexpected" in err
+    assert "RuntimeError" in err

--- a/tests/test_cli_whoami.py
+++ b/tests/test_cli_whoami.py
@@ -1,0 +1,30 @@
+"""Tests for ``office whoami`` (auth probe stub)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from office_cli.cli import main
+
+
+def test_whoami_text_unauthenticated(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["whoami"]) == 0
+    assert capsys.readouterr().out.strip() == "unauthenticated"
+
+
+def test_whoami_json_payload(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["whoami", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "unauthenticated"
+    assert payload["user"] is None
+    assert set(payload["backends"]) == {"bamboohr", "google_sheets", "slack"}
+    assert all(v == "unconfigured" for v in payload["backends"].values())
+
+
+def test_whoami_help_smoke(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["whoami", "--help"])
+    assert exc.value.code == 0
+    assert "Probe authentication state" in capsys.readouterr().out

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,467 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
+name = "black"
+version = "26.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/e36e27c9cebc1311b7579210df6f1c86e50f2d7143ae4fcf8a5017dc8809/black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78", size = 1889234, upload-time = "2026-03-12T03:40:30.964Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7b/9871acf393f64a5fa33668c19350ca87177b181f44bb3d0c33b2d534f22c/black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568", size = 1720522, upload-time = "2026-03-12T03:40:32.346Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f", size = 1787824, upload-time = "2026-03-12T03:40:33.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload-time = "2026-03-12T03:40:35.442Z" },
+    { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload-time = "2026-03-12T03:40:36.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "flake8"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mccabe" },
+    { name = "pycodestyle" },
+    { name = "pyflakes" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "office-cli"
+version = "0.0.1"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "bandit" },
+    { name = "black" },
+    { name = "flake8" },
+    { name = "isort" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bandit", specifier = ">=1.7.5" },
+    { name = "black", specifier = ">=23.7.0" },
+    { name = "flake8", specifier = ">=6.1" },
+    { name = "isort", specifier = ">=5.12.0" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-cov", specifier = ">=4.1" },
+    { name = "pytest-xdist", specifier = ">=3.0" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycodestyle"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]


### PR DESCRIPTION
## Summary

- Scaffolds office-cli as a PyPI-publishable CLI per the AgentCulture sibling pattern (mirrors `agentculture/steward`, scaffolded via `agentculture/afi-cli`)
- Verbs in this release: `office learn` / `office explain <path>` / `office whoami` (initial set; real seat-assignment / room-booking verbs land on top of issue #1)
- CI: `tests.yml` (pytest + black + isort + flake8 + bandit + markdownlint + version-check), `publish.yml` (PyPI Trusted Publishing on push to main, TestPyPI dev builds on PRs)
- Vendored skills from `agentculture/steward`: `version-bump`, `pr-review`, `run-tests`, `gh-issues`, `pypi-maintainer`, `notebooklm`, `sonarclaude` — each with `SKILL.md` + `scripts/`, no external path deps

Closes #2.

## Naming surfaces (so reviewers can grep precisely)

| Surface             | Value         |
| ------------------- | ------------- |
| GitHub repo         | `office-agent`|
| PyPI distribution   | `office-cli`  |
| Python package      | `office_cli`  |
| CLI binary          | `office`      |
| Error class         | `OfficeError` |

## Test plan

- [x] \`uv sync && uv run pytest -n auto -v\` — 11/11 passing locally
- [x] \`uv run office --version\` prints \`0.0.1\`
- [x] \`uv run python -m office_cli\` works identically
- [x] \`uv run office learn\` / \`learn --json\` / \`whoami\` / \`whoami --json\` / \`explain office\` all clean
- [x] black / isort / flake8 / bandit / markdownlint-cli2 clean
- [x] \`steward doctor . --scope self\` exits 0
- [x] \`uv build\` produces \`office_cli-0.0.1.tar.gz\` + \`office_cli-0.0.1-py3-none-any.whl\`
- [ ] \`tests\` + \`version-check\` jobs green on this PR
- [ ] \`publish.yml\` test-publish step uploads \`0.0.1.devN\` to TestPyPI

## Post-merge checklist (manual UI work — Claude can't click these)

- [ ] Configure **PyPI Trusted Publisher** for \`office-cli\` ← \`agentculture/office-agent\`, environment \`pypi\`, workflow \`publish.yml\`
- [ ] Configure **TestPyPI Trusted Publisher** with the same mapping, environment \`testpypi\`
- [ ] Create GitHub Environments \`pypi\` and \`testpypi\` on the repo
- [ ] Branch protection on \`main\`: require \`tests\` and \`version-check\` jobs

Generated with [Claude Code](https://claude.com/claude-code)

- Claude