### PR TITLE
feat: v1 seating Stage 1 — data + CLI core (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,8 @@ __marimo__/
 .streamlit/secrets.toml
 .afi/
 .claude/skills.local.yaml
+
+# Office data — only `.example.csv` files are committed; the live CSVs are
+# operator state.
+seats/assignments.csv
+seats/audit-log.csv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2026-05-01
+
+### Added
+
+- v1 seating Stage 1 (data + CLI core) per [issue #1](https://github.com/agentculture/office-agent/issues/1).
+- Domain layer: `office_cli.offices`, `office_cli.floors`, `office_cli.seats`,
+  `office_cli.people` packages with frozen dataclass models and a strict
+  ID contract (`SEAT_RE`, `ROOM_RE`).
+- `AssignmentStore` Protocol with a CSV-backed implementation (`CsvStore`)
+  plus an append-only `AuditLog`. `SeatService` enforces "one seat per
+  person globally" and writes audit entries on every mutation.
+- Floor SVG parser and validator (`office_cli.floors.parse_svg`,
+  `validate_floor`) covering the rules in the issue's SVG ID contract:
+  ID format, uniqueness, viewBox, cluster-capacity match.
+- New CLI verbs: `office floors list|validate`, `office seats list|assign|
+  unassign|move|history`, `office whereis EMAIL`. All honor `--json`.
+- Sample data: `data/offices.yaml` (one office, one floor),
+  `floors/tlv-floor-5.svg` (placeholder traced floor, 6 seats + 1 room),
+  `seats/{assignments,audit-log}.example.csv` schema examples.
+- Runtime dependency: `PyYAML>=6.0`. SVG parsing uses the stdlib
+  `xml.etree.ElementTree`; the historical bandit B314/B405 advisories no
+  longer apply (Python's XML parsers were hardened upstream — see
+  [python/cpython#135294](https://github.com/python/cpython/pull/135294)).
+  These bandit checks are skipped via `pyproject.toml`.
+- `docs/architecture.md` documenting Stage 1 scope and the deferred surfaces.
+
 ## [0.0.1] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.1.0] - 2026-05-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,28 +36,34 @@ office-agent/
 │   │   ├── __init__.py          # argparse main(); _ArgumentParser override
 │   │   ├── _errors.py           # OfficeError + EXIT_SUCCESS / _USER_ERROR / _ENV_ERROR / _INTERNAL_ERROR
 │   │   ├── _output.py           # emit_result / emit_error / emit_diagnostic
-│   │   └── _commands/           # learn, explain, whoami (and future verbs)
+│   │   └── _commands/           # learn, explain, whoami, floors, seats, whereis
+│   ├── _config.py               # resolve_data_dir() / --data-dir / OFFICE_DATA_DIR
+│   ├── offices/                 # offices.yaml loader + Office/Floor/Cluster/Room
+│   ├── floors/                  # SVG parse + ID contract + validator
+│   ├── seats/                   # AssignmentStore + CsvStore + AuditLog + SeatService
+│   ├── people/                  # Employee + EmployeeDirectory (StubDirectory in v0.1.0)
 │   └── explain/                 # Markdown catalog for `office explain <path>`
-├── tests/                       # pytest suite (smoke / learn / whoami)
+├── data/offices.yaml            # office / floor / cluster topology
+├── floors/                      # human-traced floor SVGs
+├── seats/                       # assignments.csv + audit-log.csv (git-ignored)
+├── docs/                        # architecture.md, tracing-guide.md (TBD)
+├── tests/                       # pytest suite incl. fixtures/ for offices+floors
 ├── .github/workflows/           # tests.yml, publish.yml
 ├── .claude/skills/              # vendored from agentculture/steward
 └── pyproject.toml               # SSoT for version; [project.scripts] entry
 ```
-
-Future surfaces (issue #1):
-
-- `floors/<office>-<floor>.svg` — human-traced floor plans (Inkscape)
-- `data/offices.yaml` — office / floor / cluster metadata (capacity, etc.)
-- `seats/assignments.example.csv` — schema example (real data lives in Sheets/DB)
 
 ## Build / test / publish
 
 ```bash
 uv sync                           # install runtime + dev deps
 uv run pytest -n auto -v          # full suite, parallel
-uv run office --version           # 0.0.1
+uv run office --version           # 0.1.0
 uv run office learn               # agent affordance
 uv run office whoami              # auth probe stub
+uv run office floors validate floors/tlv-floor-5.svg
+uv run office seats list --vacant
+uv run office whereis alice@example.com
 uv run python -m office_cli       # equivalent to `office`
 
 uv run black --check office_cli tests

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ BambooHR; assignments live in a Google Sheet (v1) or DynamoDB (v2). The
 CLI exposes the same operations as the Slack `/whereis` command and the
 web map.
 
-> **Status — v0.0.1.** This release ships only the agent-first scaffold
-> (`learn`, `explain`, `whoami`). Real verbs (seat assign, room book,
-> where, …) land in later versions on top of the SVG floor-plan contract
-> defined in [issue #1](https://github.com/agentculture/office-agent/issues/1).
+> **Status — v0.1.0.** Stage 1 of the v1 seating system is in: floor
+> SVG parser/validator, CSV-backed assignment store with append-only
+> audit log, and CLI verbs (`floors`, `seats`, `whereis`). Google
+> Sheets, BambooHR, Slack `/whereis`, and the web map land in later
+> stages on top of the same `office_cli.seats` service. See
+> [issue #1](https://github.com/agentculture/office-agent/issues/1).
 
 ## Naming surfaces
 
@@ -34,13 +36,34 @@ office --version
 ## Use
 
 ```bash
-office learn              # structured self-teaching prompt
-office learn --json       # same, JSON-shaped
-office explain office     # markdown root entry
-office explain whoami     # docs for any verb
-office whoami             # auth probe (returns "unauthenticated" in v0.0.1)
-office whoami --json      # JSON: {status, user, backends}
+office learn                                    # self-teaching prompt
+office explain seats                            # markdown docs for any verb
+office whoami --json                            # auth probe (stub)
+
+# v0.1.0 seating verbs:
+office floors list --json
+office floors validate floors/tlv-floor-5.svg
+office seats list --vacant
+office seats assign 5-T-01 alice@example.com
+office seats move alice@example.com 5-T-02
+office seats history 5-T-01 --json
+office whereis alice@example.com
 ```
+
+`office` reads `data/offices.yaml`, `floors/`, and `seats/` from the
+current working directory. Override with `--data-dir DIR` or
+`OFFICE_DATA_DIR=DIR`.
+
+## Adding a new floor
+
+1. **Trace the floor in Inkscape** following `docs/tracing-guide.md` and
+   the SVG ID contract in `CLAUDE.md`. Save as Plain SVG.
+2. **Drop the SVG into `floors/`** as `<office>-floor-<N>.svg`.
+3. **Add an entry to `data/offices.yaml`** with cluster capacities and
+   any named rooms.
+4. Verify: `office floors validate floors/<file>.svg`. Errors fail the
+   command; warnings (e.g. cluster-capacity mismatches) are
+   informational.
 
 ## Develop
 

--- a/data/offices.yaml
+++ b/data/offices.yaml
@@ -1,0 +1,24 @@
+# Office topology — the integration boundary between the floor-plan SVGs in
+# `floors/` and the `office_cli` backend.
+#
+# Per CLAUDE.md / issue #1:
+# - office id is short, hyphenated (`tlv`, `fc`); used as `office.id`;
+# - floor id is `<office>-floor-<N>`; the trailing number must match the
+#   `<floor>-<CLUSTER>-<NN>` segment in seat ids inside the SVG;
+# - each cluster declares an integer capacity; the build warns if it does not
+#   match the count of seat ids in the SVG;
+# - rooms list architect ids verbatim (`5.18`).
+
+offices:
+  - id: tlv
+    name: "Tel Aviv"
+    address: "Tel Aviv, Israel"
+    floors:
+      - id: tlv-floor-5
+        svg: floors/tlv-floor-5.svg
+        status: active
+        clusters:
+          T: { capacity: 6, type: open-space }
+          Z: { capacity: 2, type: phone-room }
+        rooms:
+          "5.18": { name: "Meeting Room 8P", type: meeting, capacity: 8 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,78 @@
+# Architecture — v0.1.0 (Stage 1)
+
+`office` ships in stages on top of issue
+[#1](https://github.com/agentculture/office-agent/issues/1). This document
+captures **what is implemented today** and **what is deferred** so the
+boundary stays explicit.
+
+## Layered model
+
+```text
+   CLI verbs (office_cli.cli._commands)
+            │
+            ▼
+   SeatService  ──►  AssignmentStore (Protocol)
+   (office_cli.seats._service)        │
+            │                         ├── CsvStore       ✓ implemented
+            ▼                         ├── SheetsStore    ◌ deferred
+   AuditLog (append-only CSV)         └── DynamoStore    ◌ deferred
+            │
+            ▼
+   Office topology (office_cli.offices)
+   ── load_offices(data_dir) → {Office → Floor → Cluster, Room}
+
+   Floor SVG layer (office_cli.floors)
+   ── parse_svg(path) → FloorSvg
+   ── validate_floor(svg, floor) → list[Issue]
+```
+
+`office_cli.people` exposes an `EmployeeDirectory` Protocol with a
+`StubDirectory` that trusts whatever email it receives. The
+`BambooHRDirectory` lands in the BambooHR stage.
+
+## Stage 1 — implemented in v0.1.0
+
+- Frozen-dataclass domain models: `Office`, `Floor`, `Cluster`, `Room`,
+  `Assignment`, `AuditEntry`, `Employee`.
+- `data/offices.yaml` schema (`load_offices`).
+- Floor SVG parser (`parse_svg`) — reads `<rect>` / `<polygon>` with `id`
+  and `class`; ignores everything else.
+- Validator (`validate_floor`) — view-box, ID format, cluster mapping,
+  duplicate IDs, untagged-but-shaped IDs, capacity mismatch (warning).
+- CSV-backed `AssignmentStore` (`CsvStore`) and append-only `AuditLog`.
+- `SeatService` invariants: seat must exist; one seat per email
+  globally; every mutation writes audit.
+- CLI verbs: `office floors list|validate`, `office seats list|assign|
+  unassign|move|history`, `office whereis EMAIL`. Every verb honors
+  `--json` and the shared `--data-dir`.
+- Sample data: `data/offices.yaml` (one office, one floor),
+  `floors/tlv-floor-5.svg` (placeholder), `seats/*.example.csv`.
+- Test fixtures + parametric tests on the ID contract, SVG parser,
+  validator, store, service, and each CLI verb (text and JSON).
+
+## Deferred surfaces
+
+Each is a separate issue/PR after Stage 1 ships.
+
+| Stage              | Surface                                       | Notes                                                                   |
+| ------------------ | --------------------------------------------- | ----------------------------------------------------------------------- |
+| 2. Sheets store    | `office_cli.seats.SheetsStore`                | Same Protocol; service-account auth; 5-min read cache.                  |
+| 3. BambooHR        | `office_cli.people.BambooHRDirectory`         | Live pull, 5-min cache; auto-vacate on offboarding (the killer feature). |
+| 4. Slack `/whereis`| `office_slack/` Bolt app                      | Imports `SeatService.whereis`; renders Block Kit with deep link.        |
+| 5. Web frontend    | `office_web/` (Vite + a small Python server)  | Search-first map, `?asOf=YYYY-MM-DD`, role-aware `hidden` rendering.    |
+| 6. Effective dates | service-layer `effective_from / _until`       | Columns already exist; the service starts honoring them.                |
+| 7. SSO + roles     | viewer / editor / planning                    | Drives whether `hidden=TRUE` rows expose details.                       |
+| 8. DynamoDB        | `office_cli.seats.DynamoStore`                | Migration script from Sheets, kept identical Protocol.                  |
+
+## Operating notes
+
+- Real assignment data lives in `seats/assignments.csv` and
+  `seats/audit-log.csv`; both are git-ignored. Only the `*.example.csv`
+  files are checked in as schema documentation.
+- `OFFICE_DATA_DIR` (or `--data-dir DIR`) overrides where the CLI looks
+  for `data/`, `floors/`, and `seats/`.
+- The audit log is append-only by contract. "Who used to sit at X?" is
+  literally the chronological projection of the audit-log CSV.
+- `office_cli.seats.SeatService._build_seat_index` unions every loaded
+  floor's seat IDs *and* every room declared in YAML, so rooms remain
+  assignable even before someone traces them.

--- a/floors/tlv-floor-5.svg
+++ b/floors/tlv-floor-5.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">
+  <!-- Placeholder traced floor used by tests and `office floors validate`.
+       The real floor 5 trace will be produced by Ori in Inkscape per
+       docs/tracing-guide.md. Schema: every <rect class="seat"> has a
+       <floor>-<CLUSTER>-<NN> id; every <polygon class="room"> uses the
+       architect id verbatim. -->
+  <g id="background"/>
+  <g id="seats">
+    <rect id="5-T-01" class="seat" x="120"  y="80"  width="40" height="60"/>
+    <rect id="5-T-02" class="seat" x="180"  y="80"  width="40" height="60"/>
+    <rect id="5-T-03" class="seat" x="240"  y="80"  width="40" height="60"/>
+    <rect id="5-T-04" class="seat" x="120"  y="160" width="40" height="60"/>
+    <rect id="5-T-05" class="seat" x="180"  y="160" width="40" height="60"/>
+    <rect id="5-T-06" class="seat" x="240"  y="160" width="40" height="60"/>
+    <rect id="5-Z-01" class="seat" x="900"  y="80"  width="60" height="80"/>
+    <rect id="5-Z-02" class="seat" x="980"  y="80"  width="60" height="80"/>
+  </g>
+  <g id="rooms">
+    <polygon id="5.18" class="room"
+             points="1400,300 1700,300 1700,500 1400,500"/>
+  </g>
+</svg>

--- a/office_cli/_config.py
+++ b/office_cli/_config.py
@@ -1,0 +1,50 @@
+"""Resolve where the office data (offices.yaml, floors/, seats/) lives.
+
+Resolution order:
+
+1. ``--data-dir`` CLI flag (passed through ``args.data_dir``);
+2. ``OFFICE_DATA_DIR`` environment variable;
+3. the current working directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
+
+
+def resolve_data_dir(args: argparse.Namespace | None = None) -> Path:
+    explicit = getattr(args, "data_dir", None) if args is not None else None
+    candidate: Path
+    if explicit:
+        candidate = Path(explicit).expanduser()
+    elif os.environ.get("OFFICE_DATA_DIR"):
+        candidate = Path(os.environ["OFFICE_DATA_DIR"]).expanduser()
+    else:
+        candidate = Path.cwd()
+    if not candidate.is_dir():
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message=f"data dir does not exist: {candidate}",
+            remediation="pass --data-dir or set OFFICE_DATA_DIR to the office-agent checkout",
+        )
+    return candidate
+
+
+def add_data_dir_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--data-dir",
+        help="Directory containing data/offices.yaml, floors/, seats/. "
+        "Defaults to $OFFICE_DATA_DIR or the current working directory.",
+    )
+
+
+def assignments_csv(data_dir: Path) -> Path:
+    return data_dir / "seats" / "assignments.csv"
+
+
+def audit_log_csv(data_dir: Path) -> Path:
+    return data_dir / "seats" / "audit-log.csv"

--- a/office_cli/cli/__init__.py
+++ b/office_cli/cli/__init__.py
@@ -17,7 +17,10 @@ import sys
 
 from office_cli import __version__
 from office_cli.cli._commands import explain as _explain_cmd
+from office_cli.cli._commands import floors as _floors_cmd
 from office_cli.cli._commands import learn as _learn_cmd
+from office_cli.cli._commands import seats as _seats_cmd
+from office_cli.cli._commands import whereis as _whereis_cmd
 from office_cli.cli._commands import whoami as _whoami_cmd
 from office_cli.cli._errors import EXIT_INTERNAL_ERROR, EXIT_USER_ERROR, OfficeError
 from office_cli.cli._output import emit_error
@@ -47,9 +50,9 @@ def _build_parser() -> argparse.ArgumentParser:
     _learn_cmd.register(sub)
     _explain_cmd.register(sub)
     _whoami_cmd.register(sub)
-    # Register noun groups here:
-    #   from office_cli.cli._commands import seat as _seat_group
-    #   _seat_group.register(sub)
+    _floors_cmd.register(sub)
+    _seats_cmd.register(sub)
+    _whereis_cmd.register(sub)
 
     return parser
 

--- a/office_cli/cli/_commands/floors.py
+++ b/office_cli/cli/_commands/floors.py
@@ -58,66 +58,77 @@ def cmd_list(args: argparse.Namespace) -> int:
 
 def cmd_validate(args: argparse.Namespace) -> int:
     data_dir = resolve_data_dir(args)
-    offices = load_offices(data_dir)
-    floor_index: dict[Path, Floor] = {}
-    for office in offices.values():
-        for floor in office.floors.values():
-            floor_index[floor.svg.resolve()] = floor
-
-    targets: list[Path]
-    if args.path:
-        targets = [Path(args.path).resolve()]
-    elif args.all:
-        targets = sorted(floor_index.keys())
-    else:
-        raise OfficeError(
-            code=EXIT_USER_ERROR,
-            message="pass an SVG path or --all",
-            remediation="example: office floors validate floors/tlv-floor-5.svg",
-        )
-
-    payload: list[dict[str, object]] = []
-    error_count = 0
-    for target in targets:
-        floor = floor_index.get(target)
-        if floor is None:
-            raise OfficeError(
-                code=EXIT_USER_ERROR,
-                message=f"SVG {target} is not declared in offices.yaml",
-                remediation="add a floors entry pointing at this SVG",
-            )
-        svg = parse_svg(target)
-        issues = validate_floor(svg, floor)
-        errors = [i for i in issues if i.severity is Severity.ERROR]
-        warnings = [i for i in issues if i.severity is Severity.WARNING]
-        error_count += len(errors)
-        payload.append(
-            {
-                "floor": floor.id,
-                "svg": str(target),
-                "ok": not errors,
-                "errors": [i.to_dict() for i in errors],
-                "warnings": [i.to_dict() for i in warnings],
-                "seat_count": len(svg.seat_ids),
-                "room_count": len(svg.room_ids),
-            }
-        )
-
+    floor_index = _index_floors(load_offices(data_dir))
+    targets = _resolve_targets(args, floor_index, data_dir)
+    payload = [_validate_one(t, floor_index) for t in targets]
+    error_count = sum(len(item["errors"]) for item in payload)  # type: ignore[arg-type]
     if args.json:
         emit_result({"results": payload}, json_mode=True)
     else:
-        for item in payload:
-            mark = "OK " if item["ok"] else "FAIL"
-            emit_result(
-                f"{mark} {item['floor']} ({item['svg']}) "
-                f"seats={item['seat_count']} rooms={item['room_count']}",
-                json_mode=False,
-            )
-            for err in item["errors"]:  # type: ignore[union-attr]
-                emit_diagnostic(f"  error [{err['rule']}]: {err['message']}")
-            for warn in item["warnings"]:  # type: ignore[union-attr]
-                emit_diagnostic(f"  warn  [{warn['rule']}]: {warn['message']}")
+        _print_text(payload)
     return EXIT_USER_ERROR if error_count else 0
+
+
+def _index_floors(offices: dict[str, object]) -> dict[Path, Floor]:
+    out: dict[Path, Floor] = {}
+    for office in offices.values():
+        for floor in office.floors.values():  # type: ignore[attr-defined]
+            out[floor.svg.resolve()] = floor
+    return out
+
+
+def _resolve_targets(
+    args: argparse.Namespace, floor_index: dict[Path, Floor], data_dir: Path
+) -> list[Path]:
+    if args.path:
+        p = Path(args.path)
+        # Relative paths resolve against the data dir (not cwd) so they line up
+        # with floor.svg paths from offices.yaml when --data-dir != $PWD.
+        return [(p if p.is_absolute() else data_dir / p).resolve()]
+    if args.all:
+        return sorted(floor_index.keys())
+    raise OfficeError(
+        code=EXIT_USER_ERROR,
+        message="pass an SVG path or --all",
+        remediation="example: office floors validate floors/tlv-floor-5.svg",
+    )
+
+
+def _validate_one(target: Path, floor_index: dict[Path, Floor]) -> dict[str, object]:
+    floor = floor_index.get(target)
+    if floor is None:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"SVG {target} is not declared in offices.yaml",
+            remediation="add a floors entry pointing at this SVG",
+        )
+    svg = parse_svg(target)
+    issues = validate_floor(svg, floor)
+    errors = [i for i in issues if i.severity is Severity.ERROR]
+    warnings = [i for i in issues if i.severity is Severity.WARNING]
+    return {
+        "floor": floor.id,
+        "svg": str(target),
+        "ok": not errors,
+        "errors": [i.to_dict() for i in errors],
+        "warnings": [i.to_dict() for i in warnings],
+        "seat_count": len(svg.seat_ids),
+        "room_count": len(svg.room_ids),
+    }
+
+
+def _print_text(payload: list[dict[str, object]]) -> None:
+    for item in payload:
+        mark = "OK " if item["ok"] else "FAIL"
+        emit_result(
+            f"{mark} {item['floor']} ({item['svg']}) "
+            f"seats={item['seat_count']} rooms={item['room_count']}",
+            json_mode=False,
+        )
+        for err in item["errors"]:  # type: ignore[union-attr]
+            emit_diagnostic(f"  error [{err['rule']}]: {err['message']}")
+        for warn in item["warnings"]:  # type: ignore[union-attr]
+            emit_diagnostic(f"  warn  [{warn['rule']}]: {warn['message']}")
 
 
 def register(sub: argparse._SubParsersAction) -> None:

--- a/office_cli/cli/_commands/floors.py
+++ b/office_cli/cli/_commands/floors.py
@@ -1,0 +1,149 @@
+"""``office floors`` — list and validate floor SVGs against ``offices.yaml``."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from office_cli._config import add_data_dir_arg, resolve_data_dir
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+from office_cli.cli._output import emit_diagnostic, emit_result
+from office_cli.floors import Severity, parse_svg, validate_floor
+from office_cli.offices import Floor, load_offices
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    data_dir = resolve_data_dir(args)
+    offices = load_offices(data_dir)
+    json_mode = bool(args.json)
+    if args.office and args.office not in offices:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"unknown office: {args.office}",
+            remediation="run: office floors list to see known offices",
+        )
+    items: list[dict[str, object]] = []
+    for office in offices.values():
+        if args.office and office.id != args.office:
+            continue
+        for floor in office.floors.values():
+            items.append(
+                {
+                    "office": office.id,
+                    "floor": floor.id,
+                    "status": floor.status,
+                    "svg": str(floor.svg),
+                    "clusters": {letter: c.capacity for letter, c in floor.clusters.items()},
+                    "rooms": list(floor.rooms.keys()),
+                }
+            )
+    if json_mode:
+        emit_result({"floors": items}, json_mode=True)
+        return 0
+    if not items:
+        emit_result("no floors", json_mode=False)
+        return 0
+    lines = []
+    for it in items:
+        clusters = ", ".join(
+            f"{k}={v}" for k, v in sorted(it["clusters"].items())  # type: ignore[arg-type]
+        )
+        lines.append(
+            f"{it['office']}\t{it['floor']}\t{it['status']}\t"
+            f"clusters[{clusters}]\trooms={len(it['rooms'])}"  # type: ignore[arg-type]
+        )
+    emit_result("\n".join(lines), json_mode=False)
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    data_dir = resolve_data_dir(args)
+    offices = load_offices(data_dir)
+    floor_index: dict[Path, Floor] = {}
+    for office in offices.values():
+        for floor in office.floors.values():
+            floor_index[floor.svg.resolve()] = floor
+
+    targets: list[Path]
+    if args.path:
+        targets = [Path(args.path).resolve()]
+    elif args.all:
+        targets = sorted(floor_index.keys())
+    else:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="pass an SVG path or --all",
+            remediation="example: office floors validate floors/tlv-floor-5.svg",
+        )
+
+    payload: list[dict[str, object]] = []
+    error_count = 0
+    for target in targets:
+        floor = floor_index.get(target)
+        if floor is None:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"SVG {target} is not declared in offices.yaml",
+                remediation="add a floors entry pointing at this SVG",
+            )
+        svg = parse_svg(target)
+        issues = validate_floor(svg, floor)
+        errors = [i for i in issues if i.severity is Severity.ERROR]
+        warnings = [i for i in issues if i.severity is Severity.WARNING]
+        error_count += len(errors)
+        payload.append(
+            {
+                "floor": floor.id,
+                "svg": str(target),
+                "ok": not errors,
+                "errors": [i.to_dict() for i in errors],
+                "warnings": [i.to_dict() for i in warnings],
+                "seat_count": len(svg.seat_ids),
+                "room_count": len(svg.room_ids),
+            }
+        )
+
+    if args.json:
+        emit_result({"results": payload}, json_mode=True)
+    else:
+        for item in payload:
+            mark = "OK " if item["ok"] else "FAIL"
+            emit_result(
+                f"{mark} {item['floor']} ({item['svg']}) "
+                f"seats={item['seat_count']} rooms={item['room_count']}",
+                json_mode=False,
+            )
+            for err in item["errors"]:  # type: ignore[union-attr]
+                emit_diagnostic(f"  error [{err['rule']}]: {err['message']}")
+            for warn in item["warnings"]:  # type: ignore[union-attr]
+                emit_diagnostic(f"  warn  [{warn['rule']}]: {warn['message']}")
+    return EXIT_USER_ERROR if error_count else 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "floors",
+        help="List and validate floor SVGs.",
+        description="List and validate floor SVGs against data/offices.yaml.",
+    )
+    inner = p.add_subparsers(dest="floors_cmd")
+
+    p_list = inner.add_parser("list", help="List configured offices and floors.")
+    p_list.add_argument("--office", help="Restrict to a single office id.")
+    p_list.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    add_data_dir_arg(p_list)
+    p_list.set_defaults(func=cmd_list)
+
+    p_val = inner.add_parser("validate", help="Validate one or all floor SVGs.")
+    p_val.add_argument("path", nargs="?", help="Path to a floor SVG.")
+    p_val.add_argument("--all", action="store_true", help="Validate every declared SVG.")
+    p_val.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    add_data_dir_arg(p_val)
+    p_val.set_defaults(func=cmd_validate)
+
+    p.set_defaults(func=lambda args: _missing_subcommand(p))
+
+
+def _missing_subcommand(parser: argparse.ArgumentParser) -> int:
+    parser.print_help()
+    return 0

--- a/office_cli/cli/_commands/seats.py
+++ b/office_cli/cli/_commands/seats.py
@@ -9,6 +9,8 @@ from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 from office_cli.cli._output import emit_result
 from office_cli.seats import build_service
 
+_NOTE_HELP = "Optional free-text note."
+
 
 def cmd_list(args: argparse.Namespace) -> int:
     data_dir = resolve_data_dir(args)
@@ -113,7 +115,7 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_assign = inner.add_parser("assign", help="Assign a seat to an employee email.")
     p_assign.add_argument("seat_id")
     p_assign.add_argument("email")
-    p_assign.add_argument("--note", help="Optional free-text note.")
+    p_assign.add_argument("--note", help=_NOTE_HELP)
     p_assign.add_argument(
         "--hidden", action="store_true", help="Mark assignment as private (hidden=TRUE)."
     )
@@ -123,7 +125,7 @@ def register(sub: argparse._SubParsersAction) -> None:
 
     p_unassign = inner.add_parser("unassign", help="Vacate a seat.")
     p_unassign.add_argument("seat_id")
-    p_unassign.add_argument("--note", help="Optional free-text note.")
+    p_unassign.add_argument("--note", help=_NOTE_HELP)
     p_unassign.add_argument("--json", action="store_true")
     add_data_dir_arg(p_unassign)
     p_unassign.set_defaults(func=cmd_unassign)
@@ -131,7 +133,7 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_move = inner.add_parser("move", help="Atomically move an employee to a new seat.")
     p_move.add_argument("email")
     p_move.add_argument("new_seat_id")
-    p_move.add_argument("--note", help="Optional free-text note.")
+    p_move.add_argument("--note", help=_NOTE_HELP)
     p_move.add_argument("--json", action="store_true")
     add_data_dir_arg(p_move)
     p_move.set_defaults(func=cmd_move)

--- a/office_cli/cli/_commands/seats.py
+++ b/office_cli/cli/_commands/seats.py
@@ -1,0 +1,150 @@
+"""``office seats`` — list, assign, unassign, move, history."""
+
+from __future__ import annotations
+
+import argparse
+
+from office_cli._config import add_data_dir_arg, resolve_data_dir
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+from office_cli.cli._output import emit_result
+from office_cli.seats import build_service
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    data_dir = resolve_data_dir(args)
+    service = build_service(data_dir)
+    if args.vacant and args.occupied:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="--vacant and --occupied are mutually exclusive",
+            remediation="pass at most one of the two",
+        )
+    rows = service.list_seats(
+        floor=args.floor,
+        cluster=args.cluster,
+        only_vacant=args.vacant,
+        only_occupied=args.occupied,
+    )
+    if args.json:
+        emit_result({"seats": [a.to_dict() for a in rows]}, json_mode=True)
+        return 0
+    if not rows:
+        emit_result("no seats match", json_mode=False)
+        return 0
+    lines = []
+    for a in rows:
+        who = a.employee_email or "(vacant)"
+        marks = "P" if a.hidden else "."
+        lines.append(f"{a.seat_id}\t{a.floor}\t{marks}\t{who}\t{a.last_updated}")
+    emit_result("\n".join(lines), json_mode=False)
+    return 0
+
+
+def cmd_assign(args: argparse.Namespace) -> int:
+    data_dir = resolve_data_dir(args)
+    service = build_service(data_dir)
+    a = service.assign(args.seat_id, args.email, note=args.note or "", hidden=args.hidden)
+    _emit_assignment(a, args.json, "assigned")
+    return 0
+
+
+def cmd_unassign(args: argparse.Namespace) -> int:
+    data_dir = resolve_data_dir(args)
+    service = build_service(data_dir)
+    a = service.unassign(args.seat_id, note=args.note or "")
+    _emit_assignment(a, args.json, "unassigned")
+    return 0
+
+
+def cmd_move(args: argparse.Namespace) -> int:
+    data_dir = resolve_data_dir(args)
+    service = build_service(data_dir)
+    a = service.move(args.email, args.new_seat_id, note=args.note or "")
+    _emit_assignment(a, args.json, "moved")
+    return 0
+
+
+def cmd_history(args: argparse.Namespace) -> int:
+    data_dir = resolve_data_dir(args)
+    service = build_service(data_dir)
+    entries = service.history(args.seat_id)
+    if args.json:
+        emit_result(
+            {"seat_id": args.seat_id, "history": [e.to_dict() for e in entries]},
+            json_mode=True,
+        )
+        return 0
+    if not entries:
+        emit_result(f"no history for {args.seat_id}", json_mode=False)
+        return 0
+    lines = []
+    for e in entries:
+        who = e.employee_email or e.old_employee_email or ""
+        lines.append(f"{e.timestamp}\t{e.action}\t{e.seat_id}\t{who}\t{e.note}")
+    emit_result("\n".join(lines), json_mode=False)
+    return 0
+
+
+def _emit_assignment(assignment, json_mode: bool, verb: str) -> None:
+    if json_mode:
+        emit_result({"action": verb, "assignment": assignment.to_dict()}, json_mode=True)
+    else:
+        who = assignment.employee_email or "(vacant)"
+        emit_result(f"{verb}: {assignment.seat_id} → {who}", json_mode=False)
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "seats",
+        help="List and mutate seat assignments.",
+        description="List and mutate seat assignments stored under seats/.",
+    )
+    inner = p.add_subparsers(dest="seats_cmd")
+
+    p_list = inner.add_parser("list", help="List seats with assignment status.")
+    p_list.add_argument("--floor", help="Restrict to a single floor id.")
+    p_list.add_argument("--cluster", help="Restrict to a single cluster letter.")
+    p_list.add_argument("--vacant", action="store_true", help="Only vacant seats.")
+    p_list.add_argument("--occupied", action="store_true", help="Only occupied seats.")
+    p_list.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    add_data_dir_arg(p_list)
+    p_list.set_defaults(func=cmd_list)
+
+    p_assign = inner.add_parser("assign", help="Assign a seat to an employee email.")
+    p_assign.add_argument("seat_id")
+    p_assign.add_argument("email")
+    p_assign.add_argument("--note", help="Optional free-text note.")
+    p_assign.add_argument(
+        "--hidden", action="store_true", help="Mark assignment as private (hidden=TRUE)."
+    )
+    p_assign.add_argument("--json", action="store_true")
+    add_data_dir_arg(p_assign)
+    p_assign.set_defaults(func=cmd_assign)
+
+    p_unassign = inner.add_parser("unassign", help="Vacate a seat.")
+    p_unassign.add_argument("seat_id")
+    p_unassign.add_argument("--note", help="Optional free-text note.")
+    p_unassign.add_argument("--json", action="store_true")
+    add_data_dir_arg(p_unassign)
+    p_unassign.set_defaults(func=cmd_unassign)
+
+    p_move = inner.add_parser("move", help="Atomically move an employee to a new seat.")
+    p_move.add_argument("email")
+    p_move.add_argument("new_seat_id")
+    p_move.add_argument("--note", help="Optional free-text note.")
+    p_move.add_argument("--json", action="store_true")
+    add_data_dir_arg(p_move)
+    p_move.set_defaults(func=cmd_move)
+
+    p_history = inner.add_parser("history", help="Show audit-log entries for a seat.")
+    p_history.add_argument("seat_id")
+    p_history.add_argument("--json", action="store_true")
+    add_data_dir_arg(p_history)
+    p_history.set_defaults(func=cmd_history)
+
+    p.set_defaults(func=lambda args: _missing_subcommand(p))
+
+
+def _missing_subcommand(parser: argparse.ArgumentParser) -> int:
+    parser.print_help()
+    return 0

--- a/office_cli/cli/_commands/whereis.py
+++ b/office_cli/cli/_commands/whereis.py
@@ -1,0 +1,42 @@
+"""``office whereis EMAIL`` — find a person's seat.
+
+The CLI mirror of the Slack ``/whereis`` slash command; both call the same
+:class:`SeatService` underneath.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from office_cli._config import add_data_dir_arg, resolve_data_dir
+from office_cli.cli._output import emit_result
+from office_cli.seats import build_service
+
+
+def cmd_whereis(args: argparse.Namespace) -> int:
+    data_dir = resolve_data_dir(args)
+    service = build_service(data_dir)
+    a = service.whereis(args.email)
+    if args.json:
+        emit_result(
+            {"email": args.email, "assignment": a.to_dict() if a else None},
+            json_mode=True,
+        )
+        return 0
+    if a is None:
+        emit_result(f"{args.email}: no seat", json_mode=False)
+        return 0
+    emit_result(f"{args.email}: {a.seat_id} ({a.floor})", json_mode=False)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "whereis",
+        help="Look up an employee's seat by email.",
+        description="Look up an employee's seat by email.",
+    )
+    p.add_argument("email")
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    add_data_dir_arg(p)
+    p.set_defaults(func=cmd_whereis)

--- a/office_cli/explain/catalog.py
+++ b/office_cli/explain/catalog.py
@@ -13,16 +13,21 @@ _ROOT = """\
 # office
 
 office is AgentCulture's CLI for seat assignments and meeting-room
-operations across multiple office floors. v0.0.1 ships only the agent-first
-scaffold (`learn`, `explain`, `whoami`); real verbs (seat assign, room book,
-where, etc.) land in later versions on top of the SVG-based floor plan
-contract.
+operations across multiple office floors. From v0.1.0 the seating-system
+data model and core CLI verbs are in place; Sheets / BambooHR / Slack /
+web ship in subsequent stages on top of the same `office_cli.seats`
+service layer.
 
 ## Verbs
 
 - `office learn` — structured self-teaching prompt.
 - `office explain <path>` — markdown docs for any noun/verb.
 - `office whoami` — auth probe stub.
+- `office floors list|validate` — list configured floors; validate SVGs.
+- `office seats list|assign|unassign|move|history` — query and mutate
+  seat assignments (CSV-backed in v0.1.0).
+- `office whereis EMAIL` — find a person's seat (CLI mirror of Slack
+  `/whereis`).
 
 ## Exit-code policy
 
@@ -37,6 +42,9 @@ contract.
 - `office explain learn`
 - `office explain explain`
 - `office explain whoami`
+- `office explain floors`
+- `office explain seats`
+- `office explain whereis`
 """
 
 _LEARN = """\
@@ -86,10 +94,160 @@ stable; values evolve as back-ends come online.
 """
 
 
+_FLOORS = """\
+# office floors
+
+List configured offices/floors and validate floor SVGs against the
+`data/offices.yaml` topology.
+
+## Subcommands
+
+- `office floors list [--office ID] [--json] [--data-dir DIR]`
+- `office floors validate [PATH] [--all] [--json] [--data-dir DIR]`
+
+## Validation rules
+
+A traced floor SVG must:
+
+- have `viewBox="0 0 1920 1080"`;
+- give every `<rect class="seat">` a `<floor>-<CLUSTER>-<NN>` id whose
+  floor segment matches the floor entry's id;
+- give every `<polygon class="room">` an architect id like `5.18`;
+- have unique ids within the file.
+
+Cluster capacities and room declarations missing from `offices.yaml`
+surface as warnings (not failures).
+"""
+
+_FLOORS_LIST = """\
+# office floors list
+
+Walk `data/offices.yaml` and emit one row per declared floor: office id,
+floor id, status, cluster summary, room count.
+
+## Usage
+
+    office floors list
+    office floors list --office tlv
+    office floors list --json
+
+`--data-dir DIR` (or `OFFICE_DATA_DIR`) overrides the working directory.
+"""
+
+_FLOORS_VALIDATE = """\
+# office floors validate
+
+Validate one or all floor SVGs against the `data/offices.yaml` topology.
+Errors fail the run with exit code 1; warnings do not.
+
+## Usage
+
+    office floors validate floors/tlv-floor-5.svg
+    office floors validate --all
+    office floors validate --all --json
+
+## Output
+
+Text: one line per floor (`OK` / `FAIL`) plus indented `error [rule]:` /
+`warn [rule]:` lines. JSON: `{"results": [{"floor","ok","errors","warnings",...}]}`.
+"""
+
+_SEATS = """\
+# office seats
+
+List and mutate seat assignments stored under `seats/`. The CSV-backed
+store in v0.1.0 is a stand-in for the Sheets-backed store coming next.
+
+## Subcommands
+
+- `office seats list [--floor F] [--cluster L] [--vacant|--occupied] [--json]`
+- `office seats assign SEAT EMAIL [--note N] [--hidden] [--json]`
+- `office seats unassign SEAT [--note N] [--json]`
+- `office seats move EMAIL NEW_SEAT [--note N] [--json]`
+- `office seats history SEAT [--json]`
+
+## Invariants
+
+- a seat must exist in some floor's SVG (or be a YAML-declared room);
+- an employee holds at most one seat globally — re-assigning rejects
+  with a hint to use `move`;
+- every mutation appends an entry to `seats/audit-log.csv`.
+"""
+
+_SEATS_ASSIGN = """\
+# office seats assign
+
+Assign a seat to an employee email. Fails if the seat is occupied by a
+different employee, or if the employee already holds another seat
+globally (use `office seats move` instead).
+
+## Usage
+
+    office seats assign 5-T-01 alice@tipalti.com
+    office seats assign 5.18 bob@tipalti.com --hidden --note "exec seat"
+
+`--hidden` marks the row `hidden=TRUE`; non-privileged surfaces (web,
+Slack) will render it as "occupied (private)".
+"""
+
+_SEATS_MOVE = """\
+# office seats move
+
+Atomically move an employee from their current seat to a new one. The
+old seat is vacated and the new seat is assigned in a single operation;
+two audit entries are written (one `unassign`, one `assign`) sharing a
+timestamp.
+
+## Usage
+
+    office seats move alice@tipalti.com 5-T-02
+
+Fails if the email has no current seat (use `assign`) or if the target
+seat is occupied.
+"""
+
+_SEATS_HISTORY = """\
+# office seats history
+
+Return chronological audit-log entries for a seat. Answers "who used to
+sit at 5-T-01?" without ever overwriting history — the audit log is
+append-only.
+
+## Usage
+
+    office seats history 5-T-01
+    office seats history 5-T-01 --json
+"""
+
+_WHEREIS = """\
+# office whereis EMAIL
+
+Find a person's current seat by email. The CLI mirror of the (planned)
+Slack `/whereis` slash command — both surfaces call the same
+`SeatService.whereis` underneath.
+
+## Usage
+
+    office whereis alice@tipalti.com
+    office whereis alice@tipalti.com --json
+
+Exits 0 even when no seat is found; the JSON payload reports
+`assignment: null` so callers can disambiguate.
+"""
+
+
 ENTRIES: dict[tuple[str, ...], str] = {
     (): _ROOT,
     ("office",): _ROOT,
     ("learn",): _LEARN,
     ("explain",): _EXPLAIN,
     ("whoami",): _WHOAMI,
+    ("floors",): _FLOORS,
+    ("floors", "list"): _FLOORS_LIST,
+    ("floors", "validate"): _FLOORS_VALIDATE,
+    ("seats",): _SEATS,
+    ("seats", "assign"): _SEATS_ASSIGN,
+    ("seats", "move"): _SEATS_MOVE,
+    ("seats", "history"): _SEATS_HISTORY,
+    ("whereis",): _WHEREIS,
 }

--- a/office_cli/floors/__init__.py
+++ b/office_cli/floors/__init__.py
@@ -1,0 +1,26 @@
+"""Floor SVG parsing and validation against ``offices.yaml``."""
+
+from __future__ import annotations
+
+from office_cli.floors._ids import (
+    ROOM_RE,
+    SEAT_RE,
+    is_room_id,
+    is_seat_id,
+    parse_seat_id,
+)
+from office_cli.floors._svg import FloorSvg, parse_svg
+from office_cli.floors._validate import Issue, Severity, validate_floor
+
+__all__ = [
+    "FloorSvg",
+    "Issue",
+    "ROOM_RE",
+    "SEAT_RE",
+    "Severity",
+    "is_room_id",
+    "is_seat_id",
+    "parse_seat_id",
+    "parse_svg",
+    "validate_floor",
+]

--- a/office_cli/floors/_ids.py
+++ b/office_cli/floors/_ids.py
@@ -1,0 +1,40 @@
+"""Canonical ID contract for floor SVGs.
+
+Mirrors the SVG ID rules in
+``CLAUDE.md`` and `agentculture/office-agent#1
+<https://github.com/agentculture/office-agent/issues/1>`_.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+SEAT_RE = re.compile(r"^(?P<floor>\d+)-(?P<cluster>[A-Z])-(?P<num>\d{2})$")
+ROOM_RE = re.compile(r"^\d+\.\d+$")
+CLUSTER_BOUNDARY_RE = re.compile(r"^cluster-\d+-[A-Z]$")
+
+
+@dataclass(frozen=True)
+class SeatId:
+    floor: str
+    cluster: str
+    num: int
+
+    def __str__(self) -> str:
+        return f"{self.floor}-{self.cluster}-{self.num:02d}"
+
+
+def is_seat_id(s: str) -> bool:
+    return SEAT_RE.match(s) is not None
+
+
+def is_room_id(s: str) -> bool:
+    return ROOM_RE.match(s) is not None
+
+
+def parse_seat_id(s: str) -> SeatId:
+    m = SEAT_RE.match(s)
+    if not m:
+        raise ValueError(f"not a seat id: {s!r}")
+    return SeatId(floor=m["floor"], cluster=m["cluster"], num=int(m["num"]))

--- a/office_cli/floors/_svg.py
+++ b/office_cli/floors/_svg.py
@@ -28,6 +28,26 @@ class FloorSvg:
 
 
 def parse_svg(path: Path) -> FloorSvg:
+    root = _load_root(path)
+    seats: list[str] = []
+    rooms: list[str] = []
+    untagged: list[str] = []
+    seen: set[str] = set()
+    dup: list[str] = []
+    for tag in ("rect", "polygon"):
+        for el in root.iter(f"{_SVG_NS}{tag}"):
+            _classify(el, seats, rooms, untagged, seen, dup)
+    return FloorSvg(
+        path=path,
+        view_box=root.attrib.get("viewBox", ""),
+        seat_ids=tuple(seats),
+        room_ids=tuple(rooms),
+        untagged_ids=tuple(untagged),
+        duplicate_ids=tuple(dup),
+    )
+
+
+def _load_root(path: Path) -> ET.Element:
     if not path.is_file():
         raise OfficeError(
             code=EXIT_USER_ERROR,
@@ -35,44 +55,33 @@ def parse_svg(path: Path) -> FloorSvg:
             remediation="check the path or run from the repo root",
         )
     try:
-        tree = ET.parse(path)
+        return ET.parse(path).getroot()
     except ET.ParseError as err:
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=f"SVG is not well-formed XML: {path}: {err}",
             remediation="open in Inkscape and re-save as Plain SVG",
         ) from err
