### PR TITLE
feat: v1 seating Stage 2 — Sheets-backed AssignmentStore (#1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-01
+
+### Added
+
+- v1 seating Stage 2 — Google Sheets-backed `AssignmentStore` and append-only
+  `AuditLog`. Selectable via `data/offices.yaml` (`storage.type: sheets`) or
+  the `OFFICE_STORE` / `OFFICE_SHEETS_ID` / `OFFICE_SHEETS_SA` env vars.
+- New optional extra: `pip install office-cli[sheets]` pulls `gspread>=6.0`.
+  CSV users do not pay for the dep tree.
+- `office_cli.seats.sheets` package: `SheetsStore`, `SheetsAuditLog`, and a
+  thin `SheetsClient` shim so unit tests use a `FakeSheetsClient` without
+  real credentials. Reads honor a 5-minute TTL cache; writes invalidate it.
+- `build_service(data_dir)` picks the assignment-store / audit-log pair from
+  the resolved storage config; the CSV path remains the default.
+
+### Changed
+
+- `office_cli.seats.__init__` re-exports the Sheets backends behind a
+  guarded import so the package still loads cleanly without `gspread`.
+
 ## [0.1.0] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `office_cli.seats.__init__` re-exports the Sheets backends behind a
   guarded import so the package still loads cleanly without `gspread`.
+- `office_cli.seats.AuditLog` is now a `Protocol` (mirroring the
+  `AssignmentStore` shape from Stage 1). The CSV concrete class is
+  `office_cli.seats.CsvAuditLog`. `AuditLog` is still re-exported, so
+  type-checked downstream callers see the Protocol; runtime callers
+  that constructed `AuditLog(path)` need to switch to `CsvAuditLog(path)`.
 
 ## [0.1.0] - 2026-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,3 +74,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CLAUDE.md` updated to cover the post-bootstrap conventions while
   preserving the SVG ID contract and architectural guardrails for the v1
   seating system (issue #1).
+
+[Unreleased]: https://github.com/agentculture/office-agent/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/agentculture/office-agent/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/agentculture/office-agent/compare/v0.0.1...v0.1.0
+[0.0.1]: https://github.com/agentculture/office-agent/releases/tag/v0.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ office-agent/
 │   ├── _config.py               # resolve_data_dir() / --data-dir / OFFICE_DATA_DIR
 │   ├── offices/                 # offices.yaml loader + Office/Floor/Cluster/Room
 │   ├── floors/                  # SVG parse + ID contract + validator
-│   ├── seats/                   # AssignmentStore + CsvStore + AuditLog + SeatService
+│   ├── seats/                   # AssignmentStore + Csv/Sheets stores + AuditLog + SeatService
 │   ├── people/                  # Employee + EmployeeDirectory (StubDirectory in v0.1.0)
 │   └── explain/                 # Markdown catalog for `office explain <path>`
 ├── data/offices.yaml            # office / floor / cluster topology
@@ -58,7 +58,7 @@ office-agent/
 ```bash
 uv sync                           # install runtime + dev deps
 uv run pytest -n auto -v          # full suite, parallel
-uv run office --version           # 0.1.0
+uv run office --version           # 0.2.0
 uv run office learn               # agent affordance
 uv run office whoami              # auth probe stub
 uv run office floors validate floors/tlv-floor-5.svg

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ BambooHR; assignments live in a Google Sheet (v1) or DynamoDB (v2). The
 CLI exposes the same operations as the Slack `/whereis` command and the
 web map.
 
-> **Status — v0.1.0.** Stage 1 of the v1 seating system is in: floor
-> SVG parser/validator, CSV-backed assignment store with append-only
-> audit log, and CLI verbs (`floors`, `seats`, `whereis`). Google
-> Sheets, BambooHR, Slack `/whereis`, and the web map land in later
-> stages on top of the same `office_cli.seats` service. See
-> [issue #1](https://github.com/agentculture/office-agent/issues/1).
+> **Status — v0.2.0.** Stages 1 + 2 of the v1 seating system are in:
+> floor SVG parser/validator, CSV- *and* Google Sheets-backed
+> assignment store with append-only audit log, CLI verbs (`floors`,
+> `seats`, `whereis`). BambooHR, Slack `/whereis`, and the web map
+> land in later stages on top of the same `office_cli.seats` service.
+> See [issue #1](https://github.com/agentculture/office-agent/issues/1).
 
 ## Naming surfaces
 
@@ -53,6 +53,32 @@ office whereis alice@example.com
 `office` reads `data/offices.yaml`, `floors/`, and `seats/` from the
 current working directory. Override with `--data-dir DIR` or
 `OFFICE_DATA_DIR=DIR`.
+
+### Storage backend
+
+`office` defaults to CSV-backed storage under `seats/` (`assignments.csv`,
+`audit-log.csv`). To use Google Sheets instead:
+
+```bash
+pip install office-cli[sheets]
+export OFFICE_STORE=sheets
+export OFFICE_SHEETS_ID=1abc...
+export OFFICE_SHEETS_SA=/path/to/service-account.json
+```
+
+…or declare it in `data/offices.yaml`:
+
+```yaml
+storage:
+  type: sheets
+  sheets:
+    spreadsheet_id: "1abc..."
+    service_account: "data/sheets-service-account.json"
+    cache_ttl_seconds: 300
+```
+
+Reads honor a 5-minute TTL cache; writes invalidate it. See
+`docs/architecture.md` for the full storage contract.
 
 ## Adding a new floor
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture — v0.1.0 (Stage 1)
+# Architecture — v0.2.0 (Stage 1 + Stage 2)
 
 `office` ships in stages on top of issue
 [#1](https://github.com/agentculture/office-agent/issues/1). This document
@@ -50,13 +50,56 @@ boundary stays explicit.
 - Test fixtures + parametric tests on the ID contract, SVG parser,
   validator, store, service, and each CLI verb (text and JSON).
 
+## Stage 2 — implemented in v0.2.0
+
+- `office_cli.seats.sheets.SheetsStore` and `SheetsAuditLog` implement the
+  same `AssignmentStore` / append-only audit contracts as the CSV pair.
+- A thin `SheetsClient` Protocol (`read_rows`, `replace_rows`,
+  `append_rows`) lives between the store and `gspread`, so unit tests
+  use a `FakeSheetsClient` and never need real credentials.
+- `GspreadClient` is the production adapter; gspread is imported lazily,
+  so installations without the `[sheets]` extra still load
+  `office_cli.seats` cleanly.
+- 5-minute read cache (per-store, per-process); writes invalidate it.
+- Storage selection (`office_cli._config.resolve_storage`):
+
+  1. `storage:` block in `data/offices.yaml`,
+  2. `OFFICE_STORE` / `OFFICE_SHEETS_ID` / `OFFICE_SHEETS_SA` env vars,
+  3. CSV by default.
+
+Install the extra to use Sheets:
+
+```bash
+pip install office-cli[sheets]
+```
+
+Configure either via `data/offices.yaml`:
+
+```yaml
+storage:
+  type: sheets
+  sheets:
+    spreadsheet_id: "1abc..."
+    service_account: "data/sheets-service-account.json"
+    cache_ttl_seconds: 300
+```
+
+…or via env vars (which override the YAML block):
+
+```bash
+export OFFICE_STORE=sheets
+export OFFICE_SHEETS_ID=1abc...
+export OFFICE_SHEETS_SA=/abs/or/data-dir-relative/sa.json
+```
+
+The service-account JSON should be **git-ignored**.
+
 ## Deferred surfaces
 
-Each is a separate issue/PR after Stage 1 ships.
+Each is a separate issue/PR.
 
 | Stage              | Surface                                       | Notes                                                                   |
 | ------------------ | --------------------------------------------- | ----------------------------------------------------------------------- |
-| 2. Sheets store    | `office_cli.seats.SheetsStore`                | Same Protocol; service-account auth; 5-min read cache.                  |
 | 3. BambooHR        | `office_cli.people.BambooHRDirectory`         | Live pull, 5-min cache; auto-vacate on offboarding (the killer feature). |
 | 4. Slack `/whereis`| `office_slack/` Bolt app                      | Imports `SeatService.whereis`; renders Block Kit with deep link.        |
 | 5. Web frontend    | `office_web/` (Vite + a small Python server)  | Search-first map, `?asOf=YYYY-MM-DD`, role-aware `hidden` rendering.    |

--- a/office_cli/_config.py
+++ b/office_cli/_config.py
@@ -78,7 +78,9 @@ def resolve_storage(data_dir: Path) -> StorageConfig:
     operators get a clear hint instead of an opaque gspread error.
     """
     yaml_cfg = _read_storage_block(data_dir)
-    store_type = (os.environ.get("OFFICE_STORE") or yaml_cfg.get("type") or "csv").strip().lower()
+    store_type = (
+        (os.environ.get("OFFICE_STORE") or _str_field(yaml_cfg, "type") or "csv").strip().lower()
+    )
 
     if store_type == "csv":
         return StorageConfig(type="csv")
@@ -90,11 +92,19 @@ def resolve_storage(data_dir: Path) -> StorageConfig:
             remediation="set storage.type to 'csv' or 'sheets' in offices.yaml or OFFICE_STORE",
         )
 
-    sheets_cfg = yaml_cfg.get("sheets") or {}
+    sheets_cfg = yaml_cfg.get("sheets")
+    if sheets_cfg is None:
+        sheets_cfg = {}
+    if not isinstance(sheets_cfg, dict):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="storage.sheets must be a mapping in offices.yaml",
+            remediation="see docs/architecture.md for the expected shape",
+        )
     spreadsheet_id = (
-        os.environ.get("OFFICE_SHEETS_ID") or sheets_cfg.get("spreadsheet_id") or ""
+        os.environ.get("OFFICE_SHEETS_ID") or _str_field(sheets_cfg, "spreadsheet_id") or ""
     ).strip()
-    sa_field = os.environ.get("OFFICE_SHEETS_SA") or sheets_cfg.get("service_account")
+    sa_field = os.environ.get("OFFICE_SHEETS_SA") or _str_field(sheets_cfg, "service_account")
     if not spreadsheet_id:
         raise OfficeError(
             code=EXIT_ENV_ERROR,
@@ -110,13 +120,56 @@ def resolve_storage(data_dir: Path) -> StorageConfig:
     sa_path = Path(sa_field).expanduser()
     if not sa_path.is_absolute():
         sa_path = (data_dir / sa_path).resolve()
-    ttl = int(sheets_cfg.get("cache_ttl_seconds", 300))
+    ttl = _int_field(sheets_cfg, "cache_ttl_seconds", 300)
     return StorageConfig(
         type="sheets",
         spreadsheet_id=spreadsheet_id,
         service_account=sa_path,
         cache_ttl_seconds=ttl,
     )
+
+
+def _str_field(d: dict, key: str) -> str:
+    """Read ``d[key]`` as a string. ``None`` → empty; non-string → coerced.
+
+    Returns "" for missing keys. Raises :class:`OfficeError` only if the
+    value is structurally wrong (a list/dict where a scalar is expected).
+    """
+    value = d.get(key)
+    if value is None:
+        return ""
+    if isinstance(value, (dict, list)):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"storage.{key} must be a scalar, got {type(value).__name__}",
+            remediation="see docs/architecture.md for the expected shape",
+        )
+    return str(value)
+
+
+def _int_field(d: dict, key: str, default: int) -> int:
+    value = d.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"storage.{key} must be an integer, got {type(value).__name__}",
+            remediation=f"set storage.{key} to a non-negative integer (seconds)",
+        )
+    try:
+        ttl = int(value)
+    except ValueError as err:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"storage.{key} must be an integer; got {value!r}",
+            remediation=f"set storage.{key} to a non-negative integer (seconds)",
+        ) from err
+    if ttl < 0:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"storage.{key} must be non-negative; got {ttl}",
+            remediation=f"set storage.{key} to a non-negative integer (seconds)",
+        )
+    return ttl
 
 
 def _read_storage_block(data_dir: Path) -> dict:

--- a/office_cli/_config.py
+++ b/office_cli/_config.py
@@ -1,19 +1,29 @@
-"""Resolve where the office data (offices.yaml, floors/, seats/) lives.
+"""Resolve where the office data (offices.yaml, floors/, seats/) lives,
+plus the storage backend (CSV vs Sheets) the seat service should use.
 
-Resolution order:
+Data-dir resolution order:
 
 1. ``--data-dir`` CLI flag (passed through ``args.data_dir``);
 2. ``OFFICE_DATA_DIR`` environment variable;
 3. the current working directory.
+
+Storage selection order (last wins):
+
+1. ``storage:`` block in ``data/offices.yaml`` (``type: csv`` | ``sheets``);
+2. ``OFFICE_STORE`` env var (``csv`` | ``sheets``);
+3. CLI overrides via ``OFFICE_SHEETS_ID`` / ``OFFICE_SHEETS_SA``.
 """
 
 from __future__ import annotations
 
 import argparse
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
-from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
+import yaml
+
+from office_cli.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, OfficeError
 
 
 def resolve_data_dir(args: argparse.Namespace | None = None) -> Path:
@@ -48,3 +58,80 @@ def assignments_csv(data_dir: Path) -> Path:
 
 def audit_log_csv(data_dir: Path) -> Path:
     return data_dir / "seats" / "audit-log.csv"
+
+
+@dataclass(frozen=True)
+class StorageConfig:
+    """Resolved storage backend for the seat service."""
+
+    type: str  # "csv" | "sheets"
+    spreadsheet_id: str = ""
+    service_account: Path | None = None
+    cache_ttl_seconds: int = 300
+
+
+def resolve_storage(data_dir: Path) -> StorageConfig:
+    """Pick the storage backend from offices.yaml + env overrides.
+
+    Defaults to ``csv``. Sheets requires both a spreadsheet id and a
+    service-account JSON path; we error early if either is missing so
+    operators get a clear hint instead of an opaque gspread error.
+    """
+    yaml_cfg = _read_storage_block(data_dir)
+    store_type = (os.environ.get("OFFICE_STORE") or yaml_cfg.get("type") or "csv").strip().lower()
+
+    if store_type == "csv":
+        return StorageConfig(type="csv")
+
+    if store_type != "sheets":
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"unknown storage type: {store_type!r}",
+            remediation="set storage.type to 'csv' or 'sheets' in offices.yaml or OFFICE_STORE",
+        )
+
+    sheets_cfg = yaml_cfg.get("sheets") or {}
+    spreadsheet_id = (
+        os.environ.get("OFFICE_SHEETS_ID") or sheets_cfg.get("spreadsheet_id") or ""
+    ).strip()
+    sa_field = os.environ.get("OFFICE_SHEETS_SA") or sheets_cfg.get("service_account")
+    if not spreadsheet_id:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message="storage.type=sheets requires a spreadsheet id",
+            remediation="set OFFICE_SHEETS_ID or storage.sheets.spreadsheet_id",
+        )
+    if not sa_field:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message="storage.type=sheets requires a service-account JSON",
+            remediation="set OFFICE_SHEETS_SA or storage.sheets.service_account",
+        )
+    sa_path = Path(sa_field).expanduser()
+    if not sa_path.is_absolute():
+        sa_path = (data_dir / sa_path).resolve()
+    ttl = int(sheets_cfg.get("cache_ttl_seconds", 300))
+    return StorageConfig(
+        type="sheets",
+        spreadsheet_id=spreadsheet_id,
+        service_account=sa_path,
+        cache_ttl_seconds=ttl,
+    )
+
+
+def _read_storage_block(data_dir: Path) -> dict:
+    """Return the ``storage:`` mapping from offices.yaml, or empty dict."""
+    yaml_path = data_dir / "data" / "offices.yaml"
+    if not yaml_path.is_file():
+        return {}
+    with yaml_path.open("r", encoding="utf-8") as f:
+        try:
+            raw = yaml.safe_load(f) or {}
+        except yaml.YAMLError:
+            # offices.py raises on malformed YAML; here we just decline to
+            # apply storage config and let the rest of the loader complain.
+            return {}
+    storage = raw.get("storage") or {}
+    if not isinstance(storage, dict):
+        return {}
+    return storage

--- a/office_cli/seats/__init__.py
+++ b/office_cli/seats/__init__.py
@@ -1,10 +1,25 @@
-"""Seat assignment store + audit log + business-logic service."""
+"""Seat assignment store + audit log + business-logic service.
+
+Public surface: the :class:`Assignment` / :class:`AuditEntry` models, the
+:class:`AssignmentStore` Protocol, the CSV-backed implementation
+(:class:`CsvStore` + :class:`AuditLog`), the business-logic service
+(:class:`SeatService`), and the :func:`build_service` factory.
+
+The Sheets-backed implementations live under
+:mod:`office_cli.seats.sheets` and are imported lazily so installations
+without the ``[sheets]`` extra still work.
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from office_cli._config import assignments_csv, audit_log_csv
+from office_cli._config import (
+    StorageConfig,
+    assignments_csv,
+    audit_log_csv,
+    resolve_storage,
+)
 from office_cli.floors import FloorSvg, parse_svg
 from office_cli.offices import load_offices
 from office_cli.seats._audit import AuditEntry, AuditLog
@@ -27,8 +42,9 @@ __all__ = [
 def build_service(data_dir: Path, *, actor: str = "cli") -> SeatService:
     """Wire up a :class:`SeatService` from a data directory.
 
-    Reads ``data/offices.yaml``, parses each declared floor SVG, and points
-    the service at the canonical CSV files under ``seats/``.
+    Reads ``data/offices.yaml``, parses each declared floor SVG, and picks
+    the assignment store + audit log per the resolved
+    :class:`StorageConfig` (CSV by default, Sheets when configured).
     """
     offices = load_offices(data_dir)
     floor_svgs: dict[str, FloorSvg] = {}
@@ -36,12 +52,30 @@ def build_service(data_dir: Path, *, actor: str = "cli") -> SeatService:
         for floor_id, floor in office.floors.items():
             if floor.svg.is_file():
                 floor_svgs[floor_id] = parse_svg(floor.svg)
-    store = CsvStore(assignments_csv(data_dir))
-    audit = AuditLog(audit_log_csv(data_dir))
+    store, audit = _build_backends(data_dir, resolve_storage(data_dir))
     return SeatService(
         offices=offices,
         floor_svgs=floor_svgs,
         store=store,
         audit=audit,
         actor=actor,
+    )
+
+
+def _build_backends(data_dir: Path, cfg: StorageConfig):
+    if cfg.type == "csv":
+        return (
+            CsvStore(assignments_csv(data_dir)),
+            AuditLog(audit_log_csv(data_dir)),
+        )
+    # Lazy import — gspread (and therefore the sheets shim) is optional.
+    from office_cli.seats.sheets import GspreadClient, SheetsAuditLog, SheetsStore
+
+    client = GspreadClient(
+        spreadsheet_id=cfg.spreadsheet_id,
+        service_account_path=cfg.service_account,  # type: ignore[arg-type]
+    )
+    return (
+        SheetsStore(client, cache_ttl_seconds=cfg.cache_ttl_seconds),
+        SheetsAuditLog(client),
     )

--- a/office_cli/seats/__init__.py
+++ b/office_cli/seats/__init__.py
@@ -22,9 +22,9 @@ from office_cli._config import (
 )
 from office_cli.floors import FloorSvg, parse_svg
 from office_cli.offices import load_offices
-from office_cli.seats._audit import AuditEntry, AuditLog
+from office_cli.seats._audit import AuditLog, CsvAuditLog
 from office_cli.seats._csv_store import CsvStore
-from office_cli.seats._models import Assignment
+from office_cli.seats._models import Assignment, AuditEntry
 from office_cli.seats._service import SeatService
 from office_cli.seats._store import AssignmentStore
 
@@ -33,6 +33,7 @@ __all__ = [
     "AssignmentStore",
     "AuditEntry",
     "AuditLog",
+    "CsvAuditLog",
     "CsvStore",
     "SeatService",
     "build_service",
@@ -66,7 +67,7 @@ def _build_backends(data_dir: Path, cfg: StorageConfig):
     if cfg.type == "csv":
         return (
             CsvStore(assignments_csv(data_dir)),
-            AuditLog(audit_log_csv(data_dir)),
+            CsvAuditLog(audit_log_csv(data_dir)),
         )
     # Lazy import — gspread (and therefore the sheets shim) is optional.
     from office_cli.seats.sheets import GspreadClient, SheetsAuditLog, SheetsStore

--- a/office_cli/seats/_audit.py
+++ b/office_cli/seats/_audit.py
@@ -1,18 +1,26 @@
-"""Append-only CSV audit log for seat changes.
+"""Append-only audit log for seat changes.
 
 Header::
 
     timestamp,actor,action,seat_id,employee_email,old_employee_email,note
 
 History is never overwritten; "who used to sit at <seat>?" is just a
-chronological filter on this file.
+chronological filter on this log.
+
+Two implementations live in the codebase:
+
+* :class:`CsvAuditLog` (here) — append-only CSV file, default for v1.
+* :class:`office_cli.seats.sheets.SheetsAuditLog` — Sheets-backed.
+
+Both implement the :class:`AuditLog` Protocol, which is what
+:class:`office_cli.seats.SeatService` is typed against.
 """
 
 from __future__ import annotations
 
 import csv
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Protocol
 
 from office_cli.seats._models import AuditEntry
 
@@ -27,7 +35,25 @@ FIELDNAMES = [
 ]
 
 
-class AuditLog:
+class AuditLog(Protocol):
+    """Structural type every audit-log backend must satisfy."""
+
+    def append(self, entry: AuditEntry) -> None:
+        """Append a single entry."""
+
+    def append_many(self, entries: Iterable[AuditEntry]) -> None:
+        """Append multiple entries (atomic-ish per backend)."""
+
+    def all(self) -> list[AuditEntry]:
+        """Return every entry in insertion order."""
+
+    def for_seat(self, seat_id: str) -> list[AuditEntry]:
+        """Return every entry for ``seat_id``."""
+
+
+class CsvAuditLog:
+    """Append-only CSV implementation of :class:`AuditLog`."""
+
     def __init__(self, path: Path) -> None:
         self.path = path
 

--- a/office_cli/seats/sheets/__init__.py
+++ b/office_cli/seats/sheets/__init__.py
@@ -1,0 +1,15 @@
+"""Google Sheets backends for :class:`AssignmentStore` and :class:`AuditLog`.
+
+Imports of this subpackage do not import ``gspread`` at module-load time;
+the ``GspreadClient`` adapter performs a lazy import only when constructed.
+That way, environments without the ``sheets`` extra installed can still
+import :mod:`office_cli.seats` and use the default CSV path.
+"""
+
+from __future__ import annotations
+
+from office_cli.seats.sheets._audit import SheetsAuditLog
+from office_cli.seats.sheets._client import GspreadClient, SheetsClient
+from office_cli.seats.sheets._store import SheetsStore
+
+__all__ = ["GspreadClient", "SheetsAuditLog", "SheetsClient", "SheetsStore"]

--- a/office_cli/seats/sheets/_audit.py
+++ b/office_cli/seats/sheets/_audit.py
@@ -1,0 +1,76 @@
+"""Sheets-backed append-only audit log."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from office_cli.seats._audit import FIELDNAMES
+from office_cli.seats._models import AuditEntry
+from office_cli.seats.sheets._client import SheetsClient
+
+_AUDIT_TAB = "audit-log"
+
+
+class SheetsAuditLog:
+    def __init__(self, client: SheetsClient, *, worksheet: str = _AUDIT_TAB) -> None:
+        self._client = client
+        self._worksheet = worksheet
+
+    def append(self, entry: AuditEntry) -> None:
+        self.append_many([entry])
+
+    def append_many(self, entries: Iterable[AuditEntry]) -> None:
+        rows = [_entry_to_row(e) for e in entries]
+        if not rows:
+            return
+        existing = self._client.read_rows(self._worksheet)
+        if not existing:
+            self._client.replace_rows(self._worksheet, [list(FIELDNAMES), *rows])
+        else:
+            self._client.append_rows(self._worksheet, rows)
+
+    def all(self) -> list[AuditEntry]:
+        rows = self._client.read_rows(self._worksheet)
+        if not rows:
+            return []
+        header, *body = rows
+        idx = {name: i for i, name in enumerate(header)}
+        out: list[AuditEntry] = []
+        for row in body:
+            if not row or not _cell(row, idx, "seat_id"):
+                continue
+            out.append(
+                AuditEntry(
+                    timestamp=_cell(row, idx, "timestamp"),
+                    actor=_cell(row, idx, "actor"),
+                    action=_cell(row, idx, "action"),
+                    seat_id=_cell(row, idx, "seat_id"),
+                    employee_email=_cell(row, idx, "employee_email"),
+                    old_employee_email=_cell(row, idx, "old_employee_email"),
+                    note=_cell(row, idx, "note"),
+                )
+            )
+        return out
+
+    def for_seat(self, seat_id: str) -> list[AuditEntry]:
+        return [e for e in self.all() if e.seat_id == seat_id]
+
+
+def _cell(row: list[str], idx: dict[str, int], name: str) -> str:
+    pos = idx.get(name)
+    if pos is None or pos >= len(row):
+        return ""
+    return (row[pos] or "").strip()
+
+
+def _entry_to_row(e: AuditEntry) -> list[str]:
+    values = {
+        "timestamp": e.timestamp,
+        "actor": e.actor,
+        "action": e.action,
+        "seat_id": e.seat_id,
+        "employee_email": e.employee_email,
+        "old_employee_email": e.old_employee_email,
+        "note": e.note,
+    }
+    return [values[name] for name in FIELDNAMES]

--- a/office_cli/seats/sheets/_client.py
+++ b/office_cli/seats/sheets/_client.py
@@ -60,10 +60,12 @@ class GspreadClient:
         return self._spreadsheet
 
     def _worksheet(self, name: str):
+        import gspread
+
         sh = self._open()
         try:
             return sh.worksheet(name)
-        except Exception:  # gspread.WorksheetNotFound or transport
+        except gspread.exceptions.WorksheetNotFound:
             return sh.add_worksheet(title=name, rows=1, cols=10)
 
     def read_rows(self, worksheet: str) -> list[list[str]]:

--- a/office_cli/seats/sheets/_client.py
+++ b/office_cli/seats/sheets/_client.py
@@ -1,0 +1,92 @@
+"""Thin shim over the Google Sheets API.
+
+The :class:`SheetsClient` Protocol exposes only the three operations the
+store and audit log need (read / replace / append). The store is unit-
+tested against a ``FakeSheetsClient`` so the test suite never needs real
+credentials. :class:`GspreadClient` is the production implementation —
+import is deferred to construction so the parent package can be imported
+without the ``[sheets]`` extra installed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
+
+
+class SheetsClient(Protocol):
+    def read_rows(self, worksheet: str) -> list[list[str]]:
+        """Return every cell value in ``worksheet`` as ``[[row], [row], ...]``."""
+
+    def replace_rows(self, worksheet: str, rows: list[list[str]]) -> None:
+        """Atomically replace the contents of ``worksheet`` with ``rows``."""
+
+    def append_rows(self, worksheet: str, rows: list[list[str]]) -> None:
+        """Append ``rows`` to the bottom of ``worksheet``."""
+
+
+class GspreadClient:
+    """Production :class:`SheetsClient` implementation backed by ``gspread``."""
+
+    def __init__(self, spreadsheet_id: str, service_account_path: Path) -> None:
+        try:
+            import gspread  # noqa: F401 — runtime check
+        except ImportError as err:
+            raise OfficeError(
+                code=EXIT_ENV_ERROR,
+                message="gspread is not installed",
+                remediation="install the sheets extra: pip install office-cli[sheets]",
+            ) from err
+        if not service_account_path.is_file():
+            raise OfficeError(
+                code=EXIT_ENV_ERROR,
+                message=f"service-account JSON not found: {service_account_path}",
+                remediation=(
+                    "point OFFICE_SHEETS_SA / storage.sheets.service_account at a real file"
+                ),
+            )
+        self._spreadsheet_id = spreadsheet_id
+        self._service_account_path = service_account_path
+        self._spreadsheet = None
+
+    def _open(self):
+        if self._spreadsheet is None:
+            import gspread
+
+            gc = gspread.service_account(filename=str(self._service_account_path))
+            self._spreadsheet = gc.open_by_key(self._spreadsheet_id)
+        return self._spreadsheet
+
+    def _worksheet(self, name: str):
+        sh = self._open()
+        try:
+            return sh.worksheet(name)
+        except Exception:  # gspread.WorksheetNotFound or transport
+            return sh.add_worksheet(title=name, rows=1, cols=10)
+
+    def read_rows(self, worksheet: str) -> list[list[str]]:
+        ws = self._worksheet(worksheet)
+        return ws.get_all_values()
+
+    def replace_rows(self, worksheet: str, rows: list[list[str]]) -> None:
+        ws = self._worksheet(worksheet)
+        ws.clear()
+        if rows:
+            ws.update(values=rows, range_name=f"A1:{_col_letter(len(rows[0]))}{len(rows)}")
+
+    def append_rows(self, worksheet: str, rows: list[list[str]]) -> None:
+        if not rows:
+            return
+        ws = self._worksheet(worksheet)
+        ws.append_rows(rows, value_input_option="USER_ENTERED")
+
+
+def _col_letter(n: int) -> str:
+    """1 → A, 26 → Z, 27 → AA. Used for range bounds."""
+    out = ""
+    while n > 0:
+        n, rem = divmod(n - 1, 26)
+        out = chr(ord("A") + rem) + out
+    return out

--- a/office_cli/seats/sheets/_client.py
+++ b/office_cli/seats/sheets/_client.py
@@ -21,7 +21,14 @@ class SheetsClient(Protocol):
         """Return every cell value in ``worksheet`` as ``[[row], [row], ...]``."""
 
     def replace_rows(self, worksheet: str, rows: list[list[str]]) -> None:
-        """Atomically replace the contents of ``worksheet`` with ``rows``."""
+        """Replace the contents of ``worksheet`` with ``rows``.
+
+        The :class:`GspreadClient` adapter does this in two requests
+        (``clear`` + ``update``), so it is **not atomic** — a transport
+        failure between the two leaves the worksheet empty. Callers that
+        care should either retry on failure or build a higher-level
+        recovery (e.g. a backup tab).
+        """
 
     def append_rows(self, worksheet: str, rows: list[list[str]]) -> None:
         """Append ``rows`` to the bottom of ``worksheet``."""

--- a/office_cli/seats/sheets/_store.py
+++ b/office_cli/seats/sheets/_store.py
@@ -1,0 +1,123 @@
+"""Sheets-backed :class:`AssignmentStore`.
+
+Worksheet shape mirrors :mod:`office_cli.seats._csv_store`: header row
+followed by one row per assignment. The cache TTL defaults to 5 minutes
+per the v1 architecture decision (see ``docs/architecture.md``).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Iterable
+
+from office_cli.seats._csv_store import FIELDNAMES
+from office_cli.seats._models import Assignment
+from office_cli.seats.sheets._client import SheetsClient
+
+_DEFAULT_TTL_SECONDS = 300
+_ASSIGNMENTS_TAB = "assignments"
+
+
+class SheetsStore:
+    def __init__(
+        self,
+        client: SheetsClient,
+        *,
+        worksheet: str = _ASSIGNMENTS_TAB,
+        cache_ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+        clock: "callable[[], float] | None" = None,  # type: ignore[name-defined]
+    ) -> None:
+        self._client = client
+        self._worksheet = worksheet
+        self._ttl = cache_ttl_seconds
+        self._clock = clock or time.monotonic
+        self._cache: list[Assignment] | None = None
+        self._cache_at: float = 0.0
+
+    # -- AssignmentStore -------------------------------------------------
+
+    def list(self) -> list[Assignment]:
+        if self._cache is not None and (self._clock() - self._cache_at) < self._ttl:
+            return list(self._cache)
+        rows = self._client.read_rows(self._worksheet)
+        self._cache = _rows_to_assignments(rows)
+        self._cache_at = self._clock()
+        return list(self._cache)
+
+    def get(self, seat_id: str) -> Assignment | None:
+        for a in self.list():
+            if a.seat_id == seat_id:
+                return a
+        return None
+
+    def by_email(self, email: str) -> Assignment | None:
+        if not email:
+            return None
+        for a in self.list():
+            if a.employee_email == email:
+                return a
+        return None
+
+    def upsert(self, assignment: Assignment) -> None:
+        self.upsert_many([assignment])
+
+    def upsert_many(self, assignments: Iterable[Assignment]) -> None:
+        existing = {a.seat_id: a for a in self.list()}
+        for a in assignments:
+            existing[a.seat_id] = a
+        ordered = sorted(existing.values(), key=lambda a: (a.floor, a.seat_id))
+        rows = [list(FIELDNAMES)] + [_assignment_to_row(a) for a in ordered]
+        self._client.replace_rows(self._worksheet, rows)
+        self._cache = ordered
+        self._cache_at = self._clock()
+
+    # -- Helpers ---------------------------------------------------------
+
+    def invalidate(self) -> None:
+        self._cache = None
+        self._cache_at = 0.0
+
+
+def _rows_to_assignments(rows: list[list[str]]) -> list[Assignment]:
+    if not rows:
+        return []
+    header, *body = rows
+    idx = {name: i for i, name in enumerate(header)}
+    out: list[Assignment] = []
+    for row in body:
+        if not row or not _cell(row, idx, "seat_id"):
+            continue
+        out.append(
+            Assignment(
+                seat_id=_cell(row, idx, "seat_id"),
+                floor=_cell(row, idx, "floor"),
+                employee_email=_cell(row, idx, "employee_email"),
+                last_updated=_cell(row, idx, "last_updated"),
+                hidden=_cell(row, idx, "hidden").strip().lower() in {"true", "1", "yes"},
+                notes=_cell(row, idx, "notes"),
+                effective_from=_cell(row, idx, "effective_from"),
+                effective_until=_cell(row, idx, "effective_until"),
+            )
+        )
+    return out
+
+
+def _cell(row: list[str], idx: dict[str, int], name: str) -> str:
+    pos = idx.get(name)
+    if pos is None or pos >= len(row):
+        return ""
+    return (row[pos] or "").strip()
+
+
+def _assignment_to_row(a: Assignment) -> list[str]:
+    values = {
+        "seat_id": a.seat_id,
+        "floor": a.floor,
+        "employee_email": a.employee_email,
+        "last_updated": a.last_updated,
+        "hidden": "TRUE" if a.hidden else "FALSE",
+        "notes": a.notes,
+        "effective_from": a.effective_from,
+        "effective_until": a.effective_until,
+    }
+    return [values[name] for name in FIELDNAMES]

--- a/office_cli/seats/sheets/_store.py
+++ b/office_cli/seats/sheets/_store.py
@@ -62,6 +62,9 @@ class SheetsStore:
         self.upsert_many([assignment])
 
     def upsert_many(self, assignments: Iterable[Assignment]) -> None:
+        # Force a fresh read so we don't merge against a TTL-stale snapshot
+        # and clobber rows another writer added during the cache window.
+        self.invalidate()
         existing = {a.seat_id: a for a in self.list()}
         for a in assignments:
             existing[a.seat_id] = a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"
@@ -16,6 +16,9 @@ classifiers = [
 dependencies = [
     "PyYAML>=6.0",
 ]
+
+[project.optional-dependencies]
+sheets = ["gspread>=6.0"]
 
 [project.urls]
 Homepage = "https://github.com/agentculture/office-agent"

--- a/tests/test_seats_service_sheets.py
+++ b/tests/test_seats_service_sheets.py
@@ -1,0 +1,58 @@
+"""End-to-end SeatService test against the Sheets backends.
+
+Exercises the same invariants as ``test_seats_service`` (assign / move /
+double-assignment / history) but with ``SheetsStore`` + ``SheetsAuditLog``
+behind a ``FakeSheetsClient``. Proves the service is genuinely store-
+agnostic.
+"""
+
+from __future__ import annotations
+
+from itertools import count
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli._errors import OfficeError
+from office_cli.floors import parse_svg
+from office_cli.offices import load_offices
+from office_cli.seats import SeatService
+from office_cli.seats.sheets import SheetsAuditLog, SheetsStore
+from tests.test_sheets_store import FakeSheetsClient
+
+
+def _service(data_dir: Path) -> SeatService:
+    offices = load_offices(data_dir)
+    floor_svgs = {}
+    for office in offices.values():
+        for floor_id, floor in office.floors.items():
+            if floor.svg.is_file():
+                floor_svgs[floor_id] = parse_svg(floor.svg)
+    client = FakeSheetsClient()
+    counter = count(1)
+
+    def clock() -> str:
+        return f"2026-05-01T00:00:{next(counter):02d}Z"
+
+    return SeatService(
+        offices=offices,
+        floor_svgs=floor_svgs,
+        store=SheetsStore(client, cache_ttl_seconds=0),
+        audit=SheetsAuditLog(client),
+        actor="cli",
+        clock=clock,
+    )
+
+
+def test_full_flow_against_sheets(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com")
+    with pytest.raises(OfficeError):
+        s.assign("5-T-02", "alice@example.com")  # one-seat-per-email rule
+    moved = s.move("alice@example.com", "5-T-02")
+    assert moved.seat_id == "5-T-02"
+    history_old = s.history("5-T-01")
+    history_new = s.history("5-T-02")
+    assert [e.action for e in history_old] == ["assign", "unassign"]
+    assert [e.action for e in history_new] == ["assign"]
+    assert s.whereis("alice@example.com").seat_id == "5-T-02"

--- a/tests/test_sheets_store.py
+++ b/tests/test_sheets_store.py
@@ -1,0 +1,175 @@
+"""Tests for the Sheets-backed AssignmentStore + AuditLog.
+
+A ``FakeSheetsClient`` plays the role of gspread; no real creds are
+needed. Cache-TTL behavior is exercised with an injected clock.
+"""
+
+from __future__ import annotations
+
+from itertools import count
+
+import pytest
+
+from office_cli.seats import Assignment, AuditEntry
+from office_cli.seats.sheets import SheetsAuditLog, SheetsStore
+
+
+class FakeSheetsClient:
+    def __init__(self) -> None:
+        self.tabs: dict[str, list[list[str]]] = {}
+        self.read_calls = 0
+
+    def read_rows(self, worksheet: str) -> list[list[str]]:
+        self.read_calls += 1
+        return [list(r) for r in self.tabs.get(worksheet, [])]
+
+    def replace_rows(self, worksheet: str, rows: list[list[str]]) -> None:
+        self.tabs[worksheet] = [list(r) for r in rows]
+
+    def append_rows(self, worksheet: str, rows: list[list[str]]) -> None:
+        self.tabs.setdefault(worksheet, []).extend(list(r) for r in rows)
+
+
+def test_round_trip() -> None:
+    client = FakeSheetsClient()
+    store = SheetsStore(client, cache_ttl_seconds=0)
+    a = Assignment(
+        seat_id="5-T-01",
+        floor="tlv-floor-5",
+        employee_email="alice@example.com",
+        last_updated="2026-05-01T00:00:01Z",
+        hidden=True,
+        notes="ergonomic",
+    )
+    store.upsert(a)
+    rows = store.list()
+    assert len(rows) == 1
+    assert rows[0].seat_id == "5-T-01"
+    assert rows[0].employee_email == "alice@example.com"
+    assert rows[0].hidden is True
+
+
+def test_list_uses_cache_within_ttl() -> None:
+    client = FakeSheetsClient()
+    counter = count()
+
+    def clock() -> float:
+        # First call seeds, subsequent calls advance by 1s each invocation.
+        return next(counter) * 1.0
+
+    store = SheetsStore(client, cache_ttl_seconds=10, clock=clock)
+    store.list()  # cache miss
+    store.list()  # cache hit
+    store.list()  # cache hit
+    assert client.read_calls == 1
+
+
+def test_list_refreshes_after_ttl() -> None:
+    client = FakeSheetsClient()
+    now = [0.0]
+
+    def clock() -> float:
+        return now[0]
+
+    store = SheetsStore(client, cache_ttl_seconds=10, clock=clock)
+    store.list()
+    now[0] = 5.0
+    store.list()  # still inside TTL
+    now[0] = 100.0
+    store.list()  # outside TTL
+    assert client.read_calls == 2
+
+
+def test_upsert_invalidates_via_replace() -> None:
+    client = FakeSheetsClient()
+    store = SheetsStore(client, cache_ttl_seconds=99999)
+    store.upsert(Assignment(seat_id="5-T-01", floor="tlv-floor-5", employee_email="a@x"))
+    store.upsert(Assignment(seat_id="5-T-01", floor="tlv-floor-5", employee_email="b@x"))
+    rows = store.list()
+    assert rows[0].employee_email == "b@x"
+
+
+def test_by_email() -> None:
+    client = FakeSheetsClient()
+    store = SheetsStore(client, cache_ttl_seconds=0)
+    store.upsert_many(
+        [
+            Assignment(seat_id="5-T-01", floor="tlv-floor-5", employee_email="a@x"),
+            Assignment(seat_id="5-T-02", floor="tlv-floor-5", employee_email="b@x"),
+        ]
+    )
+    assert store.by_email("a@x").seat_id == "5-T-01"
+    assert store.by_email("nobody@x") is None
+    assert store.by_email("") is None
+
+
+def test_audit_append_seeds_header_then_appends() -> None:
+    client = FakeSheetsClient()
+    audit = SheetsAuditLog(client)
+    audit.append(
+        AuditEntry(
+            timestamp="2026-05-01T00:00:01Z",
+            actor="t",
+            action="assign",
+            seat_id="5-T-01",
+            employee_email="alice@x",
+        )
+    )
+    audit.append(
+        AuditEntry(
+            timestamp="2026-05-01T00:00:02Z",
+            actor="t",
+            action="unassign",
+            seat_id="5-T-01",
+            old_employee_email="alice@x",
+        )
+    )
+    rows = audit.all()
+    assert [r.action for r in rows] == ["assign", "unassign"]
+
+
+def test_audit_for_seat_filters() -> None:
+    client = FakeSheetsClient()
+    audit = SheetsAuditLog(client)
+    audit.append_many(
+        [
+            AuditEntry(
+                timestamp="t1",
+                actor="t",
+                action="assign",
+                seat_id="5-T-01",
+                employee_email="a@x",
+            ),
+            AuditEntry(
+                timestamp="t2",
+                actor="t",
+                action="assign",
+                seat_id="5-T-02",
+                employee_email="b@x",
+            ),
+        ]
+    )
+    history = audit.for_seat("5-T-01")
+    assert len(history) == 1
+    assert history[0].employee_email == "a@x"
+
+
+def test_gspread_missing_raises_clear_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If gspread isn't installed, GspreadClient must surface OfficeError."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def block_gspread(name, *args, **kwargs):
+        if name == "gspread":
+            raise ImportError("blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", block_gspread)
+
+    from office_cli.cli._errors import OfficeError
+    from office_cli.seats.sheets import GspreadClient
+
+    with pytest.raises(OfficeError) as exc:
+        GspreadClient(spreadsheet_id="x", service_account_path=None)  # type: ignore[arg-type]
+    assert "gspread is not installed" in exc.value.message

--- a/tests/test_sheets_store.py
+++ b/tests/test_sheets_store.py
@@ -103,6 +103,26 @@ def test_by_email() -> None:
     assert store.by_email("") is None
 
 
+def test_upsert_many_bypasses_cache_to_avoid_clobber() -> None:
+    """Qodo #4: a stale TTL snapshot must not erase concurrent writes.
+
+    Simulate: process A reads, gets a cache. Process B writes a new seat
+    directly to the sheet. Process A then upserts a different seat. The
+    new seat from B must survive A's write.
+    """
+    client = FakeSheetsClient()
+    store_a = SheetsStore(client, cache_ttl_seconds=99999)
+    store_a.upsert(Assignment(seat_id="5-T-01", floor="tlv-floor-5", employee_email="a@x"))
+    # Prime A's cache.
+    _ = store_a.list()
+    # B writes directly to the sheet (concurrent process).
+    client.tabs["assignments"].append(["5-T-99", "tlv-floor-5", "b@x", "", "FALSE", "", "", ""])
+    # A upserts a different seat. Must merge against fresh state, not cache.
+    store_a.upsert(Assignment(seat_id="5-T-02", floor="tlv-floor-5", employee_email="c@x"))
+    surviving = {a.seat_id for a in store_a.list()}
+    assert {"5-T-01", "5-T-02", "5-T-99"} <= surviving
+
+
 def test_audit_append_seeds_header_then_appends() -> None:
     client = FakeSheetsClient()
     audit = SheetsAuditLog(client)

--- a/tests/test_storage_config.py
+++ b/tests/test_storage_config.py
@@ -1,0 +1,97 @@
+"""Tests for the storage selector in office_cli._config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from office_cli._config import resolve_storage
+from office_cli.cli._errors import OfficeError
+
+
+def _write(data_dir: Path, body: str) -> None:
+    (data_dir / "data").mkdir(parents=True, exist_ok=True)
+    (data_dir / "data" / "offices.yaml").write_text(body, encoding="utf-8")
+
+
+def test_default_is_csv(tmp_path: Path) -> None:
+    cfg = resolve_storage(tmp_path)
+    assert cfg.type == "csv"
+
+
+def test_yaml_block_csv(tmp_path: Path) -> None:
+    _write(tmp_path, "storage:\n  type: csv\n")
+    cfg = resolve_storage(tmp_path)
+    assert cfg.type == "csv"
+
+
+def test_yaml_block_sheets(tmp_path: Path) -> None:
+    sa = tmp_path / "sa.json"
+    sa.write_text("{}", encoding="utf-8")
+    _write(
+        tmp_path,
+        f"""
+storage:
+  type: sheets
+  sheets:
+    spreadsheet_id: SPREAD123
+    service_account: {sa}
+    cache_ttl_seconds: 60
+""".lstrip(),
+    )
+    cfg = resolve_storage(tmp_path)
+    assert cfg.type == "sheets"
+    assert cfg.spreadsheet_id == "SPREAD123"
+    assert cfg.service_account == sa
+    assert cfg.cache_ttl_seconds == 60
+
+
+def test_env_overrides_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sa = tmp_path / "sa.json"
+    sa.write_text("{}", encoding="utf-8")
+    _write(tmp_path, "storage:\n  type: csv\n")
+    monkeypatch.setenv("OFFICE_STORE", "sheets")
+    monkeypatch.setenv("OFFICE_SHEETS_ID", "FROM_ENV")
+    monkeypatch.setenv("OFFICE_SHEETS_SA", str(sa))
+    cfg = resolve_storage(tmp_path)
+    assert cfg.type == "sheets"
+    assert cfg.spreadsheet_id == "FROM_ENV"
+
+
+def test_sheets_requires_spreadsheet_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_STORE", "sheets")
+    monkeypatch.delenv("OFFICE_SHEETS_ID", raising=False)
+    monkeypatch.delenv("OFFICE_SHEETS_SA", raising=False)
+    with pytest.raises(OfficeError) as exc:
+        resolve_storage(tmp_path)
+    assert "spreadsheet id" in exc.value.message
+
+
+def test_sheets_requires_service_account(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_STORE", "sheets")
+    monkeypatch.setenv("OFFICE_SHEETS_ID", "X")
+    monkeypatch.delenv("OFFICE_SHEETS_SA", raising=False)
+    with pytest.raises(OfficeError) as exc:
+        resolve_storage(tmp_path)
+    assert "service-account" in exc.value.message
+
+
+def test_unknown_store_type_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_STORE", "dynamo")
+    with pytest.raises(OfficeError) as exc:
+        resolve_storage(tmp_path)
+    assert "unknown storage type" in exc.value.message
+
+
+def test_relative_service_account_resolves_to_data_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sa = tmp_path / "creds" / "sa.json"
+    sa.parent.mkdir()
+    sa.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("OFFICE_STORE", "sheets")
+    monkeypatch.setenv("OFFICE_SHEETS_ID", "X")
+    monkeypatch.setenv("OFFICE_SHEETS_SA", "creds/sa.json")
+    cfg = resolve_storage(tmp_path)
+    assert cfg.service_account == sa.resolve()

--- a/tests/test_storage_config.py
+++ b/tests/test_storage_config.py
@@ -84,6 +84,61 @@ def test_unknown_store_type_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert "unknown storage type" in exc.value.message
 
 
+def test_non_string_type_coerced(tmp_path: Path) -> None:
+    """Copilot #1: yaml `type: 1` should not crash with AttributeError."""
+    _write(tmp_path, "storage:\n  type: 1\n")
+    with pytest.raises(OfficeError) as exc:
+        resolve_storage(tmp_path)
+    assert "unknown storage type" in exc.value.message
+
+
+def test_non_dict_sheets_block_rejected(tmp_path: Path) -> None:
+    """Copilot #2: yaml `sheets: somestring` should surface a clear error."""
+    _write(tmp_path, "storage:\n  type: sheets\n  sheets: nope\n")
+    with pytest.raises(OfficeError) as exc:
+        resolve_storage(tmp_path)
+    assert "must be a mapping" in exc.value.message
+
+
+def test_non_int_ttl_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Copilot #3: cache_ttl_seconds must coerce cleanly or raise OfficeError."""
+    sa = tmp_path / "sa.json"
+    sa.write_text("{}", encoding="utf-8")
+    _write(
+        tmp_path,
+        f"""
+storage:
+  type: sheets
+  sheets:
+    spreadsheet_id: X
+    service_account: {sa}
+    cache_ttl_seconds: not-a-number
+""".lstrip(),
+    )
+    with pytest.raises(OfficeError) as exc:
+        resolve_storage(tmp_path)
+    assert "must be an integer" in exc.value.message
+
+
+def test_negative_ttl_rejected(tmp_path: Path) -> None:
+    sa = tmp_path / "sa.json"
+    sa.write_text("{}", encoding="utf-8")
+    _write(
+        tmp_path,
+        f"""
+storage:
+  type: sheets
+  sheets:
+    spreadsheet_id: X
+    service_account: {sa}
+    cache_ttl_seconds: -1
+""".lstrip(),
+    )
+    with pytest.raises(OfficeError) as exc:
+        resolve_storage(tmp_path)
+    assert "non-negative" in exc.value.message
+
+
 def test_relative_service_account_resolves_to_data_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -50,6 +50,145 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -155,6 +294,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "47.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/14/88/7aa18ad9c11bc87689affa5ce4368d884b517502d75739d475fc6f4a03c7/cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0", size = 7904299, upload-time = "2026-04-24T19:53:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/07/55/c18f75724544872f234678fdedc871391722cb34a2aee19faa9f63100bb2/cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7", size = 4631180, upload-time = "2026-04-24T19:53:37.517Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/65/31a5cc0eaca99cec5bafffe155d407115d96136bb161e8b49e0ef73f09a7/cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1", size = 4653529, upload-time = "2026-04-24T19:53:39.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bc/641c0519a495f3bfd0421b48d7cd325c4336578523ccd76ea322b6c29c7a/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c", size = 4638570, upload-time = "2026-04-24T19:53:42.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f2/300327b0a47f6dc94dd8b71b57052aefe178bb51745073d73d80604f11ab/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829", size = 5238019, upload-time = "2026-04-24T19:53:44.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/5b5cf994391d4bf9d9c7efd4c66aabe4d95227256627f8fea6cff7dfadbd/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7", size = 4686832, upload-time = "2026-04-24T19:53:47.015Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2c/ae950e28fd6475c852fc21a44db3e6b5bcc1261d1e370f2b6e42fa800fef/cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923", size = 4269301, upload-time = "2026-04-24T19:53:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fb/6a39782e150ffe5cc1b0018cb6ddc48bf7ca62b498d7539ffc8a758e977d/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab", size = 4638110, upload-time = "2026-04-24T19:53:51.011Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d7/0b3c71090a76e5c203164a47688b697635ece006dcd2499ab3a4dbd3f0bd/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736", size = 5194988, upload-time = "2026-04-24T19:53:52.962Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/63a961498a9df51721ab578c5a2622661411fc520e00bd83b0cc64eb20c4/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7", size = 4686563, upload-time = "2026-04-24T19:53:55.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/5ee5b145248f92250de86145d1c1d6edebbd57a7fe7caa4dedb5d4cf06a1/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52", size = 4770094, upload-time = "2026-04-24T19:53:57.753Z" },
+    { url = "https://files.pythonhosted.org/packages/92/43/21d220b2da5d517773894dacdcdb5c682c28d3fffce65548cb06e87d5501/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd", size = 4913811, upload-time = "2026-04-24T19:54:00.236Z" },
+    { url = "https://files.pythonhosted.org/packages/31/98/dc4ad376ac5f1a1a7d4a83f7b0c6f2bcad36b5d2d8f30aeb482d3a7d9582/cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63", size = 3237158, upload-time = "2026-04-24T19:54:02.606Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/da/97f62d18306b5133468bc3f8cc73a3111e8cdc8cf8d3e69474d6e5fd2d1b/cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b", size = 3758706, upload-time = "2026-04-24T19:54:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
+]
+
+[[package]]
 name = "execnet"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -175,6 +367,54 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.50.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/18/238d7021d151bdab868f23433817b027dd759135202f4dfce0670d1230ca/google_auth-2.50.0.tar.gz", hash = "sha256:f35eafb191195328e8ce10a7883970877e7aeb49c2bfaa54aa0e394316d353d0", size = 336523, upload-time = "2026-04-30T21:19:29.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/cf/4880c2137c14280b2f59975cdf12cc442bc0ae1f9ea473a26eaa0c146786/google_auth-2.50.0-py3-none-any.whl", hash = "sha256:04382175e28b94f49694977f0a792688b59a668def1499e9d8de996dc9ce5b15", size = 246495, upload-time = "2026-04-30T21:19:27.664Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/82/62482931dcbe5266a2680d0da17096f2aab983ecb320277d9556700ce00e/google_auth_oauthlib-1.3.1.tar.gz", hash = "sha256:14c22c7b3dd3d06dbe44264144409039465effdd1eef94f7ce3710e486cc4bfa", size = 21663, upload-time = "2026-03-30T22:49:56.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e0/cb454a95f460903e39f101e950038ec24a072ca69d0a294a6df625cc1627/google_auth_oauthlib-1.3.1-py3-none-any.whl", hash = "sha256:1a139ef23f1318756805b0e95f655c238bffd29655329a2978218248da4ee7f8", size = 19247, upload-time = "2026-03-30T20:02:23.894Z" },
+]
+
+[[package]]
+name = "gspread"
+version = "6.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/83/42d1d813822ed016d77aabadc99b09de3b5bd68532fd6bae23fd62347c41/gspread-6.2.1.tar.gz", hash = "sha256:2c7c99f7c32ebea6ec0d36f2d5cbe8a2be5e8f2a48bde87ad1ea203eff32bd03", size = 82590, upload-time = "2025-05-14T15:56:25.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/76/563fb20dedd0e12794d9a12cfe0198458cc0501fdc7b034eee2166d035d5/gspread-6.2.1-py3-none-any.whl", hash = "sha256:6d4ec9f1c23ae3c704a9219026dac01f2b328ac70b96f1495055d453c4c184db", size = 59977, upload-time = "2025-05-14T15:56:24.014Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
@@ -235,11 +475,25 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "office-cli"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+sheets = [
+    { name = "gspread" },
 ]
 
 [package.dev-dependencies]
@@ -254,7 +508,11 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pyyaml", specifier = ">=6.0" }]
+requires-dist = [
+    { name = "gspread", marker = "extra == 'sheets'", specifier = ">=6.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
+provides-extras = ["sheets"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -304,12 +562,42 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -449,6 +737,34 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -468,4 +784,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]


### PR DESCRIPTION
## Summary

Stage 2 of the v1 seating system per
[issue #1](https://github.com/agentculture/office-agent/issues/1). Adds Google
Sheets as a selectable storage backend behind the `AssignmentStore` Protocol
that landed in Stage 1. CSV remains the default; Sheets is opt-in.

- **`office_cli.seats.sheets` package** — `SheetsClient` Protocol +
  `GspreadClient` adapter (gspread imported lazily so the parent package
  loads without the extra), `SheetsStore` (5-min read cache, write-through
  invalidation), and `SheetsAuditLog` (append-only; seeds header on first
  write).
- **Storage selector** — `office_cli._config.resolve_storage` picks the
  backend from `data/offices.yaml`'s `storage:` block, with env overrides
  `OFFICE_STORE` / `OFFICE_SHEETS_ID` / `OFFICE_SHEETS_SA`. Errors early
  with a clear remediation when sheets is requested but unconfigured.
- **`build_service`** wires the right (store, audit) pair from the
  resolved config — no caller-side change needed.
- **Optional extra** — `pip install office-cli[sheets]` pulls
  `gspread>=6.0`. CSV-only users do not pay for the dep tree.

## Test plan

- [x] `uv run pytest -n auto -v` — 91 tests pass: existing 74 plus
  - SheetsStore: round-trip, cache hit within TTL, refresh after TTL,
    upsert replaces, by-email lookup;
  - SheetsAuditLog: header-then-append seeding, filter by seat;
  - storage config: default-csv, yaml-csv, yaml-sheets, env-overrides-yaml,
    missing-id rejected, missing-SA rejected, unknown-type rejected,
    relative-SA-resolves-to-data-dir;
  - `gspread` missing → clear `OfficeError` with remediation;
  - end-to-end SeatService flow against Sheets backends through a
    `FakeSheetsClient` (assign / one-seat-per-email rejection / move /
    history / whereis).
- [x] black / isort / flake8 / bandit / markdownlint clean.
- [x] `steward doctor . --scope self` clean.
- [x] `uv build` produces 0.2.0 wheel + sdist.

## Out of scope (Stage 3+)

- BambooHR-backed `EmployeeDirectory`. The `StubDirectory` continues to
  trust the email it receives until that lands.
- Slack `/whereis`, web frontend, effective-date enforcement, SSO/roles,
  DynamoDB store. Each is enumerated in `docs/architecture.md`.

- Claude

Generated with Claude Code