### PR TITLE
feat: v1 seating Stage 3 — BambooHR directory + auto-vacate (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-01
+
+### Added
+
+- v1 seating Stage 3 — BambooHR-backed `EmployeeDirectory` with the
+  **auto-vacate killer feature** ([#7](https://github.com/agentculture/office-agent/issues/7)).
+  When BambooHR no longer returns an employee in its `/v1/employees/directory`
+  response, every seat assigned to them renders as vacant — the assignment
+  row in the store is **not** mutated; the filter is applied at view time.
+- New optional extra: `pip install office-cli[bamboohr]` pulls
+  `requests>=2.31`. The CSV/stub paths still work without the dep tree.
+- `office_cli.people.bamboohr` package: `BambooHRClient` Protocol,
+  `RequestsBambooHRClient` (lazy import; thin shim over the BambooHR
+  REST API), and `BambooHRDirectory` (5-minute TTL cache, fail-open on
+  refresh errors with a stale-cache stderr warning).
+- `office_cli._config.resolve_directory` picks the directory backend
+  from `data/offices.yaml`'s `directory:` block, with env overrides
+  `OFFICE_DIRECTORY` / `BAMBOOHR_API_TOKEN` / `BAMBOOHR_SUBDOMAIN`. The
+  API token is **env-only** by design (never in YAML).
+- `SeatService` now accepts an optional `directory` argument and
+  applies the auto-vacate filter in `list_seats` and `whereis`. Default
+  is `StubDirectory` so existing callers see no behavioral change.
+- `build_service(data_dir)` resolves and threads through both the
+  storage backend and the directory.
+
 ## [0.2.0] - 2026-05-01
 
 ### Added
@@ -80,7 +105,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   preserving the SVG ID contract and architectural guardrails for the v1
   seating system (issue #1).
 
-[Unreleased]: https://github.com/agentculture/office-agent/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/agentculture/office-agent/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/agentculture/office-agent/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/agentculture/office-agent/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/agentculture/office-agent/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/agentculture/office-agent/releases/tag/v0.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ office-agent/
 │   ├── offices/                 # offices.yaml loader + Office/Floor/Cluster/Room
 │   ├── floors/                  # SVG parse + ID contract + validator
 │   ├── seats/                   # AssignmentStore + Csv/Sheets stores + AuditLog + SeatService
-│   ├── people/                  # Employee + EmployeeDirectory (StubDirectory in v0.1.0)
+│   ├── people/                  # Employee + EmployeeDirectory (Stub + BambooHR backends)
 │   └── explain/                 # Markdown catalog for `office explain <path>`
 ├── data/offices.yaml            # office / floor / cluster topology
 ├── floors/                      # human-traced floor SVGs
@@ -58,7 +58,7 @@ office-agent/
 ```bash
 uv sync                           # install runtime + dev deps
 uv run pytest -n auto -v          # full suite, parallel
-uv run office --version           # 0.2.0
+uv run office --version           # 0.3.0
 uv run office learn               # agent affordance
 uv run office whoami              # auth probe stub
 uv run office floors validate floors/tlv-floor-5.svg

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ BambooHR; assignments live in a Google Sheet (v1) or DynamoDB (v2). The
 CLI exposes the same operations as the Slack `/whereis` command and the
 web map.
 
-> **Status — v0.2.0.** Stages 1 + 2 of the v1 seating system are in:
-> floor SVG parser/validator, CSV- *and* Google Sheets-backed
-> assignment store with append-only audit log, CLI verbs (`floors`,
-> `seats`, `whereis`). BambooHR, Slack `/whereis`, and the web map
-> land in later stages on top of the same `office_cli.seats` service.
-> See [issue #1](https://github.com/agentculture/office-agent/issues/1).
+> **Status — v0.3.0.** Stages 1 + 2 + 3 of the v1 seating system are
+> in: floor SVG parser/validator, CSV / Google Sheets-backed assignment
+> store with append-only audit log, BambooHR-backed `EmployeeDirectory`
+> with the auto-vacate killer feature, and CLI verbs (`floors`,
+> `seats`, `whereis`). Slack `/whereis` and the web map land in later
+> stages on top of the same `office_cli.seats` service. See
+> [issue #1](https://github.com/agentculture/office-agent/issues/1).
 
 ## Naming surfaces
 
@@ -79,6 +80,34 @@ storage:
 
 Reads honor a 5-minute TTL cache; writes invalidate it. See
 `docs/architecture.md` for the full storage contract.
+
+### People directory (BambooHR)
+
+`office` defaults to a no-op `StubDirectory` that trusts whatever email
+it receives. Switch to BambooHR for the auto-vacate killer feature
+(seats render as vacant automatically when an employee is offboarded):
+
+```bash
+pip install office-cli[bamboohr]
+export OFFICE_DIRECTORY=bamboohr
+export BAMBOOHR_SUBDOMAIN=tipalti
+export BAMBOOHR_API_TOKEN=...   # env-only — do not commit
+```
+
+…or declare the public bits in `data/offices.yaml` and keep the token
+in the env:
+
+```yaml
+directory:
+  type: bamboohr
+  bamboohr:
+    subdomain: tipalti
+    cache_ttl_seconds: 300
+```
+
+The directory affects rendering only; assignments stay in the store
+unchanged. Re-activating an employee in BambooHR restores their seat
+without any write.
 
 ## Adding a new floor
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture — v0.2.0 (Stage 1 + Stage 2)
+# Architecture — v0.3.0 (Stages 1–3)
 
 `office` ships in stages on top of issue
 [#1](https://github.com/agentculture/office-agent/issues/1). This document
@@ -26,9 +26,12 @@ boundary stays explicit.
    ── validate_floor(svg, floor) → list[Issue]
 ```
 
-`office_cli.people` exposes an `EmployeeDirectory` Protocol with a
-`StubDirectory` that trusts whatever email it receives. The
-`BambooHRDirectory` lands in the BambooHR stage.
+`office_cli.people` exposes an `EmployeeDirectory` Protocol with two
+implementations: `StubDirectory` (default — trusts whatever email it
+receives) and `BambooHRDirectory` (5-min TTL cache; presence in
+BambooHR's `/v1/employees/directory` is the auto-vacate signal). The
+service applies a view-time auto-vacate filter: a seat whose stored
+email is no longer active in the directory renders as vacant.
 
 ## Stage 1 — implemented in v0.1.0
 
@@ -94,13 +97,65 @@ export OFFICE_SHEETS_SA=/abs/or/data-dir-relative/sa.json
 
 The service-account JSON should be **git-ignored**.
 
+## Stage 3 — implemented in v0.3.0
+
+- `office_cli.people.bamboohr.BambooHRDirectory` implements
+  `EmployeeDirectory` against the BambooHR `/v1/employees/directory`
+  endpoint with a 5-minute TTL cache.
+- `RequestsBambooHRClient` is the production adapter; `requests` is
+  imported lazily so installs without the `[bamboohr]` extra still
+  load `office_cli.people` cleanly.
+- `BambooHRClient` Protocol exposes only `fetch_directory()`; tests use
+  a `FakeBambooHRClient` and never need real credentials.
+- **Fail-open**: a refresh failure with a populated cache logs to stderr
+  and serves the previous snapshot. Only a first-fetch failure raises
+  `OfficeError(EXIT_ENV_ERROR)`.
+- **Auto-vacate** is implemented in `SeatService` via
+  `_apply_autovacate`: rows whose stored email is missing from the
+  directory render as vacant in `list_seats` / `whereis`. The store
+  row is **not mutated** — history and the underlying CSV/Sheet stay
+  intact, so reactivating an employee restores the seat without any
+  write.
+- **API token is env-only**: `BAMBOOHR_API_TOKEN` must never be
+  committed to `data/offices.yaml`. The YAML block carries
+  `subdomain` and `cache_ttl_seconds` only.
+
+Install the extra to use BambooHR:
+
+```bash
+pip install office-cli[bamboohr]
+```
+
+Configure either via `data/offices.yaml`:
+
+```yaml
+directory:
+  type: bamboohr
+  bamboohr:
+    subdomain: tipalti
+    cache_ttl_seconds: 300
+```
+
+…plus the API token in the env (never in YAML):
+
+```bash
+export BAMBOOHR_API_TOKEN=...
+```
+
+…or full env override:
+
+```bash
+export OFFICE_DIRECTORY=bamboohr
+export BAMBOOHR_SUBDOMAIN=tipalti
+export BAMBOOHR_API_TOKEN=...
+```
+
 ## Deferred surfaces
 
 Each is a separate issue/PR.
 
 | Stage              | Surface                                       | Notes                                                                   |
 | ------------------ | --------------------------------------------- | ----------------------------------------------------------------------- |
-| 3. BambooHR        | `office_cli.people.BambooHRDirectory`         | Live pull, 5-min cache; auto-vacate on offboarding (the killer feature). |
 | 4. Slack `/whereis`| `office_slack/` Bolt app                      | Imports `SeatService.whereis`; renders Block Kit with deep link.        |
 | 5. Web frontend    | `office_web/` (Vite + a small Python server)  | Search-first map, `?asOf=YYYY-MM-DD`, role-aware `hidden` rendering.    |
 | 6. Effective dates | service-layer `effective_from / _until`       | Columns already exist; the service starts honoring them.                |

--- a/office_cli/_config.py
+++ b/office_cli/_config.py
@@ -35,6 +35,8 @@ import yaml
 
 from office_cli.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, OfficeError
 
+_SHAPE_HINT = "see docs/architecture.md for the expected shape"
+
 
 def resolve_data_dir(args: argparse.Namespace | None = None) -> Path:
     explicit = getattr(args, "data_dir", None) if args is not None else None
@@ -109,7 +111,7 @@ def resolve_storage(data_dir: Path) -> StorageConfig:
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message="storage.sheets must be a mapping in offices.yaml",
-            remediation="see docs/architecture.md for the expected shape",
+            remediation=_SHAPE_HINT,
         )
     spreadsheet_id = (
         os.environ.get("OFFICE_SHEETS_ID") or _str_field(sheets_cfg, "spreadsheet_id") or ""
@@ -152,7 +154,7 @@ def _str_field(d: dict, key: str) -> str:
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=f"storage.{key} must be a scalar, got {type(value).__name__}",
-            remediation="see docs/architecture.md for the expected shape",
+            remediation=_SHAPE_HINT,
         )
     return str(value)
 
@@ -254,7 +256,7 @@ def resolve_directory(data_dir: Path) -> DirectoryConfig:
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message="directory.bamboohr must be a mapping in offices.yaml",
-            remediation="see docs/architecture.md for the expected shape",
+            remediation=_SHAPE_HINT,
         )
     subdomain = (
         os.environ.get("BAMBOOHR_SUBDOMAIN") or _str_field(bamboo_cfg, "subdomain") or ""

--- a/office_cli/_config.py
+++ b/office_cli/_config.py
@@ -37,6 +37,8 @@ from office_cli.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, OfficeError
 
 _SHAPE_HINT = "see docs/architecture.md for the expected shape"
 _BAMBOOHR_TTL_MAX_SECONDS = 300
+_PREFIX_SHEETS = "storage.sheets"
+_PREFIX_BAMBOOHR = "directory.bamboohr"
 
 
 def resolve_data_dir(args: argparse.Namespace | None = None) -> Path:
@@ -118,11 +120,11 @@ def resolve_storage(data_dir: Path) -> StorageConfig:
         )
     spreadsheet_id = (
         os.environ.get("OFFICE_SHEETS_ID")
-        or _str_field(sheets_cfg, "spreadsheet_id", prefix="storage.sheets")
+        or _str_field(sheets_cfg, "spreadsheet_id", prefix=_PREFIX_SHEETS)
         or ""
     ).strip()
     sa_field = os.environ.get("OFFICE_SHEETS_SA") or _str_field(
-        sheets_cfg, "service_account", prefix="storage.sheets"
+        sheets_cfg, "service_account", prefix=_PREFIX_SHEETS
     )
     if not spreadsheet_id:
         raise OfficeError(
@@ -139,7 +141,7 @@ def resolve_storage(data_dir: Path) -> StorageConfig:
     sa_path = Path(sa_field).expanduser()
     if not sa_path.is_absolute():
         sa_path = (data_dir / sa_path).resolve()
-    ttl = _int_field(sheets_cfg, "cache_ttl_seconds", 300, prefix="storage.sheets")
+    ttl = _int_field(sheets_cfg, "cache_ttl_seconds", 300, prefix=_PREFIX_SHEETS)
     return StorageConfig(
         type="sheets",
         spreadsheet_id=spreadsheet_id,
@@ -274,7 +276,7 @@ def resolve_directory(data_dir: Path) -> DirectoryConfig:
         )
     subdomain = (
         os.environ.get("BAMBOOHR_SUBDOMAIN")
-        or _str_field(bamboo_cfg, "subdomain", prefix="directory.bamboohr")
+        or _str_field(bamboo_cfg, "subdomain", prefix=_PREFIX_BAMBOOHR)
         or ""
     ).strip()
     api_token = (os.environ.get("BAMBOOHR_API_TOKEN") or "").strip()
@@ -290,7 +292,7 @@ def resolve_directory(data_dir: Path) -> DirectoryConfig:
             message="directory.type=bamboohr requires an API token",
             remediation=("set BAMBOOHR_API_TOKEN (env-only — do not commit the token to YAML)"),
         )
-    ttl = _int_field(bamboo_cfg, "cache_ttl_seconds", 300, prefix="directory.bamboohr")
+    ttl = _int_field(bamboo_cfg, "cache_ttl_seconds", 300, prefix=_PREFIX_BAMBOOHR)
     if ttl > _BAMBOOHR_TTL_MAX_SECONDS:
         raise OfficeError(
             code=EXIT_USER_ERROR,

--- a/office_cli/_config.py
+++ b/office_cli/_config.py
@@ -1,5 +1,6 @@
 """Resolve where the office data (offices.yaml, floors/, seats/) lives,
-plus the storage backend (CSV vs Sheets) the seat service should use.
+plus the storage backend (CSV vs Sheets) and people directory (Stub vs
+BambooHR) the seat service should use.
 
 Data-dir resolution order:
 
@@ -12,6 +13,15 @@ Storage selection order (last wins):
 1. ``storage:`` block in ``data/offices.yaml`` (``type: csv`` | ``sheets``);
 2. ``OFFICE_STORE`` env var (``csv`` | ``sheets``);
 3. CLI overrides via ``OFFICE_SHEETS_ID`` / ``OFFICE_SHEETS_SA``.
+
+Directory selection order (last wins):
+
+1. ``directory:`` block in ``data/offices.yaml`` (``type: stub`` | ``bamboohr``);
+2. ``OFFICE_DIRECTORY`` env var (``stub`` | ``bamboohr``);
+3. ``BAMBOOHR_API_TOKEN`` / ``BAMBOOHR_SUBDOMAIN`` env overrides.
+
+The API token is intentionally **env-only**; the YAML block carries the
+subdomain and TTL but never the token (so YAML can be checked in).
 """
 
 from __future__ import annotations
@@ -174,6 +184,16 @@ def _int_field(d: dict, key: str, default: int) -> int:
 
 def _read_storage_block(data_dir: Path) -> dict:
     """Return the ``storage:`` mapping from offices.yaml, or empty dict."""
+    return _read_top_level_block(data_dir, "storage")
+
+
+def _read_top_level_block(data_dir: Path, key: str) -> dict:
+    """Return the named top-level mapping from offices.yaml, or empty dict.
+
+    Used for the ``storage:`` and ``directory:`` blocks. Malformed YAML
+    is swallowed here; ``office_cli.offices.load_offices`` is the
+    authoritative parser and raises on it.
+    """
     yaml_path = data_dir / "data" / "offices.yaml"
     if not yaml_path.is_file():
         return {}
@@ -181,10 +201,81 @@ def _read_storage_block(data_dir: Path) -> dict:
         try:
             raw = yaml.safe_load(f) or {}
         except yaml.YAMLError:
-            # offices.py raises on malformed YAML; here we just decline to
-            # apply storage config and let the rest of the loader complain.
             return {}
-    storage = raw.get("storage") or {}
-    if not isinstance(storage, dict):
+    block = raw.get(key) or {}
+    if not isinstance(block, dict):
         return {}
-    return storage
+    return block
+
+
+@dataclass(frozen=True)
+class DirectoryConfig:
+    """Resolved people-directory backend for the seat service."""
+
+    type: str  # "stub" | "bamboohr"
+    subdomain: str = ""
+    api_token: str = ""
+    cache_ttl_seconds: int = 300
+
+
+def resolve_directory(data_dir: Path) -> DirectoryConfig:
+    """Pick the directory backend from offices.yaml + env overrides.
+
+    Defaults to ``stub`` (the trust-the-email no-op directory). BambooHR
+    requires both a subdomain and an API token; we error early so
+    operators get a clear hint instead of an opaque HTTP error.
+
+    The API token is intentionally env-only: ``BAMBOOHR_API_TOKEN`` is
+    a secret and must not be committed in ``data/offices.yaml``.
+    """
+    yaml_cfg = _read_top_level_block(data_dir, "directory")
+    dir_type = (
+        (os.environ.get("OFFICE_DIRECTORY") or _str_field(yaml_cfg, "type") or "stub")
+        .strip()
+        .lower()
+    )
+
+    if dir_type == "stub":
+        return DirectoryConfig(type="stub")
+
+    if dir_type != "bamboohr":
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"unknown directory type: {dir_type!r}",
+            remediation=(
+                "set directory.type to 'stub' or 'bamboohr' in offices.yaml or OFFICE_DIRECTORY"
+            ),
+        )
+
+    bamboo_cfg = yaml_cfg.get("bamboohr")
+    if bamboo_cfg is None:
+        bamboo_cfg = {}
+    if not isinstance(bamboo_cfg, dict):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="directory.bamboohr must be a mapping in offices.yaml",
+            remediation="see docs/architecture.md for the expected shape",
+        )
+    subdomain = (
+        os.environ.get("BAMBOOHR_SUBDOMAIN") or _str_field(bamboo_cfg, "subdomain") or ""
+    ).strip()
+    api_token = (os.environ.get("BAMBOOHR_API_TOKEN") or "").strip()
+    if not subdomain:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message="directory.type=bamboohr requires a subdomain",
+            remediation="set BAMBOOHR_SUBDOMAIN or directory.bamboohr.subdomain",
+        )
+    if not api_token:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message="directory.type=bamboohr requires an API token",
+            remediation=("set BAMBOOHR_API_TOKEN (env-only — do not commit the token to YAML)"),
+        )
+    ttl = _int_field(bamboo_cfg, "cache_ttl_seconds", 300)
+    return DirectoryConfig(
+        type="bamboohr",
+        subdomain=subdomain,
+        api_token=api_token,
+        cache_ttl_seconds=ttl,
+    )

