### PR TITLE
feat: v1 seating Stage 4 — Slack /whereis slash command (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-01
+
+### Added
+
+- v1 seating Stage 4 — Slack `/whereis` slash command
+  ([#8](https://github.com/agentculture/office-agent/issues/8)). New
+  `office_cli.slack` subpackage wraps `SeatService.whereis` in a
+  `slack_bolt` app and ships a `office slack-serve` CLI verb that
+  blocks on `SocketModeHandler.start()`.
+- New optional extra: `pip install office-cli[slack]` pulls
+  `slack-bolt>=1.18` and `slack-sdk>=3.27`. The package still imports
+  cleanly without it (lazy import inside `_serve.py`).
+- Slash command supports three invocation shapes — `/whereis`
+  (caller's own seat via `users.info`), `/whereis @user`
+  (`<@U…>` mention parsed and resolved to email), and
+  `/whereis email@domain` (plain text fallback).
+- Block Kit response is **ephemeral by default** — only the caller
+  sees the result. A deep-link button to the web map surfaces when
+  `OFFICE_WEB_BASE_URL` is set (Stage 5 placeholder until the map
+  ships).
+- `hidden=TRUE` seats render as "occupied (private)" with no
+  email/notes leakage; full-detail rendering is gated behind Stage 7
+  roles.
+
 ## [0.3.0] - 2026-05-01
 
 ### Added
@@ -105,7 +129,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   preserving the SVG ID contract and architectural guardrails for the v1
   seating system (issue #1).
 
-[Unreleased]: https://github.com/agentculture/office-agent/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/agentculture/office-agent/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/agentculture/office-agent/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/agentculture/office-agent/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/agentculture/office-agent/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/agentculture/office-agent/compare/v0.0.1...v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ office-agent/
 │   ├── floors/                  # SVG parse + ID contract + validator
 │   ├── seats/                   # AssignmentStore + Csv/Sheets stores + AuditLog + SeatService
 │   ├── people/                  # Employee + EmployeeDirectory (Stub + BambooHR backends)
+│   ├── slack/                   # `/whereis` Bolt app + Socket Mode runner (optional [slack] extra)
 │   └── explain/                 # Markdown catalog for `office explain <path>`
 ├── data/offices.yaml            # office / floor / cluster topology
 ├── floors/                      # human-traced floor SVGs
@@ -58,7 +59,7 @@ office-agent/
 ```bash
 uv sync                           # install runtime + dev deps
 uv run pytest -n auto -v          # full suite, parallel
-uv run office --version           # 0.3.0
+uv run office --version           # 0.4.0
 uv run office learn               # agent affordance
 uv run office whoami              # auth probe stub
 uv run office floors validate floors/tlv-floor-5.svg

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ BambooHR; assignments live in a Google Sheet (v1) or DynamoDB (v2). The
 CLI exposes the same operations as the Slack `/whereis` command and the
 web map.
 
-> **Status — v0.3.0.** Stages 1 + 2 + 3 of the v1 seating system are
-> in: floor SVG parser/validator, CSV / Google Sheets-backed assignment
+> **Status — v0.4.0.** Stages 1–4 of the v1 seating system are in:
+> floor SVG parser/validator, CSV / Google Sheets-backed assignment
 > store with append-only audit log, BambooHR-backed `EmployeeDirectory`
-> with the auto-vacate killer feature, and CLI verbs (`floors`,
-> `seats`, `whereis`). Slack `/whereis` and the web map land in later
-> stages on top of the same `office_cli.seats` service. See
+> with the auto-vacate killer feature, CLI verbs (`floors`, `seats`,
+> `whereis`), and a Slack `/whereis` slash-command listener. The web
+> map and remaining stages land on top of the same `office_cli.seats`
+> service. See
 > [issue #1](https://github.com/agentculture/office-agent/issues/1).
 
 ## Naming surfaces
@@ -108,6 +109,35 @@ directory:
 The directory affects rendering only; assignments stay in the store
 unchanged. Re-activating an employee in BambooHR restores their seat
 without any write.
+
+### Slack `/whereis`
+
+Run a Slack `/whereis` slash command backed by the same `SeatService`:
+
+```bash
+pip install office-cli[slack]
+export SLACK_BOT_TOKEN=xoxb-...
+export SLACK_APP_TOKEN=xapp-...
+office slack-serve
+```
+
+Required Slack app scopes:
+
+- `commands` — to register `/whereis`.
+- `users:read.email` — for `users.info` to return `profile.email`.
+- `chat:write` — to post the ephemeral response.
+
+Three invocation shapes:
+
+- `/whereis` — looks up the caller's own seat.
+- `/whereis @user` — Slack mention; resolves the user's email.
+- `/whereis email@domain` — plain text fallback.
+
+Responses are **ephemeral by default** — only the caller sees them.
+`hidden=TRUE` seats render as "occupied (private)" until role gating
+(Stage 7) lifts the filter for privileged callers. Setting
+`OFFICE_WEB_BASE_URL` adds an "Open map" deep-link button to the
+response (placeholder until the web map ships in Stage 5).
 
 ## Adding a new floor
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture — v0.3.0 (Stages 1–3)
+# Architecture — v0.4.0 (Stages 1–4)
 
 `office` ships in stages on top of issue
 [#1](https://github.com/agentculture/office-agent/issues/1). This document
@@ -150,13 +150,51 @@ export BAMBOOHR_SUBDOMAIN=tipalti
 export BAMBOOHR_API_TOKEN=...
 ```
 
+## Stage 4 — implemented in v0.4.0
+
+- `office_cli.slack` subpackage wraps `SeatService.whereis` in a
+  `slack_bolt` app. The handler is structurally typed (any `client`
+  with `users_info` + `chat_postEphemeral`) so unit tests use a
+  `FakeSlackApp` + `FakeSlackClient` and never touch the SDK or the
+  network.
+- New CLI verb `office slack-serve` blocks on
+  `SocketModeHandler.start()`. **Socket Mode only** for v1 — no HTTP
+  endpoint, no signing-secret middleware. Requires both
+  `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN`.
+- Three invocation shapes for `/whereis`:
+  - empty → look up the caller's seat (resolves their email via
+    `users.info`),
+  - `<@U…>` mention → resolve mentioned user's email,
+  - plain text containing an email → use it directly.
+- Responses are **ephemeral** by default — looking up a coworker's
+  seat does not broadcast to the channel. `hidden=TRUE` seats render
+  as "occupied (private)" with no email/notes leakage; Stage 7 will
+  lift the filter for `editor`/`planning` roles.
+- Setting `OFFICE_WEB_BASE_URL` adds an "Open map" deep-link button
+  (placeholder until Stage 5 ships the web map).
+- BambooHR auto-vacate (Stage 3) flows through transparently: a
+  `/whereis` for an offboarded employee returns "no seat assigned".
+
+Install the extra to use Slack:
+
+```bash
+pip install office-cli[slack]
+```
+
+Run:
+
+```bash
+SLACK_BOT_TOKEN=xoxb-... SLACK_APP_TOKEN=xapp-... office slack-serve
+```
+
+Required Slack app scopes: `commands`, `users:read.email`, `chat:write`.
+
 ## Deferred surfaces
 
 Each is a separate issue/PR.
 
 | Stage              | Surface                                       | Notes                                                                   |
 | ------------------ | --------------------------------------------- | ----------------------------------------------------------------------- |
-| 4. Slack `/whereis`| `office_slack/` Bolt app                      | Imports `SeatService.whereis`; renders Block Kit with deep link.        |
 | 5. Web frontend    | `office_web/` (Vite + a small Python server)  | Search-first map, `?asOf=YYYY-MM-DD`, role-aware `hidden` rendering.    |
 | 6. Effective dates | service-layer `effective_from / _until`       | Columns already exist; the service starts honoring them.                |
 | 7. SSO + roles     | viewer / editor / planning                    | Drives whether `hidden=TRUE` rows expose details.                       |

--- a/office_cli/cli/__init__.py
+++ b/office_cli/cli/__init__.py
@@ -20,6 +20,7 @@ from office_cli.cli._commands import explain as _explain_cmd
 from office_cli.cli._commands import floors as _floors_cmd
 from office_cli.cli._commands import learn as _learn_cmd
 from office_cli.cli._commands import seats as _seats_cmd
+from office_cli.cli._commands import slack_serve as _slack_serve_cmd
 from office_cli.cli._commands import whereis as _whereis_cmd
 from office_cli.cli._commands import whoami as _whoami_cmd
 from office_cli.cli._errors import EXIT_INTERNAL_ERROR, EXIT_USER_ERROR, OfficeError
@@ -53,6 +54,7 @@ def _build_parser() -> argparse.ArgumentParser:
     _floors_cmd.register(sub)
     _seats_cmd.register(sub)
     _whereis_cmd.register(sub)
+    _slack_serve_cmd.register(sub)
 
     return parser
 

--- a/office_cli/cli/_commands/slack_serve.py
+++ b/office_cli/cli/_commands/slack_serve.py
@@ -75,11 +75,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     )
     p.add_argument(
         "--bot-token",
-        help="Override SLACK_BOT_TOKEN (xoxb-…). Env takes precedence if both unset.",
+        help="Override SLACK_BOT_TOKEN (xoxb-…); otherwise falls back to the env var.",
     )
     p.add_argument(
         "--app-token",
-        help="Override SLACK_APP_TOKEN (xapp-…). Env takes precedence if both unset.",
+        help="Override SLACK_APP_TOKEN (xapp-…); otherwise falls back to the env var.",
     )
     add_data_dir_arg(p)
     p.set_defaults(func=cmd_slack_serve)

--- a/office_cli/cli/_commands/slack_serve.py
+++ b/office_cli/cli/_commands/slack_serve.py
@@ -1,0 +1,85 @@
+"""``office slack-serve`` — run the Slack ``/whereis`` Socket Mode listener.
+
+Blocks until the process is interrupted. Configuration is env-first so
+operators can drop the verb into a systemd / docker entry point without
+juggling flags; ``--bot-token`` / ``--app-token`` overrides exist for
+local dev.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from office_cli._config import add_data_dir_arg, resolve_data_dir
+from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
+from office_cli.cli._output import emit_diagnostic
+from office_cli.seats import build_service
+
+
+def cmd_slack_serve(args: argparse.Namespace) -> int:
+    bot_token = (args.bot_token or os.environ.get("SLACK_BOT_TOKEN") or "").strip()
+    app_token = (args.app_token or os.environ.get("SLACK_APP_TOKEN") or "").strip()
+    if not bot_token:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message="SLACK_BOT_TOKEN is empty",
+            remediation=(
+                "set SLACK_BOT_TOKEN (xoxb-…) in the env or pass --bot-token. "
+                "The bot needs the `commands`, `users:read.email`, and "
+                "`chat:write` scopes."
+            ),
+        )
+    if not app_token:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message="SLACK_APP_TOKEN is empty",
+            remediation=(
+                "set SLACK_APP_TOKEN (xapp-…) in the env or pass --app-token. "
+                "Socket Mode needs an app-level token from the Slack app's "
+                "Basic Information page."
+            ),
+        )
+
+    data_dir = resolve_data_dir(args)
+    service = build_service(data_dir, actor="slack")
+
+    # slack_bolt is imported lazily inside `build_app` / `run_socket_mode`
+    # so a missing extra surfaces as a clear OfficeError.
+    try:
+        from slack_bolt import App
+    except ImportError as err:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message="slack-bolt is not installed",
+            remediation=("install the slack extra: pip install office-cli[slack]"),
+        ) from err
+    from office_cli.slack import build_app, run_socket_mode
+
+    app = App(token=bot_token)
+    build_app(service, app=app)
+    emit_diagnostic("Slack /whereis listener starting (Socket Mode)…")
+    run_socket_mode(app, app_token)
+    return 0
+
+
+def register(sub: argparse._SubParsersAction) -> None:
+    p = sub.add_parser(
+        "slack-serve",
+        help="Run the Slack /whereis listener (Socket Mode).",
+        description=(
+            "Blocking Socket Mode listener that wires Slack /whereis to "
+            "office_cli.seats.SeatService. Requires the [slack] extra "
+            "and both SLACK_BOT_TOKEN (xoxb-…) and SLACK_APP_TOKEN (xapp-…)."
+        ),
+    )
+    p.add_argument(
+        "--bot-token",
+        help="Override SLACK_BOT_TOKEN (xoxb-…). Env takes precedence if both unset.",
+    )
+    p.add_argument(
+        "--app-token",
+        help="Override SLACK_APP_TOKEN (xapp-…). Env takes precedence if both unset.",
+    )
+    add_data_dir_arg(p)
+    p.set_defaults(func=cmd_slack_serve)

--- a/office_cli/explain/catalog.py
+++ b/office_cli/explain/catalog.py
@@ -28,6 +28,8 @@ service layer.
   seat assignments (CSV-backed in v0.1.0).
 - `office whereis EMAIL` — find a person's seat (CLI mirror of Slack
   `/whereis`).
+- `office slack-serve` — run the Slack `/whereis` Socket Mode listener
+  (requires `pip install office-cli[slack]`).
 
 ## Exit-code policy
 
@@ -45,6 +47,7 @@ service layer.
 - `office explain floors`
 - `office explain seats`
 - `office explain whereis`
+- `office explain slack-serve`
 """
 
 _LEARN = """\
@@ -222,8 +225,8 @@ append-only.
 _WHEREIS = """\
 # office whereis EMAIL
 
-Find a person's current seat by email. The CLI mirror of the (planned)
-Slack `/whereis` slash command — both surfaces call the same
+Find a person's current seat by email. The CLI mirror of the Slack
+`/whereis` slash command — both surfaces call the same
 `SeatService.whereis` underneath.
 
 ## Usage
@@ -233,6 +236,49 @@ Slack `/whereis` slash command — both surfaces call the same
 
 Exits 0 even when no seat is found; the JSON payload reports
 `assignment: null` so callers can disambiguate.
+"""
+
+_SLACK_SERVE = """\
+# office slack-serve
+
+Run the Slack `/whereis` slash-command listener in Socket Mode. Blocks
+until the process is interrupted. Requires the optional `[slack]`
+extra (`pip install office-cli[slack]`).
+
+## Usage
+
+    office slack-serve
+    office slack-serve --bot-token xoxb-... --app-token xapp-...
+    office slack-serve --data-dir /path/to/checkout
+
+## Configuration
+
+Required env (or matching CLI flag):
+
+- `SLACK_BOT_TOKEN` (`xoxb-…`) — bot user token. Needs the `commands`,
+  `users:read.email`, and `chat:write` scopes.
+- `SLACK_APP_TOKEN` (`xapp-…`) — app-level token from the Slack app's
+  Basic Information page (Socket Mode).
+
+Optional:
+
+- `OFFICE_WEB_BASE_URL` — base URL for the web map; when set, the
+  ephemeral response includes a deep-link button to the seat.
+- `OFFICE_DATA_DIR` (or `--data-dir`) — same convention as the rest
+  of the CLI.
+
+## Behavior
+
+- Empty text → looks up the caller's seat (resolves their email via
+  `users.info`).
+- `<@U…>` mention → resolves the mentioned user's email.
+- Plain text containing an email → uses the first email-shaped token.
+- Garbage → ephemeral parse-failed response.
+- Hidden seats (`hidden=TRUE`) render as "occupied (private)" with no
+  email/notes leakage until role gating (Stage 7) lifts the filter for
+  privileged callers.
+
+Responses are **ephemeral** — only the caller sees them.
 """
 
 
@@ -250,4 +296,5 @@ ENTRIES: dict[tuple[str, ...], str] = {
     ("seats", "move"): _SEATS_MOVE,
     ("seats", "history"): _SEATS_HISTORY,
     ("whereis",): _WHEREIS,
+    ("slack-serve",): _SLACK_SERVE,
 }

--- a/office_cli/slack/__init__.py
+++ b/office_cli/slack/__init__.py
@@ -1,0 +1,22 @@
+"""Slack integration for the v1 seating system.
+
+Wraps :func:`office_cli.seats.SeatService.whereis` in a Slack Bolt app
+that exposes the ``/whereis`` slash command. Two entry points:
+
+* :func:`build_app` — register the listener on a (caller-supplied or
+  newly-constructed) :class:`slack_bolt.App`. Used by the CLI verb and
+  unit tests (which can pass a fake app).
+* :func:`run_socket_mode` — block on Slack's Socket Mode connection.
+
+``slack_bolt`` is **not** imported at package-load time; it is pulled
+lazily inside :func:`run_socket_mode` and the default-app branch of
+:func:`build_app`. That way installations without the ``[slack]`` extra
+can still import :mod:`office_cli` cleanly.
+"""
+
+from __future__ import annotations
+
+from office_cli.slack._app import build_app
+from office_cli.slack._serve import run_socket_mode
+
+__all__ = ["build_app", "run_socket_mode"]

--- a/office_cli/slack/_app.py
+++ b/office_cli/slack/_app.py
@@ -1,0 +1,96 @@
+"""``/whereis`` slash-command handler wired onto a slack_bolt App.
+
+The handler is structurally typed: it expects an ``ack`` callable, a
+``client`` with ``users_info`` + ``chat_postEphemeral`` methods, and a
+``command`` dict. Tests pass a small ``FakeSlackContext`` instead of a
+real Bolt app, so this module never needs the SDK at import time.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from office_cli.seats import SeatService
+from office_cli.slack import _blocks
+from office_cli.slack._resolve import ParsedTarget, parse_target
+
+
+def build_app(service: SeatService, *, app: Any | None = None) -> Any:
+    """Register the ``/whereis`` listener and return the configured app.
+
+    If ``app`` is ``None`` we construct a default ``slack_bolt.App``
+    (which reads ``SLACK_BOT_TOKEN`` from the env). Tests pass a fake
+    app exposing only ``.command(name)``.
+    """
+    if app is None:
+        from slack_bolt import App
+
+        app = App()
+
+    @app.command("/whereis")
+    def _handle_whereis(ack: Callable[[], None], body: dict, command: dict, client: Any) -> None:
+        ack()
+        text = command.get("text", "")
+        target = parse_target(text)
+        blocks, label = _resolve_and_lookup(service, client, body, target)
+        client.chat_postEphemeral(
+            channel=body.get("channel_id", ""),
+            user=body.get("user_id", ""),
+            blocks=blocks,
+            text=label,  # fallback for clients that ignore blocks
+        )
+
+    return app
+
+
+def _resolve_and_lookup(
+    service: SeatService,
+    client: Any,
+    body: dict,
+    target: ParsedTarget,
+) -> tuple[list[dict[str, Any]], str]:
+    """Resolve a :class:`ParsedTarget` to an email + label and run lookup."""
+    if not target.ok:
+        return _blocks.parse_failed(target.raw), "couldn't parse"
+
+    if target.email:
+        email = target.email
+        label = email
+        return _lookup(service, email, label)
+
+    user_id = target.user_id or body.get("user_id", "")
+    if not user_id:
+        return _blocks.lookup_failed("no Slack user id supplied"), "no user id"
+
+    email, fail_reason = _email_from_user_id(client, user_id)
+    if not email:
+        return _blocks.lookup_failed(fail_reason), "lookup failed"
+    # When the caller asked about themselves, label as "you"; otherwise
+    # use the @-mention so Slack renders the name.
+    label = f"<@{user_id}>" if not target.self_lookup else "you"
+    return _lookup(service, email, label)
+
+
+def _email_from_user_id(client: Any, user_id: str) -> tuple[str, str]:
+    """Return ``(email, "")`` on success, ``("", reason)`` on failure."""
+    try:
+        resp = client.users_info(user=user_id)
+    except Exception as err:  # noqa: BLE001 — surface as ephemeral message
+        return "", f"users.info call failed ({err.__class__.__name__})"
+    user = (resp or {}).get("user") or {}
+    profile = user.get("profile") or {}
+    email = (profile.get("email") or "").strip()
+    if not email:
+        return "", (
+            "no email on that Slack profile (the bot needs the " "`users:read.email` scope)"
+        )
+    return email, ""
+
+
+def _lookup(service: SeatService, email: str, label: str) -> tuple[list[dict[str, Any]], str]:
+    assignment = service.whereis(email)
+    if assignment is None:
+        return _blocks.no_seat(label), f"no seat for {email}"
+    if assignment.hidden:
+        return _blocks.hidden_private(assignment, target_label=label), "occupied (private)"
+    return _blocks.occupied(assignment, target_label=label), f"{label} → {assignment.seat_id}"

--- a/office_cli/slack/_app.py
+++ b/office_cli/slack/_app.py
@@ -32,10 +32,14 @@ def build_app(service: SeatService, *, app: Any | None = None) -> Any:
         ack()
         text = command.get("text", "")
         target = parse_target(text)
-        blocks, label = _resolve_and_lookup(service, client, body, target)
+        blocks, label = _resolve_and_lookup(service, client, body, command, target)
+        # ``command`` is the slash-command payload and is the canonical
+        # source for ``channel_id``/``user_id``; ``body`` is the Bolt-
+        # wrapped envelope and may differ in some adapter shapes. Prefer
+        # command, fall back to body.
         client.chat_postEphemeral(
-            channel=body.get("channel_id", ""),
-            user=body.get("user_id", ""),
+            channel=command.get("channel_id") or body.get("channel_id", ""),
+            user=command.get("user_id") or body.get("user_id", ""),
             blocks=blocks,
             text=label,  # fallback for clients that ignore blocks
         )
@@ -47,6 +51,7 @@ def _resolve_and_lookup(
     service: SeatService,
     client: Any,
     body: dict,
+    command: dict,
     target: ParsedTarget,
 ) -> tuple[list[dict[str, Any]], str]:
     """Resolve a :class:`ParsedTarget` to an email + label and run lookup."""
@@ -58,7 +63,7 @@ def _resolve_and_lookup(
         label = email
         return _lookup(service, email, label)
 
-    user_id = target.user_id or body.get("user_id", "")
+    user_id = target.user_id or command.get("user_id") or body.get("user_id", "")
     if not user_id:
         return _blocks.lookup_failed("no Slack user id supplied"), "no user id"
 
@@ -67,7 +72,7 @@ def _resolve_and_lookup(
         return _blocks.lookup_failed(fail_reason), "lookup failed"
     # When the caller asked about themselves, label as "you"; otherwise
     # use the @-mention so Slack renders the name.
-    label = f"<@{user_id}>" if not target.self_lookup else "you"
+    label = "you" if target.self_lookup else f"<@{user_id}>"
     return _lookup(service, email, label)
 
 
@@ -81,16 +86,17 @@ def _email_from_user_id(client: Any, user_id: str) -> tuple[str, str]:
     profile = user.get("profile") or {}
     email = (profile.get("email") or "").strip()
     if not email:
-        return "", (
-            "no email on that Slack profile (the bot needs the " "`users:read.email` scope)"
-        )
+        return "", ("no email on that Slack profile (the bot needs the `users:read.email` scope)")
     return email, ""
 
 
 def _lookup(service: SeatService, email: str, label: str) -> tuple[list[dict[str, Any]], str]:
+    # Both blocks and the `text` fallback use ``label`` so we never leak
+    # the resolved profile email through the screen-reader / older-client
+    # rendering path — it would defeat the redaction the blocks rely on.
     assignment = service.whereis(email)
     if assignment is None:
-        return _blocks.no_seat(label), f"no seat for {email}"
+        return _blocks.no_seat(label), f"no seat for {label}"
     if assignment.hidden:
         return _blocks.hidden_private(assignment, target_label=label), "occupied (private)"
     return _blocks.occupied(assignment, target_label=label), f"{label} → {assignment.seat_id}"

--- a/office_cli/slack/_blocks.py
+++ b/office_cli/slack/_blocks.py
@@ -1,0 +1,115 @@
+"""Block Kit response builders for the ``/whereis`` slash command.
+
+Every builder returns a list of `Block Kit
+<https://api.slack.com/block-kit>`_ blocks suitable for
+``chat.postEphemeral``'s ``blocks`` field. We never include user names
+or notes when ``hidden=True`` — that's the v1 privacy contract until
+Stage 7 lands roles.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from office_cli.seats import Assignment
+
+
+def _deep_link_button(seat_id: str, floor: str) -> dict[str, Any] | None:
+    base = (os.environ.get("OFFICE_WEB_BASE_URL") or "").rstrip("/")
+    if not base:
+        return None
+    url = f"{base}/floors/{floor}?seat={seat_id}"
+    return {
+        "type": "actions",
+        "elements": [
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Open map"},
+                "url": url,
+            }
+        ],
+    }
+
+
+def occupied(assignment: Assignment, *, target_label: str) -> list[dict[str, Any]]:
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    f"*{target_label}* sits at *{assignment.seat_id}* " f"on `{assignment.floor}`."
+                ),
+            },
+        }
+    ]
+    if assignment.last_updated:
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"_last updated {assignment.last_updated}_",
+                    }
+                ],
+            }
+        )
+    button = _deep_link_button(assignment.seat_id, assignment.floor)
+    if button:
+        blocks.append(button)
+    return blocks
+
+
+def hidden_private(assignment: Assignment, *, target_label: str) -> list[dict[str, Any]]:
+    """Hidden seat — render the floor but not the email or notes."""
+    return [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (f"*{target_label}* — occupied (private) on " f"`{assignment.floor}`."),
+            },
+        }
+    ]
+
+
+def no_seat(target_label: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"No seat assigned for *{target_label}*.",
+            },
+        }
+    ]
+
+
+def parse_failed(raw: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    f"Couldn't parse a person from `{raw}`. Pass an "
+                    "`@mention` or an `email@address`."
+                ),
+            },
+        }
+    ]
+
+
+def lookup_failed(reason: str) -> list[dict[str, Any]]:
+    """Used when a Slack mention's email is missing or `users.info` fails."""
+    return [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"Couldn't resolve that person to an email: {reason}.",
+            },
+        }
+    ]

--- a/office_cli/slack/_blocks.py
+++ b/office_cli/slack/_blocks.py
@@ -39,7 +39,7 @@ def occupied(assignment: Assignment, *, target_label: str) -> list[dict[str, Any
             "text": {
                 "type": "mrkdwn",
                 "text": (
-                    f"*{target_label}* sits at *{assignment.seat_id}* " f"on `{assignment.floor}`."
+                    f"*{target_label}* sits at *{assignment.seat_id}* on `{assignment.floor}`."
                 ),
             },
         }
@@ -69,7 +69,7 @@ def hidden_private(assignment: Assignment, *, target_label: str) -> list[dict[st
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": (f"*{target_label}* — occupied (private) on " f"`{assignment.floor}`."),
+                "text": f"*{target_label}* — occupied (private) on `{assignment.floor}`.",
             },
         }
     ]

--- a/office_cli/slack/_resolve.py
+++ b/office_cli/slack/_resolve.py
@@ -11,6 +11,17 @@ The Slack listener handles three input shapes:
 This module is pure: it does not import the Slack SDK and never makes
 network calls. All resolution that needs ``users.info`` is done by the
 caller using the parsed user id.
+
+ReDoS safety
+------------
+Slack caps slash-command text at ~3000 characters; we further reject
+input over :data:`_MAX_INPUT_LEN` (256) before any regex runs. The
+email regex is split into a literal-dot-separated label structure
+(``[A-Za-z0-9-]+`` segments + ``\\.`` separators) so the character
+classes do not overlap with the dot — eliminating the polynomial
+backtracking the original ``[A-Za-z0-9.-]+\\.[A-Za-z]{2,}`` form
+exhibited on adversarial inputs like ``a@b.b.b.b…`` without a valid
+TLD.
 """
 
 from __future__ import annotations
@@ -18,8 +29,11 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+_MAX_INPUT_LEN = 256
 _MENTION_RE = re.compile(r"<@(?P<user_id>[UW][A-Z0-9]+)(?:\|[^>]*)?>")
-_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+# Domain labels intentionally exclude `.` so the literal `\.` separators
+# are unambiguous — no overlapping classes, no super-linear backtracking.
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}")
 
 
 @dataclass(frozen=True)
@@ -47,9 +61,16 @@ def parse_target(text: str) -> ParsedTarget:
 
     Mention parsing happens *before* email parsing so a "user with
     `<@U123>` profile email" mention does not slip through as plain
-    text. Whitespace-only / empty text → ``self_lookup``.
+    text. Whitespace-only / empty text → ``self_lookup``. Input over
+    :data:`_MAX_INPUT_LEN` short-circuits to a parse failure with the
+    raw input truncated for the response message — defense in depth
+    against runaway regex evaluation, even though both regexes are
+    constructed to run in linear time.
     """
-    stripped = (text or "").strip()
+    raw = text or ""
+    if len(raw) > _MAX_INPUT_LEN:
+        return ParsedTarget(raw=raw[:_MAX_INPUT_LEN] + "…")
+    stripped = raw.strip()
     if not stripped:
         return ParsedTarget(self_lookup=True, raw="")
 

--- a/office_cli/slack/_resolve.py
+++ b/office_cli/slack/_resolve.py
@@ -1,0 +1,64 @@
+"""Pure parsers for the ``/whereis`` slash-command argument.
+
+The Slack listener handles three input shapes:
+
+* empty text → caller asks about their own seat (``user_id`` from the
+  command body, resolved via ``users.info``);
+* ``<@U123|alice>`` mention → Slack-encoded user reference; we extract
+  the user id and resolve via ``users.info``;
+* plain text containing an email — used directly.
+
+This module is pure: it does not import the Slack SDK and never makes
+network calls. All resolution that needs ``users.info`` is done by the
+caller using the parsed user id.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_MENTION_RE = re.compile(r"<@(?P<user_id>[UW][A-Z0-9]+)(?:\|[^>]*)?>")
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+
+@dataclass(frozen=True)
+class ParsedTarget:
+    """Result of parsing the slash-command text.
+
+    Exactly one of ``user_id`` / ``email`` is set when the parse succeeds;
+    both are empty when the text was not parseable. ``self_lookup`` flags
+    the no-arg case so the caller can read the invoker's own ``user_id``
+    from the command body.
+    """
+
+    user_id: str = ""
+    email: str = ""
+    self_lookup: bool = False
+    raw: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return bool(self.user_id or self.email or self.self_lookup)
+
+
+def parse_target(text: str) -> ParsedTarget:
+    """Parse the text after ``/whereis`` into a :class:`ParsedTarget`.
+
+    Mention parsing happens *before* email parsing so a "user with
+    `<@U123>` profile email" mention does not slip through as plain
+    text. Whitespace-only / empty text → ``self_lookup``.
+    """
+    stripped = (text or "").strip()
+    if not stripped:
+        return ParsedTarget(self_lookup=True, raw="")
+
+    mention = _MENTION_RE.search(stripped)
+    if mention:
+        return ParsedTarget(user_id=mention["user_id"], raw=stripped)
+
+    email = _EMAIL_RE.search(stripped)
+    if email:
+        return ParsedTarget(email=email.group(0), raw=stripped)
+
+    return ParsedTarget(raw=stripped)

--- a/office_cli/slack/_serve.py
+++ b/office_cli/slack/_serve.py
@@ -1,7 +1,8 @@
 """Blocking entry point for Slack Socket Mode.
 
-Lazy-imports ``slack_bolt`` and ``slack_sdk.socket_mode`` so installs
-without the ``[slack]`` extra still load the parent package cleanly.
+Lazy-imports ``SocketModeHandler`` from
+``slack_bolt.adapter.socket_mode`` so installs without the ``[slack]``
+extra still load the parent package cleanly.
 """
 
 from __future__ import annotations

--- a/office_cli/slack/_serve.py
+++ b/office_cli/slack/_serve.py
@@ -1,0 +1,38 @@
+"""Blocking entry point for Slack Socket Mode.
+
+Lazy-imports ``slack_bolt`` and ``slack_sdk.socket_mode`` so installs
+without the ``[slack]`` extra still load the parent package cleanly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
+
+
+def run_socket_mode(app: Any, app_token: str) -> None:
+    """Block until the process is interrupted.
+
+    Raises :class:`OfficeError` (``EXIT_ENV_ERROR``) if the SDK is
+    missing or the token is empty, so the CLI verb can render a
+    consistent remediation hint.
+    """
+    if not app_token:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message="SLACK_APP_TOKEN is empty",
+            remediation=(
+                "Socket Mode needs an app-level token (xapp-…). "
+                "Set SLACK_APP_TOKEN or pass --app-token."
+            ),
+        )
+    try:
+        from slack_bolt.adapter.socket_mode import SocketModeHandler
+    except ImportError as err:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message="slack-bolt is not installed",
+            remediation=("install the slack extra: pip install office-cli[slack]"),
+        ) from err
+    SocketModeHandler(app, app_token).start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.3.0"
+version = "0.4.0"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"
@@ -20,6 +20,7 @@ dependencies = [
 [project.optional-dependencies]
 sheets = ["gspread>=6.0"]
 bamboohr = ["requests>=2.31"]
+slack = ["slack-bolt>=1.18", "slack-sdk>=3.27"]
 
 [project.urls]
 Homepage = "https://github.com/agentculture/office-agent"

--- a/tests/test_cli_slack_serve.py
+++ b/tests/test_cli_slack_serve.py
@@ -1,0 +1,45 @@
+"""CLI-level tests for `office slack-serve` argument handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli import main
+
+
+def test_help_smoke(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["slack-serve", "--help"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "Socket Mode" in out
+
+
+def test_missing_bot_token(
+    data_dir: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("SLACK_APP_TOKEN", raising=False)
+    rc = main(["slack-serve", "--data-dir", str(data_dir)])
+    assert rc == 2  # EXIT_ENV_ERROR
+    err = capsys.readouterr().err
+    assert "SLACK_BOT_TOKEN" in err
+    assert "users:read.email" in err  # remediation includes scope hint
+
+
+def test_missing_app_token(
+    data_dir: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+    monkeypatch.delenv("SLACK_APP_TOKEN", raising=False)
+    rc = main(["slack-serve", "--data-dir", str(data_dir)])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "SLACK_APP_TOKEN" in err
+    assert "Socket Mode" in err

--- a/tests/test_slack_app.py
+++ b/tests/test_slack_app.py
@@ -1,0 +1,292 @@
+"""End-to-end tests for the /whereis slash-command handler.
+
+Exercises the listener against a small ``FakeSlackApp`` so no real
+``slack_bolt`` install is required. The same handler logic runs in
+production; the only difference is the app object.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from office_cli.people import Employee
+from office_cli.people.bamboohr import BambooHRDirectory
+from office_cli.seats import build_service
+from office_cli.slack import build_app
+from tests.test_bamboohr_directory import FakeBambooHRClient
+
+
+class FakeSlackApp:
+    """Captures `app.command(name)`-decorated handlers for direct invocation."""
+
+    def __init__(self) -> None:
+        self.handlers: dict[str, Any] = {}
+
+    def command(self, name: str):
+        def decorator(fn):
+            self.handlers[name] = fn
+            return fn
+
+        return decorator
+
+
+class FakeSlackClient:
+    """Stand-in for the real WebClient: records postEphemeral payloads."""
+
+    def __init__(self, users: dict[str, dict[str, Any]] | None = None) -> None:
+        self.users = users or {}
+        self.posted: list[dict[str, Any]] = []
+        self.users_info_error: Exception | None = None
+
+    def users_info(self, *, user: str) -> dict[str, Any]:
+        if self.users_info_error is not None:
+            raise self.users_info_error
+        if user not in self.users:
+            return {"user": {"profile": {}}}
+        return {"user": self.users[user]}
+
+    def chat_postEphemeral(self, **kwargs: Any) -> None:
+        self.posted.append(kwargs)
+
+
+def _invoke(app, body, command, client) -> None:
+    """Call the registered /whereis handler with a no-op ack."""
+    app.handlers["/whereis"](ack=lambda: None, body=body, command=command, client=client)
+
+
+def _service_with_active(data_dir: Path, *active_emails: str):
+    employees = [Employee(email=e, name=e.split("@")[0]) for e in active_emails]
+    client = FakeBambooHRClient(employees)
+    directory = BambooHRDirectory(client, cache_ttl_seconds=99999)
+    service = build_service(data_dir)
+    service.directory = directory
+    return service
+
+
+def _last_blocks(client: FakeSlackClient) -> list[dict[str, Any]]:
+    assert client.posted, "no chat_postEphemeral call recorded"
+    return client.posted[-1]["blocks"]
+
+
+def _block_text(blocks: list[dict[str, Any]]) -> str:
+    """Concatenate every section / context text for substring assertions."""
+    parts: list[str] = []
+    for b in blocks:
+        if "text" in b and isinstance(b["text"], dict):
+            parts.append(b["text"].get("text", ""))
+        for el in b.get("elements", []):
+            if isinstance(el, dict):
+                inner = el.get("text")
+                if isinstance(inner, dict):
+                    parts.append(inner.get("text", ""))
+                elif isinstance(inner, str):
+                    parts.append(inner)
+    return "\n".join(parts)
+
+
+def test_at_mention_renders_seat(data_dir: Path) -> None:
+    service = _service_with_active(data_dir, "alice@example.com")
+    service.assign("5-T-01", "alice@example.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient(users={"U123": {"profile": {"email": "alice@example.com"}}})
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "<@U123|alice>"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "5-T-01" in text
+    assert "tlv-floor-5" in text
+
+
+def test_plain_email_path(data_dir: Path) -> None:
+    service = _service_with_active(data_dir, "bob@example.com")
+    service.assign("5-T-02", "bob@example.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "bob@example.com"},
+        client=client,
+    )
+    assert "5-T-02" in _block_text(_last_blocks(client))
+
+
+def test_no_arg_resolves_caller(data_dir: Path) -> None:
+    service = _service_with_active(data_dir, "carol@example.com")
+    service.assign("5-T-03", "carol@example.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient(users={"U999": {"profile": {"email": "carol@example.com"}}})
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": ""},
+        client=client,
+    )
+    assert "5-T-03" in _block_text(_last_blocks(client))
+
+
+def test_no_seat_renders_helpful_message(data_dir: Path) -> None:
+    service = _service_with_active(data_dir, "ghost@example.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "ghost@example.com"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "No seat assigned" in text
+    assert "ghost@example.com" in text
+
+
+def test_hidden_seat_redacts_email(data_dir: Path) -> None:
+    service = _service_with_active(data_dir, "exec@example.com")
+    service.assign("5-T-04", "exec@example.com", hidden=True)
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "exec@example.com"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "occupied (private)" in text
+    assert "tlv-floor-5" in text
+    # The hidden-private response must NOT include the seat ID — only
+    # the floor — so the floor map row stays unidentifiable.
+    assert "5-T-04" not in text
+
+
+def test_inactive_directory_email_renders_no_seat(data_dir: Path) -> None:
+    """Stage 3 auto-vacate must surface through the Slack handler too.
+
+    Assign an active employee, then mark them inactive in the directory;
+    /whereis must report no seat (even though the row is still on disk).
+    """
+    bamboo_client = FakeBambooHRClient([Employee(email="alice@example.com")])
+    directory = BambooHRDirectory(bamboo_client, cache_ttl_seconds=0)
+    service = build_service(data_dir)
+    service.directory = directory
+    service.assign("5-T-01", "alice@example.com")
+
+    bamboo_client.employees = []  # offboarded
+    directory.invalidate()  # force fresh fetch on next is_active
+
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alice@example.com"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "No seat assigned" in text
+
+
+def test_unparseable_text(data_dir: Path) -> None:
+    service = _service_with_active(data_dir)
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "garbage_no_email_no_mention"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "Couldn't parse" in text
+    assert "garbage_no_email_no_mention" in text
+
+
+def test_users_info_failure_renders_lookup_error(data_dir: Path) -> None:
+    service = _service_with_active(data_dir)
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    client.users_info_error = ConnectionError("Slack down")
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "<@U123|alice>"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "users.info call failed" in text
+
+
+def test_users_info_missing_email_renders_clear_message(data_dir: Path) -> None:
+    service = _service_with_active(data_dir)
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient(users={"U123": {"profile": {}}})
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "<@U123|alice>"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "users:read.email" in text  # remediation hint surfaced
+
+
+def test_deep_link_button_when_base_url_set(
+    data_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OFFICE_WEB_BASE_URL", "https://office.example.com")
+    service = _service_with_active(data_dir, "alice@example.com")
+    service.assign("5-T-01", "alice@example.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alice@example.com"},
+        client=client,
+    )
+    blocks = _last_blocks(client)
+    actions = [b for b in blocks if b.get("type") == "actions"]
+    assert actions, "expected an actions block with the deep-link button"
+    button = actions[0]["elements"][0]
+    assert button["url"].startswith("https://office.example.com/")
+    assert "5-T-01" in button["url"]
+
+
+def test_text_fallback_in_postephemeral(data_dir: Path) -> None:
+    """The handler always passes a `text` fallback so screen readers and
+    older clients render something even when blocks are dropped."""
+    service = _service_with_active(data_dir, "alice@example.com")
+    service.assign("5-T-01", "alice@example.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alice@example.com"},
+        client=client,
+    )
+    assert "text" in client.posted[0]
+    assert client.posted[0]["text"]
+
+
+def test_payload_is_json_serializable(data_dir: Path) -> None:
+    """Block Kit payloads must round-trip through JSON; assert no
+    accidentally-non-serializable values (e.g. dataclass instances) leak."""
+    service = _service_with_active(data_dir, "alice@example.com")
+    service.assign("5-T-01", "alice@example.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alice@example.com"},
+        client=client,
+    )
+    json.dumps(client.posted[0]["blocks"])

--- a/tests/test_slack_app.py
+++ b/tests/test_slack_app.py
@@ -259,6 +259,46 @@ def test_deep_link_button_when_base_url_set(
     assert "5-T-01" in button["url"]
 
 
+def test_text_fallback_does_not_leak_email_for_mention(data_dir: Path) -> None:
+    """Qodo Q2: the `text` fallback must not expose the resolved profile
+    email when the caller used an @mention. Otherwise screen-readers or
+    older clients see what the blocks deliberately redacted."""
+    service = _service_with_active(data_dir, "alice@example.com")
+    # No seat assigned for alice — exercises the no-seat branch where
+    # the leak was found.
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient(users={"U123": {"profile": {"email": "alice@example.com"}}})
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"channel_id": "C1", "user_id": "U999", "text": "<@U123|alice>"},
+        client=client,
+    )
+    posted = client.posted[-1]
+    assert "alice@example.com" not in posted["text"]
+    assert "<@U123>" in posted["text"]
+
+
+def test_command_payload_takes_precedence_for_channel_user(data_dir: Path) -> None:
+    """Copilot C2: prefer command[channel_id]/user_id; fall back to body."""
+    service = _service_with_active(data_dir, "alice@example.com")
+    service.assign("5-T-01", "alice@example.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C-from-body", "user_id": "U-from-body"},
+        command={
+            "channel_id": "C-from-command",
+            "user_id": "U-from-command",
+            "text": "alice@example.com",
+        },
+        client=client,
+    )
+    assert client.posted[-1]["channel"] == "C-from-command"
+    assert client.posted[-1]["user"] == "U-from-command"
+
+
 def test_text_fallback_in_postephemeral(data_dir: Path) -> None:
     """The handler always passes a `text` fallback so screen readers and
     older clients render something even when blocks are dropped."""