-    root = tree.getroot()
-    view_box = root.attrib.get("viewBox", "")
 
-    seats: list[str] = []
-    rooms: list[str] = []
-    untagged: list[str] = []
-    seen: set[str] = set()
-    dup: list[str] = []
 
-    for tag in ("rect", "polygon"):
-        for el in root.iter(f"{_SVG_NS}{tag}"):
-            sid = el.attrib.get("id")
-            if not sid:
-                continue
-            if sid in seen:
-                dup.append(sid)
-            else:
-                seen.add(sid)
-            cls = (el.attrib.get("class") or "").strip()
-            if cls == "seat":
-                seats.append(sid)
-            elif cls == "room":
-                rooms.append(sid)
-            else:
-                untagged.append(sid)
+_BUCKETS = {"seat": 0, "room": 1}  # → index into the (seats, rooms, untagged) tuple
 
-    return FloorSvg(
-        path=path,
-        view_box=view_box,
-        seat_ids=tuple(seats),
-        room_ids=tuple(rooms),
-        untagged_ids=tuple(untagged),
-        duplicate_ids=tuple(dup),
-    )
+
+def _classify(
+    el: ET.Element,
+    seats: list[str],
+    rooms: list[str],
+    untagged: list[str],
+    seen: set[str],
+    dup: list[str],
+) -> None:
+    sid = el.attrib.get("id")
+    if not sid:
+        return
+    if sid in seen:
+        dup.append(sid)
+    else:
+        seen.add(sid)
+    cls = (el.attrib.get("class") or "").strip()
+    bucket = (seats, rooms, untagged)[_BUCKETS.get(cls, 2)]
+    bucket.append(sid)