--- a/office_cli/_config.py
+++ b/office_cli/_config.py
@@ -36,6 +36,7 @@ import yaml
 from office_cli.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, OfficeError
 
 _SHAPE_HINT = "see docs/architecture.md for the expected shape"
+_BAMBOOHR_TTL_MAX_SECONDS = 300
 
 
 def resolve_data_dir(args: argparse.Namespace | None = None) -> Path:
@@ -91,7 +92,9 @@ def resolve_storage(data_dir: Path) -> StorageConfig:
     """
     yaml_cfg = _read_storage_block(data_dir)
     store_type = (
-        (os.environ.get("OFFICE_STORE") or _str_field(yaml_cfg, "type") or "csv").strip().lower()
+        (os.environ.get("OFFICE_STORE") or _str_field(yaml_cfg, "type", prefix="storage") or "csv")
+        .strip()
+        .lower()
     )
 
     if store_type == "csv":
@@ -114,9 +117,13 @@ def resolve_storage(data_dir: Path) -> StorageConfig:
             remediation=_SHAPE_HINT,
         )
     spreadsheet_id = (
-        os.environ.get("OFFICE_SHEETS_ID") or _str_field(sheets_cfg, "spreadsheet_id") or ""
+        os.environ.get("OFFICE_SHEETS_ID")
+        or _str_field(sheets_cfg, "spreadsheet_id", prefix="storage.sheets")
+        or ""
     ).strip()
-    sa_field = os.environ.get("OFFICE_SHEETS_SA") or _str_field(sheets_cfg, "service_account")
+    sa_field = os.environ.get("OFFICE_SHEETS_SA") or _str_field(
+        sheets_cfg, "service_account", prefix="storage.sheets"
+    )
     if not spreadsheet_id:
         raise OfficeError(
             code=EXIT_ENV_ERROR,
@@ -132,7 +139,7 @@ def resolve_storage(data_dir: Path) -> StorageConfig:
     sa_path = Path(sa_field).expanduser()
     if not sa_path.is_absolute():
         sa_path = (data_dir / sa_path).resolve()
-    ttl = _int_field(sheets_cfg, "cache_ttl_seconds", 300)
+    ttl = _int_field(sheets_cfg, "cache_ttl_seconds", 300, prefix="storage.sheets")
     return StorageConfig(
         type="sheets",
         spreadsheet_id=spreadsheet_id,
@@ -141,11 +148,13 @@ def resolve_storage(data_dir: Path) -> StorageConfig:
     )
 
 
-def _str_field(d: dict, key: str) -> str:
+def _str_field(d: dict, key: str, *, prefix: str = "storage") -> str:
     """Read ``d[key]`` as a string. ``None`` → empty; non-string → coerced.
 
     Returns "" for missing keys. Raises :class:`OfficeError` only if the
     value is structurally wrong (a list/dict where a scalar is expected).