--- a/tests/test_slack_resolve.py
+++ b/tests/test_slack_resolve.py
@@ -65,7 +65,44 @@ def test_unparseable_text_marks_failure() -> None:
         ("a@b.io", "a@b.io"),
         ("name+tag@sub.example.co", "name+tag@sub.example.co"),
         ("user.name@x.io", "user.name@x.io"),
+        ("a@b.c.d.e.io", "a@b.c.d.e.io"),  # multi-label domain still matches
     ],
 )
 def test_email_shapes(text: str, expected: str) -> None:
     assert parse_target(text).email == expected
+
+
+def test_overlong_input_short_circuits() -> None:
+    """Inputs over the cap are rejected before any regex runs.
+
+    Defense in depth against ReDoS — even though the email regex is
+    constructed to run in linear time, a hard length cap means an
+    adversarial input cannot tie up the handler regardless of any
+    future regex change.
+    """
+    huge = "a" * 10_000 + "@" + "b" * 10_000
+    target = parse_target(huge)
+    assert target.ok is False
+    assert target.raw.endswith("…")  # truncated marker
+
+
+def test_redos_pathological_input_completes_quickly() -> None:
+    """Adversarial input that would have been polynomial under the old
+    `[A-Za-z0-9.-]+\\.[A-Za-z]{2,}` shape now matches/fails in linear
+    time. We do not assert wall-clock — pytest will fail the suite if
+    this hangs."""
+    import time
+
+    # 200 dot-separated segments with no valid TLD at the end.
+    needle = "a@" + ".".join(["b"] * 100) + "."
+    start = time.monotonic()
+    target = parse_target(needle)
+    elapsed = time.monotonic() - start
+    # Generous bound — linear-time regex on a 202-char input finishes in
+    # microseconds; 1s flags any future regression to a polynomial form.
+    assert elapsed < 1.0
+    # Last segment is just `.`, so there's no valid TLD; parse should
+    # treat the prefix `a@b.b.…b.b` as the match (since `b` qualifies as
+    # a 2+-char TLD when paired with the previous `b`). Either matching
+    # or failing is acceptable — what matters is that we did not hang.
+    assert target.raw == needle.strip()