--- a/office_cli/floors/_svg.py
+++ b/office_cli/floors/_svg.py
@@ -1,0 +1,78 @@
+"""Parse a floor SVG into a structured view.
+
+Reads only what the agent contract promises: ``<rect>`` / ``<polygon>``
+elements with an ``id`` attribute, optionally tagged with
+``class="seat"`` / ``class="room"``. Everything else (background image,
+layer groups, styles) is ignored.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+
+_SVG_NS = "{http://www.w3.org/2000/svg}"
+
+
+@dataclass(frozen=True)
+class FloorSvg:
+    path: Path
+    view_box: str
+    seat_ids: tuple[str, ...] = field(default_factory=tuple)
+    room_ids: tuple[str, ...] = field(default_factory=tuple)
+    untagged_ids: tuple[str, ...] = field(default_factory=tuple)
+    duplicate_ids: tuple[str, ...] = field(default_factory=tuple)
+
+
+def parse_svg(path: Path) -> FloorSvg:
+    if not path.is_file():
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"SVG not found: {path}",
+            remediation="check the path or run from the repo root",
+        )
+    try:
+        tree = ET.parse(path)
+    except ET.ParseError as err:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"SVG is not well-formed XML: {path}: {err}",
+            remediation="open in Inkscape and re-save as Plain SVG",
+        ) from err
+    root = tree.getroot()
+    view_box = root.attrib.get("viewBox", "")
+
+    seats: list[str] = []
+    rooms: list[str] = []
+    untagged: list[str] = []
+    seen: set[str] = set()
+    dup: list[str] = []
+
+    for tag in ("rect", "polygon"):
+        for el in root.iter(f"{_SVG_NS}{tag}"):
+            sid = el.attrib.get("id")
+            if not sid:
+                continue
+            if sid in seen:
+                dup.append(sid)
+            else:
+                seen.add(sid)
+            cls = (el.attrib.get("class") or "").strip()
+            if cls == "seat":
+                seats.append(sid)
+            elif cls == "room":
+                rooms.append(sid)
+            else:
+                untagged.append(sid)
+
+    return FloorSvg(
+        path=path,
+        view_box=view_box,
+        seat_ids=tuple(seats),
+        room_ids=tuple(rooms),
+        untagged_ids=tuple(untagged),
+        duplicate_ids=tuple(dup),
+    )

--- a/office_cli/floors/_validate.py
+++ b/office_cli/floors/_validate.py
@@ -1,0 +1,124 @@
+"""Validate a parsed :class:`FloorSvg` against an ``offices.yaml`` floor entry."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from enum import Enum
+
+from office_cli.floors._ids import is_room_id, is_seat_id, parse_seat_id
+from office_cli.floors._svg import FloorSvg
+from office_cli.offices._models import Floor
+
+_EXPECTED_VIEW_BOX = "0 0 1920 1080"
+
+
+class Severity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+
+
+@dataclass(frozen=True)
+class Issue:
+    severity: Severity
+    rule: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "severity": self.severity.value,
+            "rule": self.rule,
+            "message": self.message,
+        }
+
+
+def validate_floor(svg: FloorSvg, floor: Floor) -> list[Issue]:
+    """Return a list of issues; empty list means the SVG conforms."""
+    issues: list[Issue] = []
+
+    if svg.view_box != _EXPECTED_VIEW_BOX:
+        issues.append(
+            Issue(
+                Severity.ERROR,
+                "view-box",
+                f"viewBox is {svg.view_box!r}; expected {_EXPECTED_VIEW_BOX!r}",
+            )
+        )
+
+    for sid in svg.duplicate_ids:
+        issues.append(Issue(Severity.ERROR, "duplicate-id", f"id {sid!r} appears more than once"))
+
+    for sid in svg.seat_ids:
+        if not is_seat_id(sid):
+            issues.append(
+                Issue(
+                    Severity.ERROR,
+                    "seat-id-format",
+                    f"seat id {sid!r} does not match <floor>-<CLUSTER>-<NN>",
+                )
+            )
+            continue
+        parsed = parse_seat_id(sid)
+        if parsed.floor != floor.number:
+            issues.append(
+                Issue(
+                    Severity.ERROR,
+                    "seat-floor-mismatch",
+                    f"seat {sid!r} starts with floor {parsed.floor!r}; "
+                    f"expected {floor.number!r} (from floor id {floor.id!r})",
+                )
+            )
+        if parsed.cluster not in floor.clusters:
+            issues.append(
+                Issue(
+                    Severity.ERROR,
+                    "unknown-cluster",
+                    f"seat {sid!r} references cluster {parsed.cluster!r} "
+                    f"not declared for floor {floor.id!r}",
+                )
+            )
+
+    for rid in svg.room_ids:
+        if not is_room_id(rid):
+            issues.append(
+                Issue(
+                    Severity.ERROR,
+                    "room-id-format",
+                    f"room id {rid!r} does not match the architect <N>.<NN> pattern",
+                )
+            )
+            continue
+        if rid not in floor.rooms:
+            issues.append(
+                Issue(
+                    Severity.WARNING,
+                    "room-not-in-yaml",
+                    f"room {rid!r} present in SVG but not declared in offices.yaml "
+                    f"for floor {floor.id!r}",
+                )
+            )
+
+    for sid in svg.untagged_ids:
+        if is_seat_id(sid) or is_room_id(sid):
+            issues.append(
+                Issue(
+                    Severity.ERROR,
+                    "missing-class",
+                    f'id {sid!r} looks like a seat/room but has no class="seat"/"room"',
+                )
+            )
+
+    counts = Counter(parse_seat_id(s).cluster for s in svg.seat_ids if is_seat_id(s))
+    for letter, cluster in floor.clusters.items():
+        actual = counts.get(letter, 0)
+        if actual != cluster.capacity:
+            issues.append(
+                Issue(
+                    Severity.WARNING,
+                    "cluster-capacity-mismatch",
+                    f"cluster {letter!r} has {actual} seats in SVG; "
+                    f"offices.yaml declares capacity {cluster.capacity}",
+                )
+            )
+
+    return issues