+    ``prefix`` is the YAML path used in error messages (e.g.
+    ``"storage.sheets"`` or ``"directory.bamboohr"``).
     """
     value = d.get(key)
     if value is None:
@@ -153,33 +162,34 @@ def _str_field(d: dict, key: str) -> str:
     if isinstance(value, (dict, list)):
         raise OfficeError(
             code=EXIT_USER_ERROR,
-            message=f"storage.{key} must be a scalar, got {type(value).__name__}",
+            message=f"{prefix}.{key} must be a scalar, got {type(value).__name__}",
             remediation=_SHAPE_HINT,
         )
     return str(value)
 
 
-def _int_field(d: dict, key: str, default: int) -> int:
+def _int_field(d: dict, key: str, default: int, *, prefix: str = "storage") -> int:
+    """Like :func:`_str_field` but coerces to ``int`` and rejects negatives."""
     value = d.get(key, default)
     if isinstance(value, bool) or not isinstance(value, (int, str)):
         raise OfficeError(
             code=EXIT_USER_ERROR,
-            message=f"storage.{key} must be an integer, got {type(value).__name__}",
-            remediation=f"set storage.{key} to a non-negative integer (seconds)",
+            message=f"{prefix}.{key} must be an integer, got {type(value).__name__}",
+            remediation=f"set {prefix}.{key} to a non-negative integer (seconds)",
         )
     try:
         ttl = int(value)
     except ValueError as err:
         raise OfficeError(
             code=EXIT_USER_ERROR,
-            message=f"storage.{key} must be an integer; got {value!r}",
-            remediation=f"set storage.{key} to a non-negative integer (seconds)",
+            message=f"{prefix}.{key} must be an integer; got {value!r}",
+            remediation=f"set {prefix}.{key} to a non-negative integer (seconds)",
         ) from err
     if ttl < 0:
         raise OfficeError(
             code=EXIT_USER_ERROR,
-            message=f"storage.{key} must be non-negative; got {ttl}",
-            remediation=f"set storage.{key} to a non-negative integer (seconds)",
+            message=f"{prefix}.{key} must be non-negative; got {ttl}",
+            remediation=f"set {prefix}.{key} to a non-negative integer (seconds)",
         )
     return ttl
 
@@ -232,7 +242,11 @@ def resolve_directory(data_dir: Path) -> DirectoryConfig:
     """
     yaml_cfg = _read_top_level_block(data_dir, "directory")
     dir_type = (
-        (os.environ.get("OFFICE_DIRECTORY") or _str_field(yaml_cfg, "type") or "stub")
+        (
+            os.environ.get("OFFICE_DIRECTORY")
+            or _str_field(yaml_cfg, "type", prefix="directory")
+            or "stub"
+        )
         .strip()
         .lower()
     )
@@ -259,7 +273,9 @@ def resolve_directory(data_dir: Path) -> DirectoryConfig:
             remediation=_SHAPE_HINT,
         )
     subdomain = (
-        os.environ.get("BAMBOOHR_SUBDOMAIN") or _str_field(bamboo_cfg, "subdomain") or ""
+        os.environ.get("BAMBOOHR_SUBDOMAIN")
+        or _str_field(bamboo_cfg, "subdomain", prefix="directory.bamboohr")
+        or ""
     ).strip()
     api_token = (os.environ.get("BAMBOOHR_API_TOKEN") or "").strip()
     if not subdomain:
@@ -274,7 +290,19 @@ def resolve_directory(data_dir: Path) -> DirectoryConfig:
             message="directory.type=bamboohr requires an API token",
             remediation=("set BAMBOOHR_API_TOKEN (env-only — do not commit the token to YAML)"),
         )
-    ttl = _int_field(bamboo_cfg, "cache_ttl_seconds", 300)
+    ttl = _int_field(bamboo_cfg, "cache_ttl_seconds", 300, prefix="directory.bamboohr")
+    if ttl > _BAMBOOHR_TTL_MAX_SECONDS:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"directory.bamboohr.cache_ttl_seconds must not exceed "
+                f"{_BAMBOOHR_TTL_MAX_SECONDS}; got {ttl}"
+            ),
+            remediation=(
+                "the v1 spec caps the BambooHR cache at 5 minutes "
+                f"({_BAMBOOHR_TTL_MAX_SECONDS}s) so offboarding propagates promptly"
+            ),
+        )
     return DirectoryConfig(
         type="bamboohr",
         subdomain=subdomain,

--- a/office_cli/people/bamboohr/__init__.py
+++ b/office_cli/people/bamboohr/__init__.py
@@ -1,0 +1,18 @@
+"""BambooHR-backed :class:`EmployeeDirectory`.
+
+Importing this subpackage does not import ``requests`` at module-load
+time: ``RequestsBambooHRClient`` performs a lazy import on first call.
+That way, installations without the ``[bamboohr]`` extra installed can
+still import :mod:`office_cli.people` and use the default
+:class:`StubDirectory`.
+"""
+
+from __future__ import annotations
+
+from office_cli.people.bamboohr._client import (
+    BambooHRClient,
+    RequestsBambooHRClient,
+)
+from office_cli.people.bamboohr._directory import BambooHRDirectory
+
+__all__ = ["BambooHRClient", "BambooHRDirectory", "RequestsBambooHRClient"]

--- a/office_cli/people/bamboohr/_client.py
+++ b/office_cli/people/bamboohr/_client.py
@@ -1,0 +1,92 @@
+"""Thin shim over the BambooHR REST API.
+
+The :class:`BambooHRClient` Protocol exposes only the one operation the
+directory needs (``fetch_directory``). The directory is unit-tested
+against a ``FakeBambooHRClient`` so the test suite never needs real
+credentials. :class:`RequestsBambooHRClient` is the production
+implementation — ``requests`` is imported lazily so the parent package
+loads without the ``[bamboohr]`` extra.
+
+The directory endpoint ``GET /v1/employees/directory`` (BambooHR
+docs: https://documentation.bamboohr.com/reference/get-employees-directory-1)
+returns only employees whose status is "Active" — anyone marked
+terminated drops from the response. That's exactly the auto-vacate
+signal for v1: presence in the directory implies active employment.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
+from office_cli.people._stub import Employee
+
+
+class BambooHRClient(Protocol):
+    def fetch_directory(self) -> list[Employee]:
+        """Return the list of currently-active employees, keyed by email."""
+
+
+class RequestsBambooHRClient:
+    """Production :class:`BambooHRClient` implementation using ``requests``."""
+
+    def __init__(
+        self,
+        subdomain: str,
+        api_token: str,
+        *,
+        timeout_seconds: float = 10.0,
+        base_url: str | None = None,
+    ) -> None:
+        # Validate inputs first so misconfiguration surfaces with a clear
+        # remediation even when ``requests`` is missing.
+        if not subdomain:
+            raise OfficeError(
+                code=EXIT_ENV_ERROR,
+                message="BambooHR subdomain is empty",
+                remediation="set BAMBOOHR_SUBDOMAIN or directory.bamboohr.subdomain",
+            )
+        if not api_token:
+            raise OfficeError(
+                code=EXIT_ENV_ERROR,
+                message="BambooHR API token is empty",
+                remediation="set BAMBOOHR_API_TOKEN (the token must not be committed)",
+            )
+        try:
+            import requests  # noqa: F401 — runtime check
+        except ImportError as err:
+            raise OfficeError(
+                code=EXIT_ENV_ERROR,
+                message="requests is not installed",
+                remediation=("install the bamboohr extra: pip install office-cli[bamboohr]"),
+            ) from err
+        self._subdomain = subdomain
+        self._api_token = api_token
+        self._timeout = timeout_seconds
+        self._base_url = base_url or (f"https://api.bamboohr.com/api/gateway.php/{subdomain}/v1")
+
+    def fetch_directory(self) -> list[Employee]:
+        import requests
+
+        resp = requests.get(
+            f"{self._base_url}/employees/directory",
+            auth=(self._api_token, "x"),
+            headers={"Accept": "application/json"},
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        out: list[Employee] = []
+        for row in payload.get("employees") or []:
+            email = (row.get("workEmail") or "").strip()
+            if not email:
+                continue
+            out.append(
+                Employee(
+                    email=email,
+                    name=row.get("displayName") or "",
+                    role=row.get("jobTitle") or "",
+                    photo_url=row.get("photoUrl") or "",
+                )
+            )
+        return out

--- a/office_cli/people/bamboohr/_directory.py
+++ b/office_cli/people/bamboohr/_directory.py
@@ -39,6 +39,10 @@ class BambooHRDirectory:
         self._clock = clock or time.monotonic
         self._cache: dict[str, Employee] = {}
         self._cache_at: float = 0.0
+        # Distinct from `_cache_at`: tracks the *last attempt* (success or
+        # fail) so a sustained outage does not retry on every per-seat
+        # `is_active` call inside `SeatService.list_seats`.
+        self._last_attempt_at: float = 0.0
         self._has_cache = False
 
     # -- EmployeeDirectory ----------------------------------------------
@@ -55,15 +59,20 @@ class BambooHRDirectory:
     # -- Helpers ---------------------------------------------------------
 
     def _refresh_if_stale(self) -> None:
-        if self._has_cache and (self._clock() - self._cache_at) < self._ttl:
+        now = self._clock()
+        # Rate-limit *attempts* (not just successes) so a stale cache during
+        # an outage does not trigger one fetch per seat in `list_seats`.
+        if self._has_cache and (now - self._last_attempt_at) < self._ttl:
             return
         try:
             employees = self._client.fetch_directory()
         except Exception as err:  # noqa: BLE001 — fail-open by design
+            self._last_attempt_at = now
             if self._has_cache:
+                age = now - self._cache_at
                 emit_diagnostic(
                     f"BambooHR fetch failed ({err.__class__.__name__}: {err}); "
-                    f"serving cached directory from {self._cache_at:.0f}s ago"
+                    f"serving cached directory from {age:.0f}s ago"
                 )
                 return
             raise OfficeError(
@@ -72,10 +81,12 @@ class BambooHRDirectory:
                 remediation=("verify BAMBOOHR_API_TOKEN / BAMBOOHR_SUBDOMAIN and retry"),
             ) from err
         self._cache = {e.email: e for e in employees if e.email}
-        self._cache_at = self._clock()
+        self._cache_at = now
+        self._last_attempt_at = now
         self._has_cache = True
 
     def invalidate(self) -> None:
         self._cache = {}
         self._cache_at = 0.0
+        self._last_attempt_at = 0.0
         self._has_cache = False

--- a/office_cli/people/bamboohr/_directory.py
+++ b/office_cli/people/bamboohr/_directory.py
@@ -1,0 +1,81 @@
+"""TTL-cached BambooHR-backed :class:`EmployeeDirectory`.
+
+Issue #7's "fail-open" guidance: BambooHR being temporarily unreachable
+must not stop people from finding their seats. We refresh on a 5-minute
+TTL by default; if a refresh fails, we keep serving the previous cache
+and emit a stderr diagnostic. The very first fetch has no fallback, so
+it surfaces as an :class:`OfficeError` with a clear remediation.
+"""
+
+from __future__ import annotations
+
+import time
+
+from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
+from office_cli.cli._output import emit_diagnostic
+from office_cli.people._stub import Employee
+from office_cli.people.bamboohr._client import BambooHRClient
+
+_DEFAULT_TTL_SECONDS = 300
+
+
+class BambooHRDirectory:
+    """``EmployeeDirectory`` backed by a BambooHR API client.
+
+    A single in-memory ``{email: Employee}`` cache is refreshed every
+    ``cache_ttl_seconds``. ``is_active(email)`` is dict membership;
+    ``get(email)`` returns the cached :class:`Employee` or ``None``.
+    """
+
+    def __init__(
+        self,
+        client: BambooHRClient,
+        *,
+        cache_ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+        clock: "callable[[], float] | None" = None,  # type: ignore[name-defined]
+    ) -> None:
+        self._client = client
+        self._ttl = cache_ttl_seconds
+        self._clock = clock or time.monotonic
+        self._cache: dict[str, Employee] = {}
+        self._cache_at: float = 0.0
+        self._has_cache = False
+
+    # -- EmployeeDirectory ----------------------------------------------
+
+    def get(self, email: str) -> Employee | None:
+        if not email:
+            return None
+        self._refresh_if_stale()
+        return self._cache.get(email)
+
+    def is_active(self, email: str) -> bool:
+        return self.get(email) is not None
+
+    # -- Helpers ---------------------------------------------------------
+
+    def _refresh_if_stale(self) -> None:
+        if self._has_cache and (self._clock() - self._cache_at) < self._ttl:
+            return
+        try:
+            employees = self._client.fetch_directory()
+        except Exception as err:  # noqa: BLE001 — fail-open by design
+            if self._has_cache:
+                emit_diagnostic(
+                    f"BambooHR fetch failed ({err.__class__.__name__}: {err}); "
+                    f"serving cached directory from {self._cache_at:.0f}s ago"
+                )
+                return
+            raise OfficeError(
+                code=EXIT_ENV_ERROR,
+                message=f"BambooHR fetch failed: {err}",
+                remediation=("verify BAMBOOHR_API_TOKEN / BAMBOOHR_SUBDOMAIN and retry"),
+            ) from err
+        self._cache = {e.email: e for e in employees if e.email}
+        self._cache_at = self._clock()
+        self._has_cache = True
+
+    def invalidate(self) -> None:
+        self._cache = {}
+        self._cache_at = 0.0
+        self._has_cache = False

--- a/office_cli/seats/__init__.py
+++ b/office_cli/seats/__init__.py
@@ -15,13 +15,16 @@ from __future__ import annotations
 from pathlib import Path
 
 from office_cli._config import (
+    DirectoryConfig,
     StorageConfig,
     assignments_csv,
     audit_log_csv,
+    resolve_directory,
     resolve_storage,
 )
 from office_cli.floors import FloorSvg, parse_svg
 from office_cli.offices import load_offices
+from office_cli.people import EmployeeDirectory, StubDirectory
 from office_cli.seats._audit import AuditLog, CsvAuditLog
 from office_cli.seats._csv_store import CsvStore
 from office_cli.seats._models import Assignment, AuditEntry
@@ -35,7 +38,9 @@ __all__ = [
     "AuditLog",
     "CsvAuditLog",
     "CsvStore",
+    "DirectoryConfig",
     "SeatService",
+    "StorageConfig",
     "build_service",
 ]
 
@@ -45,7 +50,9 @@ def build_service(data_dir: Path, *, actor: str = "cli") -> SeatService:
 
     Reads ``data/offices.yaml``, parses each declared floor SVG, and picks
     the assignment store + audit log per the resolved
-    :class:`StorageConfig` (CSV by default, Sheets when configured).
+    :class:`StorageConfig` (CSV by default, Sheets when configured), plus
+    the people directory per the resolved :class:`DirectoryConfig` (stub
+    by default, BambooHR when configured).
     """
     offices = load_offices(data_dir)
     floor_svgs: dict[str, FloorSvg] = {}
@@ -54,13 +61,31 @@ def build_service(data_dir: Path, *, actor: str = "cli") -> SeatService:
             if floor.svg.is_file():
                 floor_svgs[floor_id] = parse_svg(floor.svg)
     store, audit = _build_backends(data_dir, resolve_storage(data_dir))
+    directory = _build_directory(resolve_directory(data_dir))
     return SeatService(
         offices=offices,
         floor_svgs=floor_svgs,
         store=store,
         audit=audit,
         actor=actor,
+        directory=directory,
     )
+
+
+def _build_directory(cfg: DirectoryConfig) -> EmployeeDirectory:
+    if cfg.type == "stub":
+        return StubDirectory()
+    # Lazy import — requests is optional.
+    from office_cli.people.bamboohr import (
+        BambooHRDirectory,
+        RequestsBambooHRClient,
+    )
+
+    client = RequestsBambooHRClient(
+        subdomain=cfg.subdomain,
+        api_token=cfg.api_token,
+    )
+    return BambooHRDirectory(client, cache_ttl_seconds=cfg.cache_ttl_seconds)
 
 
 def _build_backends(data_dir: Path, cfg: StorageConfig):

--- a/office_cli/seats/_service.py
+++ b/office_cli/seats/_service.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import dataclasses
 from datetime import datetime, timezone
-from typing import Iterable
+from typing import Iterable, cast
 
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 from office_cli.floors import FloorSvg
@@ -93,7 +93,9 @@ class SeatService:
             return a
         if self.directory.is_active(a.employee_email):
             return a
-        return dataclasses.replace(a, employee_email="", hidden=False)
+        # ``dataclasses.replace`` is typed to return ``DataclassInstance``;
+        # the runtime value is the same dataclass type, so cast is safe.
+        return cast(Assignment, dataclasses.replace(a, employee_email="", hidden=False))
 
     def history(self, seat_id: str) -> list[AuditEntry]:
         self._require_seat(seat_id)

--- a/office_cli/seats/_service.py
+++ b/office_cli/seats/_service.py
@@ -5,17 +5,23 @@ Invariants:
 * a seat must exist in some floor's SVG before it can be assigned;
 * an employee has at most one seat globally — re-assigning an email that
   already holds a seat is rejected with a hint to use ``move``;
-* every mutation appends to the audit log.
+* every mutation appends to the audit log;
+* seats whose stored email is no longer active in the directory render
+  as **vacant** — the killer auto-vacate feature from issue #1. The
+  underlying row in the assignment store is *not* mutated; the filter
+  is applied at view time.
 """
 
 from __future__ import annotations
 
+import dataclasses
 from datetime import datetime, timezone
 from typing import Iterable
 
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 from office_cli.floors import FloorSvg
 from office_cli.offices import Office
+from office_cli.people import EmployeeDirectory, StubDirectory
 from office_cli.seats._audit import AuditLog
 from office_cli.seats._models import Assignment, AuditEntry
 from office_cli.seats._store import AssignmentStore
@@ -30,6 +36,7 @@ class SeatService:
         audit: AuditLog,
         actor: str = "cli",
         clock: "callable[[], str] | None" = None,  # type: ignore[name-defined]
+        directory: EmployeeDirectory | None = None,
     ) -> None:
         self.offices = offices
         self.floor_svgs = floor_svgs
@@ -37,6 +44,7 @@ class SeatService:
         self.audit = audit
         self.actor = actor
         self._clock = clock or _utcnow_iso
+        self.directory: EmployeeDirectory = directory or StubDirectory()
         self._seat_to_floor = _build_seat_index(offices, floor_svgs)
 
     # -- Lookups ---------------------------------------------------------
@@ -60,6 +68,7 @@ class SeatService:
                 seat_id,
                 Assignment(seat_id=seat_id, floor=floor_id),
             )
+            a = self._apply_autovacate(a)
             if only_vacant and not a.is_vacant:
                 continue
             if only_occupied and a.is_vacant:
@@ -68,7 +77,23 @@ class SeatService:
         return out
 
     def whereis(self, email: str) -> Assignment | None:
+        if not self.directory.is_active(email):
+            return None
         return self.store.by_email(email)
+
+    def _apply_autovacate(self, a: Assignment) -> Assignment:
+        """Return ``a`` with ``employee_email`` cleared if the employee is
+        no longer active in the directory.
+
+        The assignment-store row stays unchanged; this is a view-time
+        filter. ``hidden`` is also reset since "occupied (private)" no
+        longer applies once the seat is rendered as vacant.
+        """
+        if not a.employee_email:
+            return a
+        if self.directory.is_active(a.employee_email):
+            return a
+        return dataclasses.replace(a, employee_email="", hidden=False)
 
     def history(self, seat_id: str) -> list[AuditEntry]:
         self._require_seat(seat_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.2.0"
+version = "0.3.0"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"
@@ -19,6 +19,7 @@ dependencies = [
 
 [project.optional-dependencies]
 sheets = ["gspread>=6.0"]
+bamboohr = ["requests>=2.31"]
 
 [project.urls]
 Homepage = "https://github.com/agentculture/office-agent"

--- a/tests/test_bamboohr_directory.py
+++ b/tests/test_bamboohr_directory.py
@@ -102,6 +102,46 @@ def test_failopen_serves_stale_cache(
     assert "serving cached directory" in err
 
 
+def test_failed_refresh_rate_limits_within_ttl(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Copilot/Qodo: a sustained outage must not refetch on every is_active call.
+
+    `SeatService.list_seats` calls `is_active` per seat, so a stale cache
+    plus a failing BambooHR would otherwise issue N requests + N stderr
+    diagnostics for an N-seat office.
+    """
+    client = FakeBambooHRClient([_emp("alice@x")])
+    now = [0.0]
+    directory = BambooHRDirectory(client, cache_ttl_seconds=10, clock=lambda: now[0])
+    directory.is_active("alice@x")  # seed cache
+    capsys.readouterr()
+    assert client.call_count == 1
+
+    # Cache is now stale; BambooHR is down.
+    now[0] = 100.0
+    client.next_error = ConnectionError("BambooHR down")
+    directory.is_active("alice@x")
+    err1 = capsys.readouterr().err
+    assert "BambooHR fetch failed" in err1
+    assert client.call_count == 2
+
+    # Two more is_active calls within the TTL window must not refetch and
+    # must not re-emit the diagnostic.
+    client.next_error = ConnectionError("still down")
+    directory.is_active("alice@x")
+    directory.is_active("bob@x")
+    assert client.call_count == 2  # rate-limited
+    assert capsys.readouterr().err == ""
+
+    # After another TTL window elapses, we try again exactly once.
+    now[0] = 220.0
+    client.next_error = ConnectionError("still down")
+    directory.is_active("alice@x")
+    directory.is_active("bob@x")
+    assert client.call_count == 3
+
+
 def test_failclosed_when_no_cache_yet() -> None:
     """First fetch failure must surface as OfficeError; we have nothing to serve."""
     client = FakeBambooHRClient()

--- a/tests/test_bamboohr_directory.py
+++ b/tests/test_bamboohr_directory.py
@@ -1,0 +1,148 @@
+"""Tests for the BambooHR-backed EmployeeDirectory.
+
+A ``FakeBambooHRClient`` plays the role of the real REST shim; no
+network calls happen. TTL behavior is exercised with an injected clock;
+fail-open semantics are verified by making the fake raise after the
+first refresh.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import pytest
+
+from office_cli.cli._errors import OfficeError
+from office_cli.people import Employee
+from office_cli.people.bamboohr import BambooHRDirectory, RequestsBambooHRClient
+
+
+class FakeBambooHRClient:
+    def __init__(self, employees: Iterable[Employee] = ()) -> None:
+        self.employees = list(employees)
+        self.call_count = 0
+        self.next_error: Exception | None = None
+
+    def fetch_directory(self) -> list[Employee]:
+        self.call_count += 1
+        if self.next_error is not None:
+            err = self.next_error
+            self.next_error = None
+            raise err
+        return list(self.employees)
+
+
+def _emp(email: str, name: str = "") -> Employee:
+    return Employee(email=email, name=name or email)
+
+
+def test_get_returns_active_employee() -> None:
+    client = FakeBambooHRClient([_emp("alice@x"), _emp("bob@x")])
+    directory = BambooHRDirectory(client, cache_ttl_seconds=99999)
+    assert directory.is_active("alice@x") is True
+    assert directory.get("alice@x").email == "alice@x"
+    assert directory.is_active("ghost@x") is False
+    assert directory.get("ghost@x") is None
+
+
+def test_empty_email_is_inactive() -> None:
+    client = FakeBambooHRClient([_emp("alice@x")])
+    directory = BambooHRDirectory(client, cache_ttl_seconds=99999)
+    assert directory.is_active("") is False
+    assert directory.get("") is None
+
+
+def test_cache_within_ttl_avoids_refetch() -> None:
+    client = FakeBambooHRClient([_emp("alice@x")])
+    directory = BambooHRDirectory(client, cache_ttl_seconds=10, clock=lambda: 0.0)
+    directory.is_active("alice@x")
+    directory.is_active("alice@x")
+    directory.is_active("alice@x")
+    assert client.call_count == 1
+
+
+def test_refresh_after_ttl() -> None:
+    client = FakeBambooHRClient([_emp("alice@x")])
+    now = [0.0]
+    directory = BambooHRDirectory(client, cache_ttl_seconds=10, clock=lambda: now[0])
+    directory.is_active("alice@x")
+    now[0] = 5.0
+    directory.is_active("alice@x")  # still cached
+    now[0] = 100.0
+    directory.is_active("alice@x")  # refresh
+    assert client.call_count == 2
+
+
+def test_offboarding_observed_after_ttl() -> None:
+    """The killer feature: after TTL, removed employees become inactive."""
+    client = FakeBambooHRClient([_emp("alice@x")])
+    now = [0.0]
+    directory = BambooHRDirectory(client, cache_ttl_seconds=10, clock=lambda: now[0])
+    assert directory.is_active("alice@x") is True
+    client.employees = []  # Alice offboarded in BambooHR
+    assert directory.is_active("alice@x") is True  # still cached
+    now[0] = 100.0
+    assert directory.is_active("alice@x") is False  # cache refreshed
+
+
+def test_failopen_serves_stale_cache(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Per #7: BambooHR outages must not stop people finding their seats."""
+    client = FakeBambooHRClient([_emp("alice@x")])
+    now = [0.0]
+    directory = BambooHRDirectory(client, cache_ttl_seconds=10, clock=lambda: now[0])
+    directory.is_active("alice@x")  # seed cache
+    client.next_error = ConnectionError("BambooHR down")
+    now[0] = 100.0
+    # Cache is stale; refresh fails. Must serve cached "alice@x".
+    assert directory.is_active("alice@x") is True
+    err = capsys.readouterr().err
+    assert "BambooHR fetch failed" in err
+    assert "serving cached directory" in err
+
+
+def test_failclosed_when_no_cache_yet() -> None:
+    """First fetch failure must surface as OfficeError; we have nothing to serve."""
+    client = FakeBambooHRClient()
+    client.next_error = ConnectionError("BambooHR down")
+    directory = BambooHRDirectory(client, cache_ttl_seconds=10)
+    with pytest.raises(OfficeError) as exc:
+        directory.is_active("alice@x")
+    assert exc.value.code == 2  # EXIT_ENV_ERROR
+    assert "BambooHR" in exc.value.message
+
+
+def test_invalidate_forces_next_refresh() -> None:
+    client = FakeBambooHRClient([_emp("alice@x")])
+    directory = BambooHRDirectory(client, cache_ttl_seconds=99999, clock=lambda: 0.0)
+    directory.is_active("alice@x")
+    directory.invalidate()
+    directory.is_active("alice@x")
+    assert client.call_count == 2
+
+
+def test_requests_client_validates_required_inputs() -> None:
+    with pytest.raises(OfficeError) as exc:
+        RequestsBambooHRClient(subdomain="", api_token="x")
+    assert "subdomain" in exc.value.message
+    with pytest.raises(OfficeError) as exc:
+        RequestsBambooHRClient(subdomain="x", api_token="")
+    assert "API token" in exc.value.message
+
+
+def test_requests_missing_raises_clear_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If requests isn't installed, RequestsBambooHRClient surfaces OfficeError."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def block_requests(name, *args, **kwargs):
+        if name == "requests":
+            raise ImportError("blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", block_requests)
+    with pytest.raises(OfficeError) as exc:
+        RequestsBambooHRClient(subdomain="x", api_token="t")
+    assert "requests is not installed" in exc.value.message

--- a/tests/test_directory_config.py
+++ b/tests/test_directory_config.py
@@ -1,0 +1,89 @@
+"""Tests for the directory selector in office_cli._config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from office_cli._config import resolve_directory
+from office_cli.cli._errors import OfficeError
+
+
+def _write(data_dir: Path, body: str) -> None:
+    (data_dir / "data").mkdir(parents=True, exist_ok=True)
+    (data_dir / "data" / "offices.yaml").write_text(body, encoding="utf-8")
+
+
+def test_default_is_stub(tmp_path: Path) -> None:
+    cfg = resolve_directory(tmp_path)
+    assert cfg.type == "stub"
+
+
+def test_yaml_block_stub(tmp_path: Path) -> None:
+    _write(tmp_path, "directory:\n  type: stub\n")
+    cfg = resolve_directory(tmp_path)
+    assert cfg.type == "stub"
+
+
+def test_yaml_block_bamboohr(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write(
+        tmp_path,
+        """
+directory:
+  type: bamboohr
+  bamboohr:
+    subdomain: tipalti
+    cache_ttl_seconds: 60
+""".lstrip(),
+    )
+    monkeypatch.setenv("BAMBOOHR_API_TOKEN", "token-xyz")
+    monkeypatch.delenv("BAMBOOHR_SUBDOMAIN", raising=False)
+    cfg = resolve_directory(tmp_path)
+    assert cfg.type == "bamboohr"
+    assert cfg.subdomain == "tipalti"
+    assert cfg.api_token == "token-xyz"
+    assert cfg.cache_ttl_seconds == 60
+
+
+def test_env_overrides_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write(tmp_path, "directory:\n  type: stub\n")
+    monkeypatch.setenv("OFFICE_DIRECTORY", "bamboohr")
+    monkeypatch.setenv("BAMBOOHR_SUBDOMAIN", "from-env")
+    monkeypatch.setenv("BAMBOOHR_API_TOKEN", "tok")
+    cfg = resolve_directory(tmp_path)
+    assert cfg.type == "bamboohr"
+    assert cfg.subdomain == "from-env"
+
+
+def test_bamboohr_requires_subdomain(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_DIRECTORY", "bamboohr")
+    monkeypatch.setenv("BAMBOOHR_API_TOKEN", "tok")
+    monkeypatch.delenv("BAMBOOHR_SUBDOMAIN", raising=False)
+    with pytest.raises(OfficeError) as exc:
+        resolve_directory(tmp_path)
+    assert "subdomain" in exc.value.message
+
+
+def test_bamboohr_requires_api_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_DIRECTORY", "bamboohr")
+    monkeypatch.setenv("BAMBOOHR_SUBDOMAIN", "x")
+    monkeypatch.delenv("BAMBOOHR_API_TOKEN", raising=False)
+    with pytest.raises(OfficeError) as exc:
+        resolve_directory(tmp_path)
+    assert "API token" in exc.value.message
+    assert "env-only" in exc.value.remediation
+
+
+def test_unknown_directory_type_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_DIRECTORY", "active-directory")
+    with pytest.raises(OfficeError) as exc:
+        resolve_directory(tmp_path)
+    assert "unknown directory type" in exc.value.message
+
+
+def test_non_dict_bamboohr_block_rejected(tmp_path: Path) -> None:
+    _write(tmp_path, "directory:\n  type: bamboohr\n  bamboohr: nope\n")
+    with pytest.raises(OfficeError) as exc:
+        resolve_directory(tmp_path)
+    assert "must be a mapping" in exc.value.message

--- a/tests/test_directory_config.py
+++ b/tests/test_directory_config.py
@@ -82,6 +82,46 @@ def test_unknown_directory_type_rejected(tmp_path: Path, monkeypatch: pytest.Mon
     assert "unknown directory type" in exc.value.message
 
 
+def test_ttl_capped_at_five_minutes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Qodo Q1: cache_ttl_seconds > 300 violates the v1 5-minute cap."""
+    _write(
+        tmp_path,
+        """
+directory:
+  type: bamboohr
+  bamboohr:
+    subdomain: tipalti
+    cache_ttl_seconds: 600
+""".lstrip(),
+    )
+    monkeypatch.setenv("BAMBOOHR_API_TOKEN", "tok")
+    with pytest.raises(OfficeError) as exc:
+        resolve_directory(tmp_path)
+    assert "must not exceed 300" in exc.value.message
+    assert "5 minutes" in exc.value.remediation
+
+
+def test_directory_errors_reference_directory_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Copilot #2/#3: error messages on directory config must say
+    'directory.bamboohr.*', not 'storage.*'."""
+    _write(
+        tmp_path,
+        """
+directory:
+  type: bamboohr
+  bamboohr:
+    subdomain: tipalti
+    cache_ttl_seconds: not-a-number
+""".lstrip(),
+    )
+    monkeypatch.setenv("BAMBOOHR_API_TOKEN", "tok")
+    with pytest.raises(OfficeError) as exc:
+        resolve_directory(tmp_path)
+    assert "directory.bamboohr.cache_ttl_seconds" in exc.value.message
+
+
 def test_non_dict_bamboohr_block_rejected(tmp_path: Path) -> None:
     _write(tmp_path, "directory:\n  type: bamboohr\n  bamboohr: nope\n")
     with pytest.raises(OfficeError) as exc:

--- a/tests/test_seats_service_autovacate.py
+++ b/tests/test_seats_service_autovacate.py
@@ -1,0 +1,76 @@
+"""End-to-end tests for the auto-vacate killer feature.
+
+When BambooHR stops listing an employee, every seat assigned to them
+must render as vacant — without anyone touching the assignment store.
+The audit log and the underlying CSV row stay unchanged.
+"""
+
+from __future__ import annotations
+
+from itertools import count
+from pathlib import Path
+
+from office_cli.floors import parse_svg
+from office_cli.offices import load_offices
+from office_cli.people import Employee
+from office_cli.people.bamboohr import BambooHRDirectory
+from office_cli.seats import CsvAuditLog, CsvStore, SeatService
+from tests.test_bamboohr_directory import FakeBambooHRClient
+
+
+def _service(data_dir: Path, directory: BambooHRDirectory) -> SeatService:
+    offices = load_offices(data_dir)
+    floor_svgs = {}
+    for office in offices.values():
+        for floor_id, floor in office.floors.items():
+            if floor.svg.is_file():
+                floor_svgs[floor_id] = parse_svg(floor.svg)
+    counter = count(1)
+
+    def clock() -> str:
+        return f"2026-05-01T00:00:{next(counter):02d}Z"
+
+    return SeatService(
+        offices=offices,
+        floor_svgs=floor_svgs,
+        store=CsvStore(data_dir / "seats" / "assignments.csv"),
+        audit=CsvAuditLog(data_dir / "seats" / "audit-log.csv"),
+        actor="cli",
+        clock=clock,
+        directory=directory,
+    )
+
+
+def test_autovacate_on_offboarding(data_dir: Path) -> None:
+    client = FakeBambooHRClient([Employee(email="alice@example.com", name="Alice")])
+    now = [0.0]
+    directory = BambooHRDirectory(client, cache_ttl_seconds=10, clock=lambda: now[0])
+    s = _service(data_dir, directory)
+
+    s.assign("5-T-01", "alice@example.com")
+    # While Alice is active: list shows her seat as occupied.
+    rows = s.list_seats(only_occupied=True)
+    assert [a.seat_id for a in rows] == ["5-T-01"]
+    assert s.whereis("alice@example.com").seat_id == "5-T-01"
+
+    # Alice is offboarded in BambooHR.
+    client.employees = []
+    # Within the cache TTL the seat still appears occupied (5-min staleness
+    # is the documented behavior).
+    rows = s.list_seats(only_occupied=True)
+    assert [a.seat_id for a in rows] == ["5-T-01"]
+
+    # After TTL expires, auto-vacate kicks in.
+    now[0] = 100.0
+    rows = s.list_seats(only_occupied=True)
+    assert rows == []
+    rows = s.list_seats(only_vacant=True)
+    assert "5-T-01" in {a.seat_id for a in rows}
+    assert s.whereis("alice@example.com") is None
+
+    # The data on disk is unchanged: history still shows the original
+    # assign, and the CSV row still names alice.
+    history = s.history("5-T-01")
+    assert [e.action for e in history] == ["assign"]
+    raw = (data_dir / "seats" / "assignments.csv").read_text(encoding="utf-8")
+    assert "alice@example.com" in raw

--- a/uv.lock
+++ b/uv.lock
@@ -485,13 +485,16 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
 ]
 
 [package.optional-dependencies]
+bamboohr = [
+    { name = "requests" },
+]
 sheets = [
     { name = "gspread" },
 ]
@@ -511,8 +514,9 @@ dev = [
 requires-dist = [
     { name = "gspread", marker = "extra == 'sheets'", specifier = ">=6.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "requests", marker = "extra == 'bamboohr'", specifier = ">=2.31" },
 ]
-provides-extras = ["sheets"]
+provides-extras = ["sheets", "bamboohr"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Stage 3 of the v1 seating system per
[issue #1](https://github.com/agentculture/office-agent/issues/1) and tracked in
[#7](https://github.com/agentculture/office-agent/issues/7). Implements the
**auto-vacate killer feature**: when an employee is removed from BambooHR's
`/v1/employees/directory` response, every seat assigned to them renders as
vacant — without mutating the assignment store.

- **`office_cli.people.bamboohr` package** — `BambooHRClient` Protocol +
  `RequestsBambooHRClient` adapter (lazy `requests` import; subdomain/token
  validated before the import check so config errors surface cleanly with
  or without the extra), plus `BambooHRDirectory` (5-min TTL cache,
  fail-open on refresh errors with a stale-but-served snapshot, fail-closed
  only on the very first fetch).
- **Storage / directory selectors** — `office_cli._config.resolve_directory`
  picks the backend from the `directory:` block in `data/offices.yaml` with
  `OFFICE_DIRECTORY` / `BAMBOOHR_API_TOKEN` / `BAMBOOHR_SUBDOMAIN` env
  overrides. The API token is **env-only** by design (never in YAML).
- **Service-layer auto-vacate** — `SeatService._apply_autovacate` clears
  `employee_email` (and resets `hidden`) for any row whose stored email is
  no longer active in the directory. Applied uniformly in `list_seats` and
  `whereis`. The store row stays unchanged; reactivating restores the seat
  without any write.
- **`build_service`** resolves and threads through both the storage and
  directory backends — no caller-side change needed.
- **Optional extra** — `pip install office-cli[bamboohr]` pulls
  `requests>=2.31`. CSV/Sheets/stub paths still work without the dep tree.

## Test plan

- [x] `uv run pytest -n auto -v` — 115 tests pass: existing 96 plus
  - BambooHR directory: get/is_active happy path, empty-email handling,
    cache hit within TTL, refresh after TTL, **offboarding observed
    after TTL** (the killer feature), fail-open with stale cache,
    fail-closed without a cache, invalidate, requests-missing →
    OfficeError, RequestsBambooHRClient validation errors;
  - Directory config: default-stub, yaml-stub, yaml-bamboohr,
    env-overrides-yaml, missing-subdomain rejected, missing-token
    rejected, unknown-type rejected, non-dict bamboohr block rejected;
  - End-to-end auto-vacate flow: assign while active → list shows
    occupied; offboard → list still shows occupied within TTL; after
    TTL → list shows vacant, `whereis` returns None, history still
    shows the original assign, CSV row still names the (now offboarded)
    email — proving the row was *not* mutated.
- [x] black / isort / flake8 / bandit / markdownlint clean.
- [x] `steward doctor . --scope self` clean.
- [x] `uv build` produces 0.3.0 wheel + sdist.

## Out of scope (Stage 4+)

- Slack `/whereis` slash command. The CLI `whereis` already shows the
  auto-vacate behavior; the Slack surface is its own issue
  ([#8](https://github.com/agentculture/office-agent/issues/8)).
- Web frontend, effective-date enforcement, SSO/roles, DynamoDB store —
  enumerated in `docs/architecture.md`.

- Claude

Generated with Claude Code