--- a/tests/test_slack_resolve.py
+++ b/tests/test_slack_resolve.py
@@ -1,0 +1,71 @@
+"""Parser tests for the /whereis slash-command argument."""
+
+from __future__ import annotations
+
+import pytest
+
+from office_cli.slack._resolve import parse_target
+
+
+def test_empty_text_is_self_lookup() -> None:
+    target = parse_target("")
+    assert target.self_lookup is True
+    assert target.user_id == ""
+    assert target.email == ""
+
+
+def test_whitespace_only_is_self_lookup() -> None:
+    assert parse_target("   ").self_lookup is True
+    assert parse_target("\t\n").self_lookup is True
+
+
+def test_mention_with_pipe_name() -> None:
+    target = parse_target("<@U12345|alice>")
+    assert target.user_id == "U12345"
+    assert target.email == ""
+    assert target.self_lookup is False
+
+
+def test_mention_without_pipe_name() -> None:
+    target = parse_target("<@U67890>")
+    assert target.user_id == "U67890"
+
+
+def test_mention_takes_precedence_over_email() -> None:
+    """A mention buried in text wins even if the text also has an email."""
+    target = parse_target("<@U123|alice> alice@x.com")
+    assert target.user_id == "U123"
+    assert target.email == ""
+
+
+def test_plain_email() -> None:
+    target = parse_target("alice@tipalti.com")
+    assert target.email == "alice@tipalti.com"
+    assert target.user_id == ""
+
+
+def test_email_with_surrounding_whitespace() -> None:
+    assert parse_target("   alice@tipalti.com   ").email == "alice@tipalti.com"
+
+
+def test_first_email_wins_among_many() -> None:
+    target = parse_target("alice@x.com bob@y.com")
+    assert target.email == "alice@x.com"
+
+
+def test_unparseable_text_marks_failure() -> None:
+    target = parse_target("nope")
+    assert target.ok is False
+    assert target.raw == "nope"
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("a@b.io", "a@b.io"),
+        ("name+tag@sub.example.co", "name+tag@sub.example.co"),
+        ("user.name@x.io", "user.name@x.io"),
+    ],
+)
+def test_email_shapes(text: str, expected: str) -> None:
+    assert parse_target(text).email == expected