--- a/office_cli/floors/_validate.py
+++ b/office_cli/floors/_validate.py
@@ -35,90 +35,110 @@ class Issue:
 def validate_floor(svg: FloorSvg, floor: Floor) -> list[Issue]:
     """Return a list of issues; empty list means the SVG conforms."""
     issues: list[Issue] = []
+    issues.extend(_check_view_box(svg))
+    issues.extend(_check_duplicates(svg))
+    for sid in svg.seat_ids:
+        issues.extend(_check_seat(sid, floor))
+    for rid in svg.room_ids:
+        issues.extend(_check_room(rid, floor))
+    issues.extend(_check_untagged(svg))
+    issues.extend(_check_capacity(svg, floor))
+    return issues
 
-    if svg.view_box != _EXPECTED_VIEW_BOX:
-        issues.append(
+
+def _check_view_box(svg: FloorSvg) -> list[Issue]:
+    if svg.view_box == _EXPECTED_VIEW_BOX:
+        return []
+    return [
+        Issue(
+            Severity.ERROR,
+            "view-box",
+            f"viewBox is {svg.view_box!r}; expected {_EXPECTED_VIEW_BOX!r}",
+        )
+    ]
+
+
+def _check_duplicates(svg: FloorSvg) -> list[Issue]:
+    return [
+        Issue(Severity.ERROR, "duplicate-id", f"id {sid!r} appears more than once")
+        for sid in svg.duplicate_ids
+    ]
+
+
+def _check_seat(sid: str, floor: Floor) -> list[Issue]:
+    if not is_seat_id(sid):
+        return [
             Issue(
                 Severity.ERROR,
-                "view-box",
-                f"viewBox is {svg.view_box!r}; expected {_EXPECTED_VIEW_BOX!r}",
+                "seat-id-format",
+                f"seat id {sid!r} does not match <floor>-<CLUSTER>-<NN>",
+            )
+        ]
+    parsed = parse_seat_id(sid)
+    out: list[Issue] = []
+    if parsed.floor != floor.number:
+        out.append(
+            Issue(
+                Severity.ERROR,
+                "seat-floor-mismatch",
+                f"seat {sid!r} starts with floor {parsed.floor!r}; "
+                f"expected {floor.number!r} (from floor id {floor.id!r})",
             )
         )
+    if parsed.cluster not in floor.clusters:
+        out.append(
+            Issue(
+                Severity.ERROR,
+                "unknown-cluster",
+                f"seat {sid!r} references cluster {parsed.cluster!r} "
+                f"not declared for floor {floor.id!r}",
+            )
+        )
+    return out
 
-    for sid in svg.duplicate_ids:
-        issues.append(Issue(Severity.ERROR, "duplicate-id", f"id {sid!r} appears more than once"))
 
-    for sid in svg.seat_ids:
-        if not is_seat_id(sid):
-            issues.append(
-                Issue(
-                    Severity.ERROR,
-                    "seat-id-format",
-                    f"seat id {sid!r} does not match <floor>-<CLUSTER>-<NN>",
-                )
+def _check_room(rid: str, floor: Floor) -> list[Issue]:
+    if not is_room_id(rid):
+        return [
+            Issue(
+                Severity.ERROR,
+                "room-id-format",
+                f"room id {rid!r} does not match the architect <N>.<NN> pattern",
             )
-            continue
-        parsed = parse_seat_id(sid)
-        if parsed.floor != floor.number:
-            issues.append(
-                Issue(
-                    Severity.ERROR,
-                    "seat-floor-mismatch",
-                    f"seat {sid!r} starts with floor {parsed.floor!r}; "
-                    f"expected {floor.number!r} (from floor id {floor.id!r})",
-                )
+        ]
+    if rid not in floor.rooms:
+        return [
+            Issue(
+                Severity.WARNING,
+                "room-not-in-yaml",
+                f"room {rid!r} present in SVG but not declared in offices.yaml "
+                f"for floor {floor.id!r}",
             )
-        if parsed.cluster not in floor.clusters:
-            issues.append(
-                Issue(
-                    Severity.ERROR,
-                    "unknown-cluster",
-                    f"seat {sid!r} references cluster {parsed.cluster!r} "
-                    f"not declared for floor {floor.id!r}",
-                )
-            )
+        ]
+    return []
 
-    for rid in svg.room_ids:
-        if not is_room_id(rid):
-            issues.append(
-                Issue(
-                    Severity.ERROR,
-                    "room-id-format",
-                    f"room id {rid!r} does not match the architect <N>.<NN> pattern",
-                )
-            )
-            continue
-        if rid not in floor.rooms:
-            issues.append(
-                Issue(
-                    Severity.WARNING,
-                    "room-not-in-yaml",
-                    f"room {rid!r} present in SVG but not declared in offices.yaml "
-                    f"for floor {floor.id!r}",
-                )
-            )
 
-    for sid in svg.untagged_ids:
-        if is_seat_id(sid) or is_room_id(sid):
-            issues.append(
-                Issue(
-                    Severity.ERROR,
-                    "missing-class",
-                    f'id {sid!r} looks like a seat/room but has no class="seat"/"room"',
-                )
-            )
+def _check_untagged(svg: FloorSvg) -> list[Issue]:
+    return [
+        Issue(
+            Severity.ERROR,
+            "missing-class",
+            f'id {sid!r} looks like a seat/room but has no class="seat"/"room"',
+        )
+        for sid in svg.untagged_ids
+        if is_seat_id(sid) or is_room_id(sid)
+    ]
 
+
+def _check_capacity(svg: FloorSvg, floor: Floor) -> list[Issue]:
     counts = Counter(parse_seat_id(s).cluster for s in svg.seat_ids if is_seat_id(s))
-    for letter, cluster in floor.clusters.items():
-        actual = counts.get(letter, 0)
-        if actual != cluster.capacity:
-            issues.append(
-                Issue(
-                    Severity.WARNING,
-                    "cluster-capacity-mismatch",
-                    f"cluster {letter!r} has {actual} seats in SVG; "
-                    f"offices.yaml declares capacity {cluster.capacity}",
-                )
-            )
-
-    return issues
+    return [
+        Issue(
+            Severity.WARNING,
+            "cluster-capacity-mismatch",
+            f"cluster {letter!r} has {counts.get(letter, 0)} seats in SVG; "
+            f"offices.yaml declares capacity {cluster.capacity}",
+        )
+        for letter, cluster in floor.clusters.items()
+        if counts.get(letter, 0) != cluster.capacity
+    ]

--- a/office_cli/offices/__init__.py
+++ b/office_cli/offices/__init__.py
@@ -1,0 +1,14 @@
+"""Office / floor / cluster / room metadata.
+
+The single entry point is :func:`load_offices`, which parses
+``<data_dir>/data/offices.yaml`` into immutable dataclasses. Failures raise
+:class:`office_cli.cli._errors.OfficeError` so the CLI layer can surface them
+without leaking tracebacks.
+"""
+
+from __future__ import annotations
+
+from office_cli.offices._models import Cluster, Floor, Office, Room
+from office_cli.offices._yaml import load_offices
+
+__all__ = ["Cluster", "Floor", "Office", "Room", "load_offices"]

--- a/office_cli/offices/_models.py
+++ b/office_cli/offices/_models.py
@@ -1,0 +1,44 @@
+"""Frozen dataclasses for the office topology."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Cluster:
+    letter: str
+    capacity: int
+    type: str = "open-space"
+
+
+@dataclass(frozen=True)
+class Room:
+    id: str
+    name: str
+    type: str = "meeting"
+    capacity: int = 0
+
+
+@dataclass(frozen=True)
+class Floor:
+    id: str
+    svg: Path
+    clusters: dict[str, Cluster] = field(default_factory=dict)
+    rooms: dict[str, Room] = field(default_factory=dict)
+    status: str = "active"
+
+    @property
+    def number(self) -> str:
+        """Floor number segment used in seat IDs (e.g. ``5`` from ``tlv-floor-5``)."""
+        last = self.id.rsplit("-", 1)[-1]
+        return last
+
+
+@dataclass(frozen=True)
+class Office:
+    id: str
+    name: str
+    address: str = ""
+    floors: dict[str, Floor] = field(default_factory=dict)

--- a/office_cli/offices/_yaml.py
+++ b/office_cli/offices/_yaml.py
@@ -1,0 +1,114 @@
+"""Load ``data/offices.yaml`` into the typed model."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from office_cli.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, OfficeError
+from office_cli.offices._models import Cluster, Floor, Office, Room
+
+
+def load_offices(data_dir: Path) -> dict[str, Office]:
+    """Parse ``<data_dir>/data/offices.yaml`` → ``{office_id: Office}``."""
+    yaml_path = data_dir / "data" / "offices.yaml"
+    if not yaml_path.is_file():
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message=f"offices.yaml not found at {yaml_path}",
+            remediation="create data/offices.yaml or set OFFICE_DATA_DIR / pass --data-dir",
+        )
+    with yaml_path.open("r", encoding="utf-8") as f:
+        try:
+            raw = yaml.safe_load(f) or {}
+        except yaml.YAMLError as err:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"offices.yaml is not valid YAML: {err}",
+                remediation="fix the YAML syntax and rerun",
+            ) from err
+
+    offices_raw = raw.get("offices")
+    if not isinstance(offices_raw, list):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="offices.yaml must contain a top-level `offices:` list",
+            remediation="see data/offices.yaml in the office-agent repo for the expected shape",
+        )
+
+    offices: dict[str, Office] = {}
+    floors_dir = data_dir / "floors"
+    for entry in offices_raw:
+        office = _parse_office(entry, floors_dir)
+        if office.id in offices:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"duplicate office id: {office.id}",
+                remediation="office ids must be globally unique in offices.yaml",
+            )
+        offices[office.id] = office
+    return offices
+
+
+def _require(d: dict[str, Any], key: str, ctx: str) -> Any:
+    if key not in d:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"missing required field `{key}` in {ctx}",
+            remediation=f"add `{key}: ...` to the {ctx} entry",
+        )
+    return d[key]
+
+
+def _parse_office(entry: Any, floors_dir: Path) -> Office:
+    if not isinstance(entry, dict):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="each office entry must be a mapping",
+            remediation="see data/offices.yaml for the expected shape",
+        )
+    oid = str(_require(entry, "id", "office"))
+    name = str(_require(entry, "name", f"office {oid}"))
+    address = str(entry.get("address", ""))
+    floors_raw = entry.get("floors", []) or []
+    floors: dict[str, Floor] = {}
+    for f in floors_raw:
+        floor = _parse_floor(f, floors_dir, oid)
+        floors[floor.id] = floor
+    return Office(id=oid, name=name, address=address, floors=floors)
+
+
+def _parse_floor(entry: Any, floors_dir: Path, office_id: str) -> Floor:
+    if not isinstance(entry, dict):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"each floor entry under office `{office_id}` must be a mapping",
+            remediation="see data/offices.yaml for the expected shape",
+        )
+    fid = str(_require(entry, "id", f"floor under office {office_id}"))
+    svg_field = entry.get("svg", f"floors/{fid}.svg")
+    svg_path = Path(svg_field)
+    if not svg_path.is_absolute():
+        # Resolve relative to the data_dir (parent of `floors/`).
+        svg_path = floors_dir.parent / svg_path
+    clusters: dict[str, Cluster] = {}
+    for letter, cdata in (entry.get("clusters") or {}).items():
+        cdata = cdata or {}
+        clusters[letter] = Cluster(
+            letter=letter,
+            capacity=int(cdata.get("capacity", 0)),
+            type=str(cdata.get("type", "open-space")),
+        )
+    rooms: dict[str, Room] = {}
+    for rid, rdata in (entry.get("rooms") or {}).items():
+        rdata = rdata or {}
+        rooms[rid] = Room(
+            id=str(rid),
+            name=str(rdata.get("name", rid)),
+            type=str(rdata.get("type", "meeting")),
+            capacity=int(rdata.get("capacity", 0)),
+        )
+    status = str(entry.get("status", "active"))
+    return Floor(id=fid, svg=svg_path, clusters=clusters, rooms=rooms, status=status)

--- a/office_cli/offices/_yaml.py
+++ b/office_cli/offices/_yaml.py
@@ -76,6 +76,12 @@ def _parse_office(entry: Any, floors_dir: Path) -> Office:
     floors: dict[str, Floor] = {}
     for f in floors_raw:
         floor = _parse_floor(f, floors_dir, oid)
+        if floor.id in floors:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"duplicate floor id under office `{oid}`: {floor.id}",
+                remediation="floor ids must be unique within an office in offices.yaml",
+            )
         floors[floor.id] = floor
     return Office(id=oid, name=name, address=address, floors=floors)
 

--- a/office_cli/people/__init__.py
+++ b/office_cli/people/__init__.py
@@ -1,0 +1,12 @@
+"""People surface — Stage 1 stub.
+
+The real source of truth for employees is BambooHR, pulled live and cached
+five minutes. Stage 1 stubs that with :class:`StubDirectory`, which trusts
+whatever email it is handed and never persists anything.
+"""
+
+from __future__ import annotations
+
+from office_cli.people._stub import Employee, EmployeeDirectory, StubDirectory
+
+__all__ = ["Employee", "EmployeeDirectory", "StubDirectory"]

--- a/office_cli/people/_stub.py
+++ b/office_cli/people/_stub.py
@@ -1,0 +1,40 @@
+"""Employee model + directory Protocol + a no-op stub."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class Employee:
+    email: str
+    name: str = ""
+    role: str = ""
+    photo_url: str = ""
+
+    @property
+    def is_active(self) -> bool:
+        # Real directories will compute this against BambooHR's offboarding
+        # state. The stub treats every email as active.
+        return True
+
+
+class EmployeeDirectory(Protocol):
+    def get(self, email: str) -> Employee | None:
+        """Return employee details for ``email`` or ``None`` if unknown."""
+
+    def is_active(self, email: str) -> bool:
+        """``True`` if the employee is currently employed (drives auto-vacate)."""
+
+
+class StubDirectory:
+    """Trust-the-email directory used until BambooHR is wired up."""
+
+    def get(self, email: str) -> Employee | None:
+        if not email:
+            return None
+        return Employee(email=email)
+
+    def is_active(self, email: str) -> bool:
+        return bool(email)

--- a/office_cli/seats/__init__.py
+++ b/office_cli/seats/__init__.py
@@ -1,0 +1,47 @@
+"""Seat assignment store + audit log + business-logic service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from office_cli._config import assignments_csv, audit_log_csv
+from office_cli.floors import FloorSvg, parse_svg
+from office_cli.offices import load_offices
+from office_cli.seats._audit import AuditEntry, AuditLog
+from office_cli.seats._csv_store import CsvStore
+from office_cli.seats._models import Assignment
+from office_cli.seats._service import SeatService
+from office_cli.seats._store import AssignmentStore
+
+__all__ = [
+    "Assignment",
+    "AssignmentStore",
+    "AuditEntry",
+    "AuditLog",
+    "CsvStore",
+    "SeatService",
+    "build_service",
+]
+
+
+def build_service(data_dir: Path, *, actor: str = "cli") -> SeatService:
+    """Wire up a :class:`SeatService` from a data directory.
+
+    Reads ``data/offices.yaml``, parses each declared floor SVG, and points
+    the service at the canonical CSV files under ``seats/``.
+    """
+    offices = load_offices(data_dir)
+    floor_svgs: dict[str, FloorSvg] = {}
+    for office in offices.values():
+        for floor_id, floor in office.floors.items():
+            if floor.svg.is_file():
+                floor_svgs[floor_id] = parse_svg(floor.svg)
+    store = CsvStore(assignments_csv(data_dir))
+    audit = AuditLog(audit_log_csv(data_dir))
+    return SeatService(
+        offices=offices,
+        floor_svgs=floor_svgs,
+        store=store,
+        audit=audit,
+        actor=actor,
+    )

--- a/office_cli/seats/_audit.py
+++ b/office_cli/seats/_audit.py
@@ -1,0 +1,81 @@
+"""Append-only CSV audit log for seat changes.
+
+Header::
+
+    timestamp,actor,action,seat_id,employee_email,old_employee_email,note
+
+History is never overwritten; "who used to sit at <seat>?" is just a
+chronological filter on this file.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Iterable
+
+from office_cli.seats._models import AuditEntry
+
+FIELDNAMES = [
+    "timestamp",
+    "actor",
+    "action",
+    "seat_id",
+    "employee_email",
+    "old_employee_email",
+    "note",
+]
+
+
+class AuditLog:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def _ensure_file(self) -> None:
+        if not self.path.exists():
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("w", encoding="utf-8", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
+                writer.writeheader()
+
+    def append(self, entry: AuditEntry) -> None:
+        self.append_many([entry])
+
+    def append_many(self, entries: Iterable[AuditEntry]) -> None:
+        self._ensure_file()
+        with self.path.open("a", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
+            for e in entries:
+                writer.writerow(
+                    {
+                        "timestamp": e.timestamp,
+                        "actor": e.actor,
+                        "action": e.action,
+                        "seat_id": e.seat_id,
+                        "employee_email": e.employee_email,
+                        "old_employee_email": e.old_employee_email,
+                        "note": e.note,
+                    }
+                )
+
+    def all(self) -> list[AuditEntry]:
+        if not self.path.exists():
+            return []
+        with self.path.open("r", encoding="utf-8", newline="") as f:
+            reader = csv.DictReader(f)
+            return [
+                AuditEntry(
+                    timestamp=row.get("timestamp", ""),
+                    actor=row.get("actor", ""),
+                    action=row.get("action", ""),
+                    seat_id=row.get("seat_id", ""),
+                    employee_email=row.get("employee_email", ""),
+                    old_employee_email=row.get("old_employee_email", ""),
+                    note=row.get("note", ""),
+                )
+                for row in reader
+                if row.get("seat_id")
+            ]
+
+    def for_seat(self, seat_id: str) -> list[AuditEntry]:
+        return [e for e in self.all() if e.seat_id == seat_id]

--- a/office_cli/seats/_csv_store.py
+++ b/office_cli/seats/_csv_store.py
@@ -1,0 +1,107 @@
+"""CSV-backed :class:`AssignmentStore`.
+
+File shape (header is required)::
+
+    seat_id,floor,employee_email,last_updated,hidden,notes,effective_from,effective_until
+
+Writes are read-modify-write of the whole file. That is fine for the
+hundreds-of-seats scale of v1; the Sheets and DynamoDB stores will
+replace this for production.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Iterable
+
+from office_cli.seats._models import Assignment
+
+FIELDNAMES = [
+    "seat_id",
+    "floor",
+    "employee_email",
+    "last_updated",
+    "hidden",
+    "notes",
+    "effective_from",
+    "effective_until",
+]
+
+
+class CsvStore:
+    """Whole-file read/write CSV store."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def _ensure_file(self) -> None:
+        if not self.path.exists():
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("w", encoding="utf-8", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
+                writer.writeheader()
+
+    def list(self) -> list[Assignment]:
+        if not self.path.exists():
+            return []
+        with self.path.open("r", encoding="utf-8", newline="") as f:
+            reader = csv.DictReader(f)
+            return [_row_to_assignment(row) for row in reader if row.get("seat_id")]
+
+    def get(self, seat_id: str) -> Assignment | None:
+        for a in self.list():
+            if a.seat_id == seat_id:
+                return a
+        return None
+
+    def by_email(self, email: str) -> Assignment | None:
+        if not email:
+            return None
+        for a in self.list():
+            if a.employee_email == email:
+                return a
+        return None
+
+    def upsert(self, assignment: Assignment) -> None:
+        self.upsert_many([assignment])
+
+    def upsert_many(self, assignments: Iterable[Assignment]) -> None:
+        self._ensure_file()
+        existing = {a.seat_id: a for a in self.list()}
+        for a in assignments:
+            existing[a.seat_id] = a
+        ordered = sorted(existing.values(), key=lambda a: (a.floor, a.seat_id))
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=FIELDNAMES)
+            writer.writeheader()
+            for a in ordered:
+                writer.writerow(_assignment_to_row(a))
+        tmp.replace(self.path)
+
+
+def _row_to_assignment(row: dict[str, str]) -> Assignment:
+    return Assignment(
+        seat_id=row["seat_id"].strip(),
+        floor=row.get("floor", "").strip(),
+        employee_email=row.get("employee_email", "").strip(),
+        last_updated=row.get("last_updated", "").strip(),
+        hidden=str(row.get("hidden", "")).strip().lower() in {"true", "1", "yes"},
+        notes=row.get("notes", "").strip(),
+        effective_from=row.get("effective_from", "").strip(),
+        effective_until=row.get("effective_until", "").strip(),
+    )
+
+
+def _assignment_to_row(a: Assignment) -> dict[str, str]:
+    return {
+        "seat_id": a.seat_id,
+        "floor": a.floor,
+        "employee_email": a.employee_email,
+        "last_updated": a.last_updated,
+        "hidden": "TRUE" if a.hidden else "FALSE",
+        "notes": a.notes,
+        "effective_from": a.effective_from,
+        "effective_until": a.effective_until,
+    }

--- a/office_cli/seats/_models.py
+++ b/office_cli/seats/_models.py
@@ -1,0 +1,59 @@
+"""Frozen models for assignments and audit entries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Assignment:
+    seat_id: str
+    floor: str
+    employee_email: str = ""
+    last_updated: str = ""
+    hidden: bool = False
+    notes: str = ""
+    effective_from: str = ""
+    effective_until: str = ""
+
+    @property
+    def is_vacant(self) -> bool:
+        return not self.employee_email
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "seat_id": self.seat_id,
+            "floor": self.floor,
+            "employee_email": self.employee_email or None,
+            "last_updated": self.last_updated,
+            "hidden": self.hidden,
+            "notes": self.notes,
+            "effective_from": self.effective_from or None,
+            "effective_until": self.effective_until or None,
+        }
+
+
+@dataclass(frozen=True)
+class AuditEntry:
+    timestamp: str
+    actor: str
+    action: str
+    seat_id: str
+    employee_email: str = ""
+    old_employee_email: str = ""
+    note: str = ""
+    extra: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        d: dict[str, object] = {
+            "timestamp": self.timestamp,
+            "actor": self.actor,
+            "action": self.action,
+            "seat_id": self.seat_id,
+            "employee_email": self.employee_email or None,
+            "old_employee_email": self.old_employee_email or None,
+            "note": self.note,
+        }
+        if self.extra:
+            d["extra"] = dict(self.extra)
+        return d

--- a/office_cli/seats/_service.py
+++ b/office_cli/seats/_service.py
@@ -54,7 +54,7 @@ class SeatService:
         for seat_id, floor_id in sorted(self._seat_to_floor.items()):
             if floor and floor_id != floor:
                 continue
-            if cluster and not seat_id.split("-")[1:2] == [cluster]:
+            if cluster and seat_id.split("-")[1:2] != [cluster]:
                 continue
             a = existing.get(
                 seat_id,
@@ -72,7 +72,7 @@ class SeatService:
 
     def history(self, seat_id: str) -> list[AuditEntry]:
         self._require_seat(seat_id)
-        return self.audit.for_seat(seat_id)
+        return sorted(self.audit.for_seat(seat_id), key=lambda e: e.timestamp)
 
     # -- Mutations -------------------------------------------------------
 

--- a/office_cli/seats/_service.py
+++ b/office_cli/seats/_service.py
@@ -1,0 +1,268 @@
+"""Business logic on top of the store + audit log.
+
+Invariants:
+
+* a seat must exist in some floor's SVG before it can be assigned;
+* an employee has at most one seat globally — re-assigning an email that
+  already holds a seat is rejected with a hint to use ``move``;
+* every mutation appends to the audit log.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+from office_cli.floors import FloorSvg
+from office_cli.offices import Office
+from office_cli.seats._audit import AuditLog
+from office_cli.seats._models import Assignment, AuditEntry
+from office_cli.seats._store import AssignmentStore
+
+
+class SeatService:
+    def __init__(
+        self,
+        offices: dict[str, Office],
+        floor_svgs: dict[str, FloorSvg],
+        store: AssignmentStore,
+        audit: AuditLog,
+        actor: str = "cli",
+        clock: "callable[[], str] | None" = None,  # type: ignore[name-defined]
+    ) -> None:
+        self.offices = offices
+        self.floor_svgs = floor_svgs
+        self.store = store
+        self.audit = audit
+        self.actor = actor
+        self._clock = clock or _utcnow_iso
+        self._seat_to_floor = _build_seat_index(offices, floor_svgs)
+
+    # -- Lookups ---------------------------------------------------------
+
+    def list_seats(
+        self,
+        *,
+        floor: str | None = None,
+        cluster: str | None = None,
+        only_vacant: bool = False,
+        only_occupied: bool = False,
+    ) -> list[Assignment]:
+        existing = {a.seat_id: a for a in self.store.list()}
+        out: list[Assignment] = []
+        for seat_id, floor_id in sorted(self._seat_to_floor.items()):
+            if floor and floor_id != floor:
+                continue
+            if cluster and not seat_id.split("-")[1:2] == [cluster]:
+                continue
+            a = existing.get(
+                seat_id,
+                Assignment(seat_id=seat_id, floor=floor_id),
+            )
+            if only_vacant and not a.is_vacant:
+                continue
+            if only_occupied and a.is_vacant:
+                continue
+            out.append(a)
+        return out
+
+    def whereis(self, email: str) -> Assignment | None:
+        return self.store.by_email(email)
+
+    def history(self, seat_id: str) -> list[AuditEntry]:
+        self._require_seat(seat_id)
+        return self.audit.for_seat(seat_id)
+
+    # -- Mutations -------------------------------------------------------
+
+    def assign(
+        self,
+        seat_id: str,
+        email: str,
+        *,
+        note: str = "",
+        hidden: bool = False,
+    ) -> Assignment:
+        floor_id = self._require_seat(seat_id)
+        if not email:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message="email is required",
+                remediation="pass a non-empty email address",
+            )
+        existing_for_email = self.store.by_email(email)
+        if existing_for_email and existing_for_email.seat_id != seat_id:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=(
+                    f"{email} is already assigned to {existing_for_email.seat_id}; "
+                    "an employee can hold at most one seat globally"
+                ),
+                remediation=f"to move them, run: office seats move {email} {seat_id}",
+            )
+        current = self.store.get(seat_id)
+        old_email = current.employee_email if current else ""
+        if current and not current.is_vacant and current.employee_email != email:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"seat {seat_id} is already assigned to {current.employee_email}",
+                remediation=f"unassign first: office seats unassign {seat_id}",
+            )
+        now = self._clock()
+        new = Assignment(
+            seat_id=seat_id,
+            floor=floor_id,
+            employee_email=email,
+            last_updated=now,
+            hidden=hidden,
+            notes=note or (current.notes if current else ""),
+            effective_from=now,
+            effective_until="",
+        )
+        self.store.upsert(new)
+        self.audit.append(
+            AuditEntry(
+                timestamp=now,
+                actor=self.actor,
+                action="assign",
+                seat_id=seat_id,
+                employee_email=email,
+                old_employee_email=old_email,
+                note=note,
+            )
+        )
+        return new
+
+    def unassign(self, seat_id: str, *, note: str = "") -> Assignment:
+        floor_id = self._require_seat(seat_id)
+        current = self.store.get(seat_id)
+        if not current or current.is_vacant:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"seat {seat_id} is already vacant",
+                remediation="nothing to do",
+            )
+        now = self._clock()
+        vacated = Assignment(
+            seat_id=seat_id,
+            floor=floor_id,
+            employee_email="",
+            last_updated=now,
+            hidden=False,
+            notes=current.notes,
+        )
+        self.store.upsert(vacated)
+        self.audit.append(
+            AuditEntry(
+                timestamp=now,
+                actor=self.actor,
+                action="unassign",
+                seat_id=seat_id,
+                employee_email="",
+                old_employee_email=current.employee_email,
+                note=note,
+            )
+        )
+        return vacated
+
+    def move(self, email: str, new_seat_id: str, *, note: str = "") -> Assignment:
+        new_floor = self._require_seat(new_seat_id)
+        current = self.store.by_email(email)
+        if current is None:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"{email} has no current seat",
+                remediation=f"use: office seats assign {new_seat_id} {email}",
+            )
+        if current.seat_id == new_seat_id:
+            return current
+        target = self.store.get(new_seat_id)
+        if target and not target.is_vacant:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"seat {new_seat_id} is occupied by {target.employee_email}",
+                remediation="unassign or swap; use a different target seat",
+            )
+        now = self._clock()
+        vacated = Assignment(
+            seat_id=current.seat_id,
+            floor=current.floor,
+            employee_email="",
+            last_updated=now,
+            hidden=False,
+            notes=current.notes,
+        )
+        moved = Assignment(
+            seat_id=new_seat_id,
+            floor=new_floor,
+            employee_email=email,
+            last_updated=now,
+            hidden=current.hidden,
+            notes=note or current.notes,
+            effective_from=now,
+        )
+        self.store.upsert_many([vacated, moved])
+        self.audit.append_many(
+            [
+                AuditEntry(
+                    timestamp=now,
+                    actor=self.actor,
+                    action="unassign",
+                    seat_id=current.seat_id,
+                    employee_email="",
+                    old_employee_email=email,
+                    note=f"move → {new_seat_id}",
+                ),
+                AuditEntry(
+                    timestamp=now,
+                    actor=self.actor,
+                    action="assign",
+                    seat_id=new_seat_id,
+                    employee_email=email,
+                    old_employee_email="",
+                    note=note or f"move from {current.seat_id}",
+                ),
+            ]
+        )
+        return moved
+
+    # -- Helpers ---------------------------------------------------------
+
+    def _require_seat(self, seat_id: str) -> str:
+        floor_id = self._seat_to_floor.get(seat_id)
+        if not floor_id:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"unknown seat: {seat_id}",
+                remediation="run: office seats list to see the known seat IDs",
+            )
+        return floor_id
+
+
+def _build_seat_index(
+    offices: Iterable[Office] | dict[str, Office],
+    floor_svgs: dict[str, FloorSvg],
+) -> dict[str, str]:
+    """Map every seat/room id → floor id by union over loaded SVGs."""
+    if isinstance(offices, dict):
+        office_iter = offices.values()
+    else:
+        office_iter = list(offices)
+    seat_to_floor: dict[str, str] = {}
+    for office in office_iter:
+        for floor_id, floor in office.floors.items():
+            svg = floor_svgs.get(floor_id)
+            if svg is None:
+                continue
+            for sid in (*svg.seat_ids, *svg.room_ids):
+                seat_to_floor.setdefault(sid, floor_id)
+            # Rooms declared in YAML even without an SVG entry should still
+            # be assignable.
+            for rid in floor.rooms:
+                seat_to_floor.setdefault(rid, floor_id)
+    return seat_to_floor
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/office_cli/seats/_store.py
+++ b/office_cli/seats/_store.py
@@ -1,0 +1,28 @@
+"""``AssignmentStore`` Protocol — the v1/v2 store boundary.
+
+The CSV implementation lives next door; v2 will add a Sheets-backed and a
+DynamoDB-backed implementation behind this same Protocol.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Protocol
+
+from office_cli.seats._models import Assignment
+
+
+class AssignmentStore(Protocol):
+    def list(self) -> list[Assignment]:
+        """Return every known assignment row (occupied or vacant)."""
+
+    def get(self, seat_id: str) -> Assignment | None:
+        """Return the row for a seat, or ``None`` if absent."""
+
+    def upsert(self, assignment: Assignment) -> None:
+        """Insert or replace the row for ``assignment.seat_id``."""
+
+    def upsert_many(self, assignments: Iterable[Assignment]) -> None:
+        """Atomic-ish bulk write: persist all rows in one operation."""
+
+    def by_email(self, email: str) -> Assignment | None:
+        """Return the (single) assignment for ``email`` or ``None``."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.0.1"
+version = "0.1.0"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"
@@ -13,7 +13,9 @@ classifiers = [
     "Topic :: Software Development",
     "Intended Audience :: Developers",
 ]
-dependencies = []
+dependencies = [
+    "PyYAML>=6.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/agentculture/office-agent"
@@ -64,7 +66,7 @@ target-version = ["py312"]
 
 [tool.bandit]
 exclude_dirs = ["tests"]
-skips = ["B101", "B404", "B603"]
+skips = ["B101", "B404", "B603", "B314", "B405"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/seats/assignments.example.csv
+++ b/seats/assignments.example.csv
@@ -1,0 +1,4 @@
+seat_id,floor,employee_email,last_updated,hidden,notes,effective_from,effective_until
+5-T-01,tlv-floor-5,alice@example.com,2026-04-30T10:00:00Z,FALSE,,2026-04-30T10:00:00Z,
+5-T-02,tlv-floor-5,,2026-04-25T08:00:00Z,FALSE,ergonomic chair,,
+5.18,tlv-floor-5,bob@example.com,2026-04-29T14:00:00Z,TRUE,exec seat,2026-04-29T14:00:00Z,

--- a/seats/audit-log.example.csv
+++ b/seats/audit-log.example.csv
@@ -1,0 +1,1 @@
+timestamp,actor,action,seat_id,employee_email,old_employee_email,note

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Shared pytest fixtures.
+
+The fixture data dir under ``tests/fixtures/`` provides a self-contained
+office topology. The ``data_dir`` fixture copies it (plus an empty
+``seats/`` directory) into a tmp path so write-mode tests don't pollute
+the repo.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def data_dir(tmp_path: Path) -> Path:
+    """Return a writable copy of the fixture office topology."""
+    target = tmp_path / "office-data"
+    shutil.copytree(FIXTURES, target)
+    (target / "seats").mkdir(exist_ok=True)
+    return target
+
+
+@pytest.fixture
+def fixtures_root() -> Path:
+    """Read-only path to ``tests/fixtures/``."""
+    return FIXTURES

--- a/tests/fixtures/data/offices.yaml
+++ b/tests/fixtures/data/offices.yaml
@@ -1,0 +1,11 @@
+offices:
+  - id: tlv
+    name: "Tel Aviv"
+    floors:
+      - id: tlv-floor-5
+        svg: floors/tlv-floor-5.svg
+        clusters:
+          T: { capacity: 6, type: open-space }
+          Z: { capacity: 2, type: phone-room }
+        rooms:
+          "5.18": { name: "Meeting Room 8P", type: meeting, capacity: 8 }

--- a/tests/fixtures/floors/tlv-floor-5-bad.svg
+++ b/tests/fixtures/floors/tlv-floor-5-bad.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <g id="seats">
+    <!-- bad floor segment (4 instead of 5) -->
+    <rect id="4-T-01" class="seat" x="0" y="0" width="10" height="10"/>
+    <!-- malformed seat id -->
+    <rect id="5-T-1" class="seat" x="10" y="0" width="10" height="10"/>
+    <!-- duplicate id -->
+    <rect id="5-T-02" class="seat" x="20" y="0" width="10" height="10"/>
+    <rect id="5-T-02" class="seat" x="30" y="0" width="10" height="10"/>
+    <!-- looks like a seat but missing class -->
+    <rect id="5-T-03" x="40" y="0" width="10" height="10"/>
+    <!-- unknown cluster -->
+    <rect id="5-Q-01" class="seat" x="50" y="0" width="10" height="10"/>
+  </g>
+  <g id="rooms">
+    <!-- bad room id format -->
+    <polygon id="room-five-eighteen" class="room" points="0,0 10,0 10,10 0,10"/>
+  </g>
+</svg>

--- a/tests/fixtures/floors/tlv-floor-5.svg
+++ b/tests/fixtures/floors/tlv-floor-5.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">
+  <g id="seats">
+    <rect id="5-T-01" class="seat" x="120" y="80"  width="40" height="60"/>
+    <rect id="5-T-02" class="seat" x="180" y="80"  width="40" height="60"/>
+    <rect id="5-T-03" class="seat" x="240" y="80"  width="40" height="60"/>
+    <rect id="5-T-04" class="seat" x="120" y="160" width="40" height="60"/>
+    <rect id="5-T-05" class="seat" x="180" y="160" width="40" height="60"/>
+    <rect id="5-T-06" class="seat" x="240" y="160" width="40" height="60"/>
+    <rect id="5-Z-01" class="seat" x="900" y="80"  width="60" height="80"/>
+    <rect id="5-Z-02" class="seat" x="980" y="80"  width="60" height="80"/>
+  </g>
+  <g id="rooms">
+    <polygon id="5.18" class="room"
+             points="1400,300 1700,300 1700,500 1400,500"/>
+  </g>
+</svg>

--- a/tests/test_cli_floors.py
+++ b/tests/test_cli_floors.py
@@ -1,0 +1,58 @@
+"""End-to-end tests for ``office floors`` commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli import main
+
+
+def test_floors_list_text(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["floors", "list", "--data-dir", str(data_dir)]) == 0
+    out = capsys.readouterr().out
+    assert "tlv-floor-5" in out
+
+
+def test_floors_list_json(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["floors", "list", "--json", "--data-dir", str(data_dir)]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["floors"]) == 1
+    floor = payload["floors"][0]
+    assert floor["floor"] == "tlv-floor-5"
+    assert floor["clusters"] == {"T": 6, "Z": 2}
+
+
+def test_floors_validate_good(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    svg = data_dir / "floors" / "tlv-floor-5.svg"
+    rc = main(["floors", "validate", str(svg), "--json", "--data-dir", str(data_dir)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["results"][0]["ok"] is True
+
+
+def test_floors_validate_bad(
+    data_dir: Path, fixtures_root: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    bad = data_dir / "floors" / "tlv-floor-5.svg"
+    bad.write_text(
+        (fixtures_root / "floors" / "tlv-floor-5-bad.svg").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    rc = main(["floors", "validate", str(bad), "--json", "--data-dir", str(data_dir)])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    result = payload["results"][0]
+    assert result["ok"] is False
+    assert result["errors"]
+
+
+def test_floors_validate_requires_target(
+    data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = main(["floors", "validate", "--data-dir", str(data_dir)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "pass an SVG path" in err or "--all" in err

--- a/tests/test_cli_floors.py
+++ b/tests/test_cli_floors.py
@@ -49,6 +49,28 @@ def test_floors_validate_bad(
     assert result["errors"]
 
 
+def test_floors_validate_relative_path_from_other_cwd(
+    data_dir: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Relative SVG path must resolve against --data-dir, not cwd. Qodo #6."""
+    other = data_dir.parent / "elsewhere"
+    other.mkdir()
+    monkeypatch.chdir(other)
+    rc = main(
+        [
+            "floors",
+            "validate",
+            "floors/tlv-floor-5.svg",
+            "--json",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["results"][0]["ok"] is True
+
+
 def test_floors_validate_requires_target(
     data_dir: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_cli_seats.py
+++ b/tests/test_cli_seats.py
@@ -1,0 +1,67 @@
+"""End-to-end tests for ``office seats`` commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli import main
+
+
+def _data(data_dir: Path) -> list[str]:
+    return ["--data-dir", str(data_dir)]
+
+
+def test_assign_then_list_json(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["seats", "assign", "5-T-01", "alice@example.com", *_data(data_dir)]) == 0
+    capsys.readouterr()
+    rc = main(["seats", "list", "--json", "--occupied", *_data(data_dir)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["seats"][0]["seat_id"] == "5-T-01"
+    assert payload["seats"][0]["employee_email"] == "alice@example.com"
+
+
+def test_double_assign_emits_error(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    main(["seats", "assign", "5-T-01", "alice@example.com", *_data(data_dir)])
+    capsys.readouterr()
+    rc = main(["seats", "assign", "5-T-02", "alice@example.com", *_data(data_dir)])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "already assigned" in captured.err
+    assert "hint:" in captured.err
+
+
+def test_move_atomic(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    main(["seats", "assign", "5-T-01", "alice@example.com", *_data(data_dir)])
+    capsys.readouterr()
+    rc = main(["seats", "move", "alice@example.com", "5-T-02", *_data(data_dir)])
+    assert rc == 0
+    capsys.readouterr()
+    rc = main(["seats", "history", "5-T-01", "--json", *_data(data_dir)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    actions = [e["action"] for e in payload["history"]]
+    assert actions == ["assign", "unassign"]
+
+
+def test_unassign(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    main(["seats", "assign", "5-T-01", "alice@example.com", *_data(data_dir)])
+    capsys.readouterr()
+    rc = main(["seats", "unassign", "5-T-01", *_data(data_dir)])
+    assert rc == 0
+
+
+def test_unknown_seat_user_error(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["seats", "assign", "9-Q-99", "alice@example.com", *_data(data_dir)])
+    assert rc == 1
+    assert "unknown seat" in capsys.readouterr().err
+
+
+def test_list_text_smoke(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["seats", "list", *_data(data_dir)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "5-T-01" in out

--- a/tests/test_cli_whereis.py
+++ b/tests/test_cli_whereis.py
@@ -1,0 +1,53 @@
+"""End-to-end tests for ``office whereis``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli import main
+
+
+def test_whereis_no_seat(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["whereis", "ghost@example.com", "--json", "--data-dir", str(data_dir)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["assignment"] is None
+
+
+def test_whereis_after_assign(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    main(
+        [
+            "seats",
+            "assign",
+            "5-T-01",
+            "alice@example.com",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    capsys.readouterr()
+    rc = main(["whereis", "alice@example.com", "--json", "--data-dir", str(data_dir)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["assignment"]["seat_id"] == "5-T-01"
+
+
+def test_whereis_text(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    main(
+        [
+            "seats",
+            "assign",
+            "5-T-01",
+            "alice@example.com",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    capsys.readouterr()
+    rc = main(["whereis", "alice@example.com", "--data-dir", str(data_dir)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "5-T-01" in out

--- a/tests/test_floors_ids.py
+++ b/tests/test_floors_ids.py
@@ -1,0 +1,43 @@
+"""Tests for the seat/room ID contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from office_cli.floors._ids import is_room_id, is_seat_id, parse_seat_id
+
+
+@pytest.mark.parametrize("sid", ["5-T-01", "5-T-99", "12-K-04", "1-Z-00"])
+def test_seat_id_happy(sid: str) -> None:
+    assert is_seat_id(sid)
+    parsed = parse_seat_id(sid)
+    assert str(parsed) == sid
+
+
+@pytest.mark.parametrize(
+    "sid",
+    [
+        "5-T-1",  # not zero-padded
+        "5-t-01",  # cluster must be uppercase
+        "5--T-01",  # extra dash
+        "T-5-01",  # floor must lead
+        "5-T-001",  # too long
+        "5.18",  # room id, not seat id
+        "5-T",  # missing num
+        "",
+    ],
+)
+def test_seat_id_rejects_malformed(sid: str) -> None:
+    assert not is_seat_id(sid)
+    with pytest.raises(ValueError):
+        parse_seat_id(sid)
+
+
+@pytest.mark.parametrize("rid", ["5.01", "5.18", "12.04"])
+def test_room_id_happy(rid: str) -> None:
+    assert is_room_id(rid)
+
+
+@pytest.mark.parametrize("rid", ["5", "5.", ".18", "5.18.0", "room-5"])
+def test_room_id_rejects_malformed(rid: str) -> None:
+    assert not is_room_id(rid)

--- a/tests/test_floors_svg.py
+++ b/tests/test_floors_svg.py
@@ -1,0 +1,41 @@
+"""Tests for SVG parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli._errors import OfficeError
+from office_cli.floors import parse_svg
+
+
+def test_parse_good_fixture(fixtures_root: Path) -> None:
+    svg = parse_svg(fixtures_root / "floors" / "tlv-floor-5.svg")
+    assert svg.view_box == "0 0 1920 1080"
+    assert len(svg.seat_ids) == 8
+    assert "5-T-01" in svg.seat_ids
+    assert svg.room_ids == ("5.18",)
+    assert svg.duplicate_ids == ()
+    assert svg.untagged_ids == ()
+
+
+def test_parse_bad_fixture_collects_duplicates(fixtures_root: Path) -> None:
+    svg = parse_svg(fixtures_root / "floors" / "tlv-floor-5-bad.svg")
+    assert "5-T-02" in svg.duplicate_ids
+    assert "5-T-03" in svg.untagged_ids  # missing class="seat"
+
+
+def test_parse_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(OfficeError) as exc:
+        parse_svg(tmp_path / "nope.svg")
+    assert exc.value.code == 1
+
+
+def test_parse_bad_xml_raises(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.svg"
+    bad.write_text("<svg><rect", encoding="utf-8")
+    with pytest.raises(OfficeError) as exc:
+        parse_svg(bad)
+    assert exc.value.code == 1
+    assert "well-formed" in exc.value.message

--- a/tests/test_floors_validate.py
+++ b/tests/test_floors_validate.py
@@ -1,0 +1,48 @@
+"""Tests for SVG-vs-YAML validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from office_cli.floors import Severity, parse_svg, validate_floor
+from office_cli.offices import load_offices
+
+
+def _floor(data_dir: Path):
+    return load_offices(data_dir)["tlv"].floors["tlv-floor-5"]
+
+
+def test_good_fixture_has_no_errors(data_dir: Path) -> None:
+    svg = parse_svg(data_dir / "floors" / "tlv-floor-5.svg")
+    issues = validate_floor(svg, _floor(data_dir))
+    assert [i for i in issues if i.severity is Severity.ERROR] == []
+
+
+def test_bad_fixture_reports_each_rule(data_dir: Path, fixtures_root: Path) -> None:
+    bad_path = fixtures_root / "floors" / "tlv-floor-5-bad.svg"
+    svg = parse_svg(bad_path)
+    issues = validate_floor(svg, _floor(data_dir))
+    rules = {i.rule for i in issues}
+    # Each of these rule violations is present in the bad fixture.
+    assert "view-box" in rules
+    assert "duplicate-id" in rules
+    assert "seat-floor-mismatch" in rules
+    assert "seat-id-format" in rules
+    assert "unknown-cluster" in rules
+    assert "missing-class" in rules
+    assert "room-id-format" in rules
+
+
+def test_warnings_do_not_block(data_dir: Path) -> None:
+    # Drop one seat from the SVG so the cluster-capacity check warns.
+    svg_path = data_dir / "floors" / "tlv-floor-5.svg"
+    text = svg_path.read_text(encoding="utf-8").replace(
+        '<rect id="5-T-06" class="seat" x="240" y="160" width="40" height="60"/>',
+        "",
+    )
+    svg_path.write_text(text, encoding="utf-8")
+    svg = parse_svg(svg_path)
+    issues = validate_floor(svg, _floor(data_dir))
+    severities = {i.severity for i in issues}
+    assert Severity.ERROR not in severities
+    assert Severity.WARNING in severities

--- a/tests/test_offices_yaml.py
+++ b/tests/test_offices_yaml.py
@@ -1,0 +1,45 @@
+"""Tests for offices.yaml loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli._errors import OfficeError
+from office_cli.offices import load_offices
+
+
+def test_loads_fixture(data_dir: Path) -> None:
+    offices = load_offices(data_dir)
+    assert set(offices) == {"tlv"}
+    floor = offices["tlv"].floors["tlv-floor-5"]
+    assert floor.number == "5"
+    assert set(floor.clusters) == {"T", "Z"}
+    assert floor.clusters["T"].capacity == 6
+    assert "5.18" in floor.rooms
+
+
+def test_missing_yaml_raises(tmp_path: Path) -> None:
+    with pytest.raises(OfficeError) as exc:
+        load_offices(tmp_path)
+    assert exc.value.code == 2
+
+
+def test_malformed_yaml_raises(tmp_path: Path) -> None:
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "offices.yaml").write_text("offices: [\n", encoding="utf-8")
+    with pytest.raises(OfficeError) as exc:
+        load_offices(tmp_path)
+    assert exc.value.code == 1
+
+
+def test_missing_office_id_rejected(tmp_path: Path) -> None:
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "offices.yaml").write_text(
+        "offices:\n  - name: anonymous\n", encoding="utf-8"
+    )
+    with pytest.raises(OfficeError) as exc:
+        load_offices(tmp_path)
+    assert exc.value.code == 1
+    assert "id" in exc.value.message

--- a/tests/test_offices_yaml.py
+++ b/tests/test_offices_yaml.py
@@ -34,6 +34,27 @@ def test_malformed_yaml_raises(tmp_path: Path) -> None:
     assert exc.value.code == 1
 
 
+def test_duplicate_floor_id_rejected(tmp_path: Path) -> None:
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "offices.yaml").write_text(
+        """
+offices:
+  - id: tlv
+    name: Tel Aviv
+    floors:
+      - id: tlv-floor-5
+        clusters: { T: { capacity: 1 } }
+      - id: tlv-floor-5
+        clusters: { K: { capacity: 1 } }
+""".lstrip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(OfficeError) as exc:
+        load_offices(tmp_path)
+    assert exc.value.code == 1
+    assert "duplicate floor id" in exc.value.message
+
+
 def test_missing_office_id_rejected(tmp_path: Path) -> None:
     (tmp_path / "data").mkdir()
     (tmp_path / "data" / "offices.yaml").write_text(

--- a/tests/test_seats_csv_store.py
+++ b/tests/test_seats_csv_store.py
@@ -1,0 +1,48 @@
+"""Tests for the CSV-backed assignment store."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from office_cli.seats import Assignment, CsvStore
+
+
+def test_round_trip(tmp_path: Path) -> None:
+    store = CsvStore(tmp_path / "assignments.csv")
+    assert store.list() == []
+    a = Assignment(
+        seat_id="5-T-01",
+        floor="tlv-floor-5",
+        employee_email="alice@example.com",
+        last_updated="2026-05-01T00:00:00Z",
+        hidden=True,
+        notes="ergonomic",
+    )
+    store.upsert(a)
+    again = CsvStore(tmp_path / "assignments.csv")
+    rows = again.list()
+    assert len(rows) == 1
+    assert rows[0].seat_id == "5-T-01"
+    assert rows[0].employee_email == "alice@example.com"
+    assert rows[0].hidden is True
+
+
+def test_upsert_replaces(tmp_path: Path) -> None:
+    store = CsvStore(tmp_path / "assignments.csv")
+    store.upsert(Assignment(seat_id="5-T-01", floor="tlv-floor-5", employee_email="a@x"))
+    store.upsert(Assignment(seat_id="5-T-01", floor="tlv-floor-5", employee_email="b@x"))
+    assert store.get("5-T-01").employee_email == "b@x"
+    assert len(store.list()) == 1
+
+
+def test_by_email(tmp_path: Path) -> None:
+    store = CsvStore(tmp_path / "assignments.csv")
+    store.upsert_many(
+        [
+            Assignment(seat_id="5-T-01", floor="tlv-floor-5", employee_email="a@x"),
+            Assignment(seat_id="5-T-02", floor="tlv-floor-5", employee_email="b@x"),
+        ]
+    )
+    assert store.by_email("a@x").seat_id == "5-T-01"
+    assert store.by_email("nobody@x") is None
+    assert store.by_email("") is None

--- a/tests/test_seats_service.py
+++ b/tests/test_seats_service.py
@@ -1,0 +1,119 @@
+"""Tests for the SeatService business logic."""
+
+from __future__ import annotations
+
+from itertools import count
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli._errors import OfficeError
+from office_cli.seats import build_service
+
+
+def _service(data_dir: Path):
+    """Build a service whose clock is deterministic."""
+    counter = count(1)
+
+    def clock() -> str:
+        return f"2026-05-01T00:00:{next(counter):02d}Z"
+
+    service = build_service(data_dir)
+    service._clock = clock  # noqa: SLF001 - test injection
+    return service
+
+
+def test_assign_writes_audit(data_dir: Path) -> None:
+    s = _service(data_dir)
+    a = s.assign("5-T-01", "alice@example.com", note="welcome")
+    assert a.employee_email == "alice@example.com"
+    assert a.floor == "tlv-floor-5"
+    history = s.history("5-T-01")
+    assert [e.action for e in history] == ["assign"]
+    assert history[0].employee_email == "alice@example.com"
+
+
+def test_double_assignment_rejected(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com")
+    with pytest.raises(OfficeError) as exc:
+        s.assign("5-T-02", "alice@example.com")
+    assert exc.value.code == 1
+    assert "already assigned" in exc.value.message
+
+
+def test_assign_to_occupied_seat_rejected(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com")
+    with pytest.raises(OfficeError):
+        s.assign("5-T-01", "bob@example.com")
+
+
+def test_unknown_seat_rejected(data_dir: Path) -> None:
+    s = _service(data_dir)
+    with pytest.raises(OfficeError) as exc:
+        s.assign("9-Q-99", "alice@example.com")
+    assert "unknown seat" in exc.value.message
+
+
+def test_unassign_then_reassign(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com")
+    s.unassign("5-T-01")
+    assert s.whereis("alice@example.com") is None
+    s.assign("5-T-01", "bob@example.com")
+    assert s.whereis("bob@example.com").seat_id == "5-T-01"
+
+
+def test_unassign_vacant_rejected(data_dir: Path) -> None:
+    s = _service(data_dir)
+    with pytest.raises(OfficeError) as exc:
+        s.unassign("5-T-01")
+    assert "vacant" in exc.value.message
+
+
+def test_move_atomic(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com")
+    moved = s.move("alice@example.com", "5-T-02")
+    assert moved.seat_id == "5-T-02"
+    assert s.whereis("alice@example.com").seat_id == "5-T-02"
+    # 5-T-01 is now vacant; history shows both transitions.
+    h1 = s.history("5-T-01")
+    h2 = s.history("5-T-02")
+    assert [e.action for e in h1] == ["assign", "unassign"]
+    assert [e.action for e in h2] == ["assign"]
+
+
+def test_move_to_occupied_rejected(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com")
+    s.assign("5-T-02", "bob@example.com")
+    with pytest.raises(OfficeError):
+        s.move("alice@example.com", "5-T-02")
+
+
+def test_move_unknown_email_rejected(data_dir: Path) -> None:
+    s = _service(data_dir)
+    with pytest.raises(OfficeError) as exc:
+        s.move("ghost@example.com", "5-T-01")
+    assert "no current seat" in exc.value.message
+
+
+def test_list_filters(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com")
+    rows = s.list_seats()
+    assert len(rows) == 9  # 8 seats + 1 room from the fixture SVG
+    occupied = s.list_seats(only_occupied=True)
+    assert [a.seat_id for a in occupied] == ["5-T-01"]
+    vacant = s.list_seats(only_vacant=True)
+    assert "5-T-01" not in {a.seat_id for a in vacant}
+    cluster_t = s.list_seats(cluster="T")
+    assert all(a.seat_id.split("-")[1] == "T" for a in cluster_t)
+
+
+def test_room_assignable(data_dir: Path) -> None:
+    s = _service(data_dir)
+    a = s.assign("5.18", "exec@example.com")
+    assert a.seat_id == "5.18"

--- a/tests/test_seats_service.py
+++ b/tests/test_seats_service.py
@@ -113,6 +113,34 @@ def test_list_filters(data_dir: Path) -> None:
     assert all(a.seat_id.split("-")[1] == "T" for a in cluster_t)
 
 
+def test_history_sorted_by_timestamp(data_dir: Path) -> None:
+    """Qodo #5: history must be chronological even if the audit log is reordered."""
+    s = build_service(data_dir)
+    # Synthesize out-of-order audit entries directly.
+    from office_cli.seats._models import AuditEntry
+
+    s.audit.append_many(
+        [
+            AuditEntry(
+                timestamp="2026-05-01T00:00:02Z",
+                actor="t",
+                action="assign",
+                seat_id="5-T-01",
+                employee_email="b@x",
+            ),
+            AuditEntry(
+                timestamp="2026-05-01T00:00:01Z",
+                actor="t",
+                action="assign",
+                seat_id="5-T-01",
+                employee_email="a@x",
+            ),
+        ]
+    )
+    history = s.history("5-T-01")
+    assert [e.timestamp for e in history] == sorted(e.timestamp for e in history)
+
+
 def test_room_assignable(data_dir: Path) -> None:
     s = _service(data_dir)
     a = s.assign("5.18", "exec@example.com")

--- a/uv.lock
+++ b/uv.lock
@@ -236,8 +236,11 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -251,6 +254,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "pyyaml", specifier = ">=6.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Lands Stage 1 of the v1 floor-plan seating system per
[issue #1](https://github.com/agentculture/office-agent/issues/1). This is the
data + CLI core; Google Sheets, BambooHR, Slack `/whereis`, and the web map
are explicit follow-ups, scoped in `docs/architecture.md`.

- **Domain layer** — `office_cli.offices`, `floors`, `seats`, `people`. Frozen
  dataclasses for `Office`/`Floor`/`Cluster`/`Room`/`Assignment`/`AuditEntry`/
  `Employee`; `load_offices()` parses `data/offices.yaml`.
- **SVG parser + validator** — `parse_svg()` reads `<rect>` / `<polygon>` with
  `id` and `class`; `validate_floor()` returns typed `Issue` records covering
  view-box, ID format (`SEAT_RE`/`ROOM_RE`), cluster mapping, duplicate IDs,
  untagged-but-shaped IDs, and cluster-capacity warnings.
- **Assignment store + audit** — `AssignmentStore` Protocol with a
  `CsvStore` implementation behind it; append-only `AuditLog`. `SeatService`
  enforces "seat must exist", "one seat per email globally", and writes audit
  entries on every mutation.
- **CLI** — `office floors list|validate`, `office seats list|assign|
  unassign|move|history`, `office whereis EMAIL`. Every verb honors
  `--json` and the shared `--data-dir` (overridable via `OFFICE_DATA_DIR`).
- **Sample data + fixtures** — `data/offices.yaml` (one office, one floor),
  `floors/tlv-floor-5.svg` placeholder (real trace lands separately), and
  `seats/*.example.csv` schema examples. Test fixtures under `tests/fixtures/`.
- **Version** bumped `0.0.1` → `0.1.0`; `PyYAML>=6.0` added as the only
  new runtime dep.

## Test plan

- [x] `uv run pytest -n auto -v` — 71 tests pass (ID contract, SVG parser,
  validator, CSV store, SeatService invariants, all CLI verbs in text + JSON
  modes).
- [x] `uv run black --check office_cli tests` — clean.
- [x] `uv run isort --check-only office_cli tests` — clean.
- [x] `uv run flake8 office_cli tests` — clean.
- [x] `uv run bandit -c pyproject.toml -r office_cli` — clean (B314/B405
  skipped per upstream stdlib XML hardening).
- [x] `markdownlint-cli2 "**/*.md"` — clean.
- [x] `steward doctor . --scope self` — clean.
- [x] `uv build` — wheel + sdist produced.
- [x] End-to-end smoke against a temp data dir: `assign` → reject double-
  assign → `move` → `whereis` → `seats history` (two audit entries).

## Out of scope (deferred to follow-up PRs)

`SheetsStore`, `BambooHRDirectory`, Slack `/whereis` Bolt app, web frontend,
SSO + role gating, `effective_from`/`effective_until` enforcement, DynamoDB
store. Each is enumerated in `docs/architecture.md`.

- Claude

Generated with Claude Code