--- a/uv.lock
+++ b/uv.lock
@@ -485,7 +485,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
@@ -497,6 +497,10 @@ bamboohr = [
 ]
 sheets = [
     { name = "gspread" },
+]
+slack = [
+    { name = "slack-bolt" },
+    { name = "slack-sdk" },
 ]
 
 [package.dev-dependencies]
@@ -515,8 +519,10 @@ requires-dist = [
     { name = "gspread", marker = "extra == 'sheets'", specifier = ">=6.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", marker = "extra == 'bamboohr'", specifier = ">=2.31" },
+    { name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.18" },
+    { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27" },
 ]
-provides-extras = ["sheets", "bamboohr"]
+provides-extras = ["sheets", "bamboohr", "slack"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -779,6 +785,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "slack-bolt"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "slack-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/97/a62dde97e84027b252807f2044bed2edcda2d063a5cb0c535fb2be8d9b5d/slack_bolt-1.28.0.tar.gz", hash = "sha256:bfe367d867e8fb157a057248ebd4ac2d7f43acac6d0700fa31381db1e10f3b0f", size = 130768, upload-time = "2026-04-06T23:24:59.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/a9/697b6a92c728f09d5ef6b8e83dc6c8a87bc6d59499b2933ed067f11b7e30/slack_bolt-1.28.0-py2.py3-none-any.whl", hash = "sha256:738d1ca5e7c7039b6e18103d29267ced6e18c2517053eff18991fdd593acce5c", size = 234819, upload-time = "2026-04-06T23:24:58.278Z" },
+]
+
+[[package]]
+name = "slack-sdk"
+version = "3.41.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/35/fc009118a13187dd9731657c60138e5a7c2dea88681a7f04dc406af5da7d/slack_sdk-3.41.0.tar.gz", hash = "sha256:eb61eb12a65bebeca9cb5d36b3f799e836ed2be21b456d15df2627cfe34076ca", size = 250568, upload-time = "2026-03-12T16:10:11.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/df/2e4be347ff98281b505cc0ccf141408cdd25eb5ca9f3830deb361b2472d3/slack_sdk-3.41.0-py2.py3-none-any.whl", hash = "sha256:bb18dcdfff1413ec448e759cf807ec3324090993d8ab9111c74081623b692a89", size = 313885, upload-time = "2026-03-12T16:10:09.811Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Stage 4 of the v1 seating system per
[issue #1](https://github.com/agentculture/office-agent/issues/1) and tracked at
[#8](https://github.com/agentculture/office-agent/issues/8). Wraps the existing
`SeatService.whereis` in a `slack_bolt` app so non-CLI users can call
`/whereis` from any Slack channel or DM.

- **`office_cli.slack` subpackage** — `_resolve.py` (pure parser for the
  slash-command text), `_app.py` (the `/whereis` handler, structurally
  typed around `ack` + `client` + `body`/`command` so tests use a
  `FakeSlackApp` + `FakeSlackClient` with no SDK install), `_blocks.py`
  (Block Kit responses for occupied / hidden-private / no-seat /
  parse-failed / lookup-failed), `_serve.py` (lazy-imports
  `SocketModeHandler` and blocks on `start()`).
- **CLI verb** — `office slack-serve [--bot-token T] [--app-token T]
  [--data-dir D]`. Env-first; missing tokens raise `OfficeError` with a
  remediation pointing at the required scopes (`commands`,
  `users:read.email`, `chat:write`).
- **Socket Mode only** for v1 (per the design pick this round) — no
  HTTP endpoint, no signing-secret middleware. `SLACK_BOT_TOKEN` (xoxb-)
  + `SLACK_APP_TOKEN` (xapp-) are both required.
- **Ephemeral responses** by default — looking up a coworker's seat
  does not broadcast to the channel. `hidden=TRUE` seats render as
  "occupied (private)" with no email/notes leakage; Stage 7 will lift
  the filter for privileged callers.
- **Stage 3 auto-vacate** flows through transparently — an offboarded
  employee's `/whereis` returns "no seat assigned" without any code
  change here.
- **Optional extra** — `pip install office-cli[slack]` pulls
  `slack-bolt>=1.18` and `slack-sdk>=3.27`. The package still imports
  cleanly without it.

## Test plan

- [x] `uv run pytest -n auto -v` — 145 tests pass: existing 118 plus
  - `_resolve.py` parser: empty/whitespace → self-lookup, `<@U…|name>`
    mention, mention-takes-precedence-over-email, plain email,
    surrounding whitespace, first-email-among-many, unparseable,
    parametric email shapes;
  - `/whereis` handler: at-mention → seat block, plain email → seat
    block, no-arg → caller's seat, no-seat → helpful message, hidden
    seat → email/notes redacted (only floor surfaces), Stage-3
    auto-vacate inactive email → "no seat", unparseable → parse-failed
    block, `users.info` failure → lookup-failed block, missing email
    on profile → `users:read.email` scope hint, deep-link button when
    `OFFICE_WEB_BASE_URL` is set, fallback `text` field present, every
    payload is `json.dumps`-able;
  - CLI: `--help` smoke (description mentions Socket Mode), missing
    `SLACK_BOT_TOKEN` → `EXIT_ENV_ERROR` with scope-list remediation,
    missing `SLACK_APP_TOKEN` → `EXIT_ENV_ERROR` with Socket-Mode
    remediation.
- [x] black / isort / flake8 / bandit / markdownlint clean.
- [x] `steward doctor . --scope self` clean.
- [x] `uv build` produces 0.4.0 wheel + sdist.
- [ ] Manual end-to-end with a real Slack workspace — operator
  follow-up (no creds in CI).

## Out of scope (deferred)

- HTTP transport / signing-secret middleware — the issue notes call it
  out, but Socket Mode was the explicit design pick for v1.
- Web map deep link is a placeholder; `OFFICE_WEB_BASE_URL` opt-in
  surfaces the button. The real map ships in Stage 5
  ([#9](https://github.com/agentculture/office-agent/issues/9)).
- SSO / role gating (Stage 7,
  [#11](https://github.com/agentculture/office-agent/issues/11)) — until
  then, every caller sees `hidden=TRUE` rows as "occupied (private)".
- Modal-based assignment edits — the Sheet stays the editor.

- Claude

Generated with Claude Code