### PR TITLE
feat: v1 seating Stage 6 — effective-date enforcement + ?asOf= rendering

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"d462d578-68ba-4ba7-af21-70a473453290","pid":47793,"procStart":"Fri May  1 11:17:49 2026","acquiredAt":1777645848931}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"d462d578-68ba-4ba7-af21-70a473453290","pid":47793,"procStart":"Fri May  1 11:17:49 2026","acquiredAt":1777645848931}

--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,5 @@ __marimo__/
 # operator state.
 seats/assignments.csv
 seats/audit-log.csv
+.claude/scheduled_tasks.lock
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-01
+
+### Added
+
+- v1 seating Stage 6 — effective-date enforcement + `?asOf=`
+  rendering ([#10](https://github.com/agentculture/office-agent/issues/10)).
+  `SeatService.list_seats` and `SeatService.whereis` honor an optional
+  `as_of` keyword; rows whose `[effective_from, effective_until]`
+  window does not contain the requested date render as vacant.
+- `office_cli._dates` — small helper module with `parse_iso_date`,
+  `today_iso_date`, `is_effective`, and `validate_window`.
+  `OfficeError(EXIT_USER_ERROR)` surfaces every malformed-date input
+  with a clear remediation.
+- New CLI flags: `office seats list --as-of YYYY-MM-DD`,
+  `office whereis EMAIL --as-of YYYY-MM-DD`,
+  `office seats assign SEAT EMAIL --from YYYY-MM-DD --until YYYY-MM-DD`.
+- Web `GET /api/floors/{id}?as_of=YYYY-MM-DD` is honored end-to-end.
+  Malformed dates surface as `400 {error, remediation}` via the
+  existing `OfficeError` handler. The frontend banner copy moves from
+  "as-of dates are not yet enforced (Stage 6)" to
+  "Showing seat map as of YYYY-MM-DD."
+- Slack `/whereis` accepts an optional trailing `YYYY-MM-DD` token —
+  `/whereis alice@x 2026-07-01`, `/whereis @alice 2026-07-01`, and
+  `/whereis 2026-07-01` (self lookup as-of the date) all work.
+
+### Changed
+
+- `SeatService.assign` (and `move`) write `effective_from` as a
+  date-only `YYYY-MM-DD` value (date precision, no time component).
+  `last_updated` and audit-log timestamps stay full ISO-8601 wall-
+  clock strings. Pre-Stage-6 rows that wrote a full ISO timestamp
+  into `effective_from` keep working — `is_effective` strips the
+  `T...` suffix before comparison.
+
 ## [0.5.0] - 2026-05-01
 
 ### Added
@@ -163,7 +197,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   preserving the SVG ID contract and architectural guardrails for the v1
   seating system (issue #1).
 
-[Unreleased]: https://github.com/agentculture/office-agent/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/agentculture/office-agent/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/agentculture/office-agent/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/agentculture/office-agent/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/agentculture/office-agent/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/agentculture/office-agent/compare/v0.2.0...v0.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ office-agent/
 │   │   ├── _output.py           # emit_result / emit_error / emit_diagnostic
 │   │   └── _commands/           # learn, explain, whoami, floors, seats, whereis
 │   ├── _config.py               # resolve_data_dir() / --data-dir / OFFICE_DATA_DIR
+│   ├── _dates.py                # parse_iso_date / today_iso_date / is_effective (Stage 6)
 │   ├── offices/                 # offices.yaml loader + Office/Floor/Cluster/Room
 │   ├── floors/                  # SVG parse + ID contract + validator
 │   ├── seats/                   # AssignmentStore + Csv/Sheets stores + AuditLog + SeatService
@@ -60,7 +61,7 @@ office-agent/
 ```bash
 uv sync                           # install runtime + dev deps
 uv run pytest -n auto -v          # full suite, parallel
-uv run office --version           # 0.5.0
+uv run office --version           # 0.6.0
 uv run office learn               # agent affordance
 uv run office whoami              # auth probe stub
 uv run office floors validate floors/tlv-floor-5.svg
@@ -140,7 +141,7 @@ Lessons paid for in advance — don't relitigate without a reason:
 - **The Google Sheet is the CMS.** Don't build an in-app editor for assignments. Don't build an in-app SVG editor either — Inkscape is the editor for layouts.
 - **Audit log is append-only.** Seat changes never overwrite history; "who used to sit at 5-T-01?" must return chronological history.
 - **Multi-office from day one.** No hardcoded `tlv`. Adding a floor = drop SVG + add `data/offices.yaml` entry, no code change.
-- **Future-dated assignments**: the data model carries `effective_from` / `effective_until` even if the UI ships without it. `?asOf=YYYY-MM-DD` renders the map as of that date.
+- **Future-dated assignments**: the data model carries `effective_from` / `effective_until` and Stage 6 enforces them at the service layer. `office seats assign --from / --until`, `office whereis --as-of`, `office seats list --as-of`, `?asOf=YYYY-MM-DD` on the web map, and a trailing `YYYY-MM-DD` token on Slack `/whereis` all flow through the same window check. `effective_*` is stored as `YYYY-MM-DD` (date precision, no time); `last_updated` and audit timestamps stay full ISO-8601.
 - **`hidden=TRUE`** rows show as "occupied (private)" to viewers; full details only to the `editor` / `planning` roles.
 - **Out of scope for v1**: hot-desking / desk booking, native mobile app, visitor/badge/sensor integration, in-app SVG editor.
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ BambooHR; assignments live in a Google Sheet (v1) or DynamoDB (v2). The
 CLI exposes the same operations as the Slack `/whereis` command and the
 web map.
 
-> **Status — v0.5.0.** Stages 1–5 of the v1 seating system are in:
+> **Status — v0.6.0.** Stages 1–6 of the v1 seating system are in:
 > floor SVG parser/validator, CSV / Google Sheets-backed assignment
 > store with append-only audit log, BambooHR-backed `EmployeeDirectory`
 > with the auto-vacate killer feature, CLI verbs (`floors`, `seats`,
-> `whereis`), a Slack `/whereis` slash-command listener, and a
-> search-first web map. Effective dates, SSO/roles, and DynamoDB
+> `whereis`), a Slack `/whereis` slash-command listener, a search-first
+> web map, and effective-date enforcement. SSO/roles and DynamoDB
 > land in later stages. See
 > [issue #1](https://github.com/agentculture/office-agent/issues/1).
 
@@ -133,11 +133,35 @@ Three invocation shapes:
 - `/whereis @user` — Slack mention; resolves the user's email.
 - `/whereis email@domain` — plain text fallback.
 
+A trailing `YYYY-MM-DD` token on any of the three shapes filters by
+effective date — e.g. `/whereis alice@x 2026-07-01` returns Alice's
+seat as of that date.
+
 Responses are **ephemeral by default** — only the caller sees them.
 `hidden=TRUE` seats render as "occupied (private)" until role gating
 (Stage 7) lifts the filter for privileged callers. Setting
 `OFFICE_WEB_BASE_URL` to your `office serve` deployment adds an
 "Open map" deep-link button to the response.
+
+### Effective-date windows
+
+Assignments can carry an effective window so the seat map renders "as
+of" any date:
+
+```bash
+office seats assign 5-T-01 alice@example.com --from 2026-07-01 --until 2026-12-31
+office whereis alice@example.com                     # default = today
+office whereis alice@example.com --as-of 2026-07-15  # inside the window
+office seats list --as-of 2026-09-01
+```
+
+The web map honors `?asOf=YYYY-MM-DD` in the URL —
+`http://localhost:8000/offices/tlv/floors/tlv-floor-5?asOf=2026-07-15`
+shows the same view, deep-linkable.
+
+`effective_from` / `effective_until` are stored as `YYYY-MM-DD` (date
+precision); `last_updated` and audit-log timestamps stay full ISO-8601.
+Empty bounds mean "always begins" / "no end".
 
 ## Adding a new floor
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture — v0.5.0 (Stages 1–5)
+# Architecture — v0.6.0 (Stages 1–6)
 
 `office` ships in stages on top of issue
 [#1](https://github.com/agentculture/office-agent/issues/1). This document
@@ -231,13 +231,40 @@ The vendored fuzzy-search shim under `office_cli/server/static/vendor/`
 is intentionally minimal — see the README there for when to swap in
 the upstream Fuse.js library.
 
+## Stage 6 — implemented in v0.6.0
+
+Effective-date enforcement ([#10](https://github.com/agentculture/office-agent/issues/10)).
+The `effective_from` / `effective_until` columns reserved by Stage 1 +
+2 are now read at view time:
+
+- `SeatService.list_seats(as_of=...)` and `SeatService.whereis(email,
+  as_of=...)` filter rows whose window does not contain the requested
+  date. Auto-vacate (Stage 3) runs after the date filter, so a seat
+  assigned to a future-dated employee renders vacant today regardless
+  of directory state.
+- `SeatService.assign(effective_from=..., effective_until=...)`
+  defaults `effective_from` to today (date-only `YYYY-MM-DD`) and
+  leaves `effective_until` open-ended. `validate_window` rejects an
+  inverted `until < from`.
+- All four surfaces honor it: `office seats list --as-of`,
+  `office whereis --as-of`, `office seats assign --from / --until`,
+  the web `?as_of=YYYY-MM-DD` query param, and a trailing
+  `YYYY-MM-DD` token on Slack `/whereis`.
+- Storage shape: `effective_from` / `effective_until` are written as
+  date-only `YYYY-MM-DD`. `last_updated` and audit-log timestamps stay
+  full ISO-8601 wall-clock strings. Pre-Stage-6 rows that wrote a full
+  ISO timestamp into `effective_from` keep working — `is_effective`
+  strips the `T...` suffix before lex comparison.
+- All malformed-date inputs surface as `OfficeError(EXIT_USER_ERROR)`
+  with a remediation, and the web routes map that to
+  `400 {error, remediation}` via the existing handler.
+
 ## Deferred surfaces
 
 Each is a separate issue/PR.
 
 | Stage              | Surface                                       | Notes                                                                   |
 | ------------------ | --------------------------------------------- | ----------------------------------------------------------------------- |
-| 6. Effective dates | service-layer `effective_from / _until`       | Columns already exist; the service starts honoring them.                |
 | 7. SSO + roles     | viewer / editor / planning                    | Drives whether `hidden=TRUE` rows expose details.                       |
 | 8. DynamoDB        | `office_cli.seats.DynamoStore`                | Migration script from Sheets, kept identical Protocol.                  |
 

--- a/office_cli/_dates.py
+++ b/office_cli/_dates.py
@@ -1,0 +1,101 @@
+"""ISO-date helpers for the effective-date window (Stage 6, issue #10).
+
+Effective dates are stored as ``YYYY-MM-DD`` strings (no time component).
+``last_updated`` and audit-log timestamps stay full ISO-8601 wall-clock
+timestamps; this module only operates on the date-precision values.
+
+Pre-Stage-6 ``Assignment`` rows wrote a full ISO timestamp into
+``effective_from``. :func:`is_effective` strips the ``T...`` suffix so
+those rows still compare correctly without a migration step.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from office_cli.seats._models import Assignment
+
+_ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def parse_iso_date(s: str, *, field: str = "date") -> str:
+    """Validate ``s`` as ``YYYY-MM-DD`` and return it normalized.
+
+    Raises :class:`office_cli.cli._errors.OfficeError` (``EXIT_USER_ERROR``)
+    on malformed input. The error class is imported lazily to avoid a
+    circular dependency with the ``office_cli.cli`` package, which itself
+    pulls in command modules that import this helper.
+    """
+    # Lazy import — see docstring.
+    from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+
+    if not isinstance(s, str) or not _ISO_DATE_RE.match(s):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"{field} must be an ISO date (YYYY-MM-DD), got: {s!r}",
+            remediation="example: --as-of 2026-07-01",
+        )
+    try:
+        datetime.strptime(s, "%Y-%m-%d")
+    except ValueError as err:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"{field} is not a real calendar date: {s!r}",
+            remediation="use a valid YYYY-MM-DD date such as 2026-07-01",
+        ) from err
+    return s
+
+
+def today_iso_date(clock: Callable[[], str] | None = None) -> str:
+    """Return today's date as ``YYYY-MM-DD``.
+
+    ``clock`` is the same injection point :class:`SeatService` uses; it
+    returns a full ISO timestamp like ``2026-05-01T00:00:01Z`` from which
+    we take the date prefix. When ``None``, falls back to UTC ``now()``.
+    """
+    if clock is None:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return _date_prefix(clock())
+
+
+def is_effective(a: "Assignment", as_of_date: str) -> bool:
+    """True iff ``as_of_date`` falls within ``a``'s effective window.
+
+    Empty ``effective_from`` means "always begins"; empty
+    ``effective_until`` means "no end". Both bounds are inclusive. Legacy
+    rows that store a full ISO timestamp in ``effective_from`` work
+    because we strip the ``T...`` suffix before comparison.
+    """
+    eff_from = _date_prefix(a.effective_from)
+    eff_until = _date_prefix(a.effective_until)
+    if eff_from and as_of_date < eff_from:
+        return False
+    if eff_until and as_of_date > eff_until:
+        return False
+    return True
+
+
+def validate_window(eff_from: str, eff_until: str) -> None:
+    """Reject a window where ``until < from``.
+
+    Both inputs are assumed to already be ``YYYY-MM-DD`` (i.e. they have
+    been through :func:`parse_iso_date`). Either may be empty.
+    """
+    if eff_from and eff_until and eff_until < eff_from:
+        from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=(f"--until ({eff_until}) is before --from ({eff_from})"),
+            remediation="swap the values or pick a later --until date",
+        )
+
+
+def _date_prefix(s: str) -> str:
+    """Return everything before the first ``T`` (or the whole string)."""
+    if not s:
+        return ""
+    return s.split("T", 1)[0]

--- a/office_cli/_dates.py
+++ b/office_cli/_dates.py
@@ -21,13 +21,17 @@ if TYPE_CHECKING:
 _ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
-def parse_iso_date(s: str, *, field: str = "date") -> str:
+def parse_iso_date(s: str, *, field: str = "date", example: str = "2026-07-01") -> str:
     """Validate ``s`` as ``YYYY-MM-DD`` and return it normalized.
 
     Raises :class:`office_cli.cli._errors.OfficeError` (``EXIT_USER_ERROR``)
     on malformed input. The error class is imported lazily to avoid a
     circular dependency with the ``office_cli.cli`` package, which itself
     pulls in command modules that import this helper.
+
+    ``example`` is woven into the remediation string so the helper stays
+    surface-neutral — CLI callers pass ``"--as-of 2026-07-01"``, the API
+    passes ``"?as_of=2026-07-01"``, and Slack falls back to a bare date.
     """
     # Lazy import — see docstring.
     from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
@@ -36,7 +40,7 @@ def parse_iso_date(s: str, *, field: str = "date") -> str:
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=f"{field} must be an ISO date (YYYY-MM-DD), got: {s!r}",
-            remediation="example: --as-of 2026-07-01",
+            remediation=f"example: {example}",
         )
     try:
         datetime.strptime(s, "%Y-%m-%d")
@@ -44,7 +48,7 @@ def parse_iso_date(s: str, *, field: str = "date") -> str:
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=f"{field} is not a real calendar date: {s!r}",
-            remediation="use a valid YYYY-MM-DD date such as 2026-07-01",
+            remediation=f"use a valid YYYY-MM-DD date such as {example.split()[-1]}",
         ) from err
     return s
 

--- a/office_cli/cli/_commands/seats.py
+++ b/office_cli/cli/_commands/seats.py
@@ -22,7 +22,11 @@ def cmd_list(args: argparse.Namespace) -> int:
             message="--vacant and --occupied are mutually exclusive",
             remediation="pass at most one of the two",
         )
-    as_of = parse_iso_date(args.as_of, field="--as-of") if args.as_of else today_iso_date()
+    as_of = (
+        parse_iso_date(args.as_of, field="--as-of", example="--as-of 2026-07-01")
+        if args.as_of
+        else today_iso_date()
+    )
     rows = service.list_seats(
         floor=args.floor,
         cluster=args.cluster,
@@ -48,8 +52,16 @@ def cmd_list(args: argparse.Namespace) -> int:
 def cmd_assign(args: argparse.Namespace) -> int:
     data_dir = resolve_data_dir(args)
     service = build_service(data_dir)
-    eff_from = parse_iso_date(args.from_date, field="--from") if args.from_date else None
-    eff_until = parse_iso_date(args.until_date, field="--until") if args.until_date else None
+    eff_from = (
+        parse_iso_date(args.from_date, field="--from", example="--from 2026-07-01")
+        if args.from_date
+        else None
+    )
+    eff_until = (
+        parse_iso_date(args.until_date, field="--until", example="--until 2026-12-31")
+        if args.until_date
+        else None
+    )
     a = service.assign(
         args.seat_id,
         args.email,

--- a/office_cli/cli/_commands/seats.py
+++ b/office_cli/cli/_commands/seats.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from office_cli._config import add_data_dir_arg, resolve_data_dir
+from office_cli._dates import parse_iso_date, today_iso_date
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 from office_cli.cli._output import emit_result
 from office_cli.seats import build_service
@@ -21,11 +22,13 @@ def cmd_list(args: argparse.Namespace) -> int:
             message="--vacant and --occupied are mutually exclusive",
             remediation="pass at most one of the two",
         )
+    as_of = parse_iso_date(args.as_of, field="--as-of") if args.as_of else today_iso_date()
     rows = service.list_seats(
         floor=args.floor,
         cluster=args.cluster,
         only_vacant=args.vacant,
         only_occupied=args.occupied,
+        as_of=as_of,
     )
     if args.json:
         emit_result({"seats": [a.to_dict() for a in rows]}, json_mode=True)
@@ -45,7 +48,16 @@ def cmd_list(args: argparse.Namespace) -> int:
 def cmd_assign(args: argparse.Namespace) -> int:
     data_dir = resolve_data_dir(args)
     service = build_service(data_dir)
-    a = service.assign(args.seat_id, args.email, note=args.note or "", hidden=args.hidden)
+    eff_from = parse_iso_date(args.from_date, field="--from") if args.from_date else None
+    eff_until = parse_iso_date(args.until_date, field="--until") if args.until_date else None
+    a = service.assign(
+        args.seat_id,
+        args.email,
+        note=args.note or "",
+        hidden=args.hidden,
+        effective_from=eff_from,
+        effective_until=eff_until,
+    )
     _emit_assignment(a, args.json, "assigned")
     return 0
 
@@ -108,6 +120,12 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_list.add_argument("--cluster", help="Restrict to a single cluster letter.")
     p_list.add_argument("--vacant", action="store_true", help="Only vacant seats.")
     p_list.add_argument("--occupied", action="store_true", help="Only occupied seats.")
+    p_list.add_argument(
+        "--as-of",
+        dest="as_of",
+        metavar="YYYY-MM-DD",
+        help="Render the seat map as of this date (default: today).",
+    )
     p_list.add_argument("--json", action="store_true", help="Emit structured JSON.")
     add_data_dir_arg(p_list)
     p_list.set_defaults(func=cmd_list)
@@ -118,6 +136,18 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_assign.add_argument("--note", help=_NOTE_HELP)
     p_assign.add_argument(
         "--hidden", action="store_true", help="Mark assignment as private (hidden=TRUE)."
+    )
+    p_assign.add_argument(
+        "--from",
+        dest="from_date",
+        metavar="YYYY-MM-DD",
+        help="Effective start date (inclusive); default: today.",
+    )
+    p_assign.add_argument(
+        "--until",
+        dest="until_date",
+        metavar="YYYY-MM-DD",
+        help="Effective end date (inclusive); default: open-ended.",
     )
     p_assign.add_argument("--json", action="store_true")
     add_data_dir_arg(p_assign)

--- a/office_cli/cli/_commands/whereis.py
+++ b/office_cli/cli/_commands/whereis.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 
 from office_cli._config import add_data_dir_arg, resolve_data_dir
+from office_cli._dates import parse_iso_date, today_iso_date
 from office_cli.cli._output import emit_result
 from office_cli.seats import build_service
 
@@ -16,7 +17,8 @@ from office_cli.seats import build_service
 def cmd_whereis(args: argparse.Namespace) -> int:
     data_dir = resolve_data_dir(args)
     service = build_service(data_dir)
-    a = service.whereis(args.email)
+    as_of = parse_iso_date(args.as_of, field="--as-of") if args.as_of else today_iso_date()
+    a = service.whereis(args.email, as_of=as_of)
     if args.json:
         emit_result(
             {"email": args.email, "assignment": a.to_dict() if a else None},
@@ -37,6 +39,12 @@ def register(sub: argparse._SubParsersAction) -> None:
         description="Look up an employee's seat by email.",
     )
     p.add_argument("email")
+    p.add_argument(
+        "--as-of",
+        dest="as_of",
+        metavar="YYYY-MM-DD",
+        help="Look up the seat as of this date (default: today).",
+    )
     p.add_argument("--json", action="store_true", help="Emit structured JSON.")
     add_data_dir_arg(p)
     p.set_defaults(func=cmd_whereis)

--- a/office_cli/cli/_commands/whereis.py
+++ b/office_cli/cli/_commands/whereis.py
@@ -17,7 +17,11 @@ from office_cli.seats import build_service
 def cmd_whereis(args: argparse.Namespace) -> int:
     data_dir = resolve_data_dir(args)
     service = build_service(data_dir)
-    as_of = parse_iso_date(args.as_of, field="--as-of") if args.as_of else today_iso_date()
+    as_of = (
+        parse_iso_date(args.as_of, field="--as-of", example="--as-of 2026-07-01")
+        if args.as_of
+        else today_iso_date()
+    )
     a = service.whereis(args.email, as_of=as_of)
     if args.json:
         emit_result(

--- a/office_cli/seats/_service.py
+++ b/office_cli/seats/_service.py
@@ -18,6 +18,7 @@ import dataclasses
 from datetime import datetime, timezone
 from typing import Iterable, cast
 
+from office_cli._dates import is_effective, today_iso_date, validate_window
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 from office_cli.floors import FloorSvg
 from office_cli.offices import Office
@@ -56,6 +57,7 @@ class SeatService:
         cluster: str | None = None,
         only_vacant: bool = False,
         only_occupied: bool = False,
+        as_of: str | None = None,
     ) -> list[Assignment]:
         existing = {a.seat_id: a for a in self.store.list()}
         out: list[Assignment] = []
@@ -68,6 +70,8 @@ class SeatService:
                 seat_id,
                 Assignment(seat_id=seat_id, floor=floor_id),
             )
+            if as_of is not None and not is_effective(a, as_of):
+                a = Assignment(seat_id=seat_id, floor=floor_id)
             a = self._apply_autovacate(a)
             if only_vacant and not a.is_vacant:
                 continue
@@ -76,10 +80,15 @@ class SeatService:
             out.append(a)
         return out
 
-    def whereis(self, email: str) -> Assignment | None:
+    def whereis(self, email: str, *, as_of: str | None = None) -> Assignment | None:
         if not self.directory.is_active(email):
             return None
-        return self.store.by_email(email)
+        a = self.store.by_email(email)
+        if a is None:
+            return None
+        if as_of is not None and not is_effective(a, as_of):
+            return None
+        return a
 
     def _apply_autovacate(self, a: Assignment) -> Assignment:
         """Return ``a`` with ``employee_email`` cleared if the employee is
@@ -110,6 +119,8 @@ class SeatService:
         *,
         note: str = "",
         hidden: bool = False,
+        effective_from: str | None = None,
+        effective_until: str | None = None,
     ) -> Assignment:
         floor_id = self._require_seat(seat_id)
         if not email:
@@ -137,6 +148,9 @@ class SeatService:
                 remediation=f"unassign first: office seats unassign {seat_id}",
             )
         now = self._clock()
+        eff_from = effective_from if effective_from is not None else today_iso_date(self._clock)
+        eff_until = effective_until or ""
+        validate_window(eff_from, eff_until)
         new = Assignment(
             seat_id=seat_id,
             floor=floor_id,
@@ -144,8 +158,8 @@ class SeatService:
             last_updated=now,
             hidden=hidden,
             notes=note or (current.notes if current else ""),
-            effective_from=now,
-            effective_until="",
+            effective_from=eff_from,
+            effective_until=eff_until,
         )
         self.store.upsert(new)
         self.audit.append(
@@ -227,7 +241,7 @@ class SeatService:
             last_updated=now,
             hidden=current.hidden,
             notes=note or current.notes,
-            effective_from=now,
+            effective_from=today_iso_date(self._clock),
         )
         self.store.upsert_many([vacated, moved])
         self.audit.append_many(

--- a/office_cli/seats/_service.py
+++ b/office_cli/seats/_service.py
@@ -62,20 +62,13 @@ class SeatService:
         existing = {a.seat_id: a for a in self.store.list()}
         out: list[Assignment] = []
         for seat_id, floor_id in sorted(self._seat_to_floor.items()):
-            if floor and floor_id != floor:
+            if not _seat_matches_scope(seat_id, floor_id, floor, cluster):
                 continue
-            if cluster and seat_id.split("-")[1:2] != [cluster]:
-                continue
-            a = existing.get(
-                seat_id,
-                Assignment(seat_id=seat_id, floor=floor_id),
-            )
+            a = existing.get(seat_id, Assignment(seat_id=seat_id, floor=floor_id))
             if as_of is not None and not is_effective(a, as_of):
                 a = Assignment(seat_id=seat_id, floor=floor_id)
             a = self._apply_autovacate(a)
-            if only_vacant and not a.is_vacant:
-                continue
-            if only_occupied and a.is_vacant:
+            if not _row_matches_occupancy(a, only_vacant, only_occupied):
                 continue
             out.append(a)
         return out
@@ -307,3 +300,26 @@ def _build_seat_index(
 
 def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _seat_matches_scope(
+    seat_id: str,
+    floor_id: str,
+    floor: str | None,
+    cluster: str | None,
+) -> bool:
+    """Return True iff the seat passes the ``--floor`` / ``--cluster`` filters."""
+    if floor and floor_id != floor:
+        return False
+    if cluster and seat_id.split("-")[1:2] != [cluster]:
+        return False
+    return True
+
+
+def _row_matches_occupancy(a: Assignment, only_vacant: bool, only_occupied: bool) -> bool:
+    """Return True iff the row passes the ``--vacant`` / ``--occupied`` filters."""
+    if only_vacant and not a.is_vacant:
+        return False
+    if only_occupied and a.is_vacant:
+        return False
+    return True

--- a/office_cli/server/_routes.py
+++ b/office_cli/server/_routes.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from office_cli._dates import parse_iso_date
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 from office_cli.offices import Floor, Office
 from office_cli.seats import Assignment, SeatService
@@ -35,7 +36,7 @@ def register_routes(app: Any, service: SeatService) -> None:
         return {"offices": [_office_to_dict(office) for office in service.offices.values()]}
 
     @app.get("/api/floors/{floor_id}")
-    def get_floor(floor_id: str) -> dict:
+    def get_floor(floor_id: str, as_of: str = "") -> dict:
         floor, office_id = _resolve_floor(service, floor_id)
         if floor is None:
             raise HTTPException(
@@ -45,11 +46,13 @@ def register_routes(app: Any, service: SeatService) -> None:
                     "remediation": "GET /api/offices to see available floor ids",
                 },
             )
-        seats = [_redact(a) for a in service.list_seats(floor=floor_id)]
+        as_of_value = parse_iso_date(as_of, field="as_of") if as_of else None
+        seats = [_redact(a) for a in service.list_seats(floor=floor_id, as_of=as_of_value)]
         return {
             "floor": _floor_to_dict(floor, office_id),
             "svg_url": f"/svgs/{floor.svg.name}",
             "seats": seats,
+            "as_of": as_of_value,
         }
 
     @app.get("/", response_class=RedirectResponse)

--- a/office_cli/server/_routes.py
+++ b/office_cli/server/_routes.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from office_cli._dates import parse_iso_date
+from office_cli._dates import parse_iso_date, today_iso_date
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 from office_cli.offices import Floor, Office
 from office_cli.seats import Assignment, SeatService
@@ -36,7 +36,11 @@ def register_routes(app: Any, service: SeatService) -> None:
         return {"offices": [_office_to_dict(office) for office in service.offices.values()]}
 
     @app.get("/api/floors/{floor_id}")
-    def get_floor(floor_id: str, as_of: str = "") -> dict:
+    def get_floor(floor_id: str, as_of: str = "", asOf: str = "") -> dict:
+        # Accept both ``as_of`` (Python convention) and ``asOf`` (camelCase
+        # used by the SPA URL surface so direct-API callers see the same
+        # contract). When both are passed, ``as_of`` wins.
+        raw = as_of or asOf
         floor, office_id = _resolve_floor(service, floor_id)
         if floor is None:
             raise HTTPException(
@@ -46,13 +50,21 @@ def register_routes(app: Any, service: SeatService) -> None:
                     "remediation": "GET /api/offices to see available floor ids",
                 },
             )
-        as_of_value = parse_iso_date(as_of, field="as_of") if as_of else None
+        if raw:
+            as_of_value = parse_iso_date(raw, field="as_of", example="?as_of=2026-07-01")
+            explicit = True
+        else:
+            as_of_value = today_iso_date(service._clock)
+            explicit = False
         seats = [_redact(a) for a in service.list_seats(floor=floor_id, as_of=as_of_value)]
         return {
             "floor": _floor_to_dict(floor, office_id),
             "svg_url": f"/svgs/{floor.svg.name}",
             "seats": seats,
-            "as_of": as_of_value,
+            # Echo the date back only when the caller asked for one — this
+            # is what the frontend uses to decide whether to surface the
+            # banner.
+            "as_of": as_of_value if explicit else None,
         }
 
     @app.get("/", response_class=RedirectResponse)

--- a/office_cli/server/_routes.py
+++ b/office_cli/server/_routes.py
@@ -24,7 +24,7 @@ _SHELL_PATH = Path(__file__).parent / "static" / "index.html"
 
 
 def register_routes(app: Any, service: SeatService) -> None:
-    from fastapi import HTTPException
+    from fastapi import HTTPException, Query
     from fastapi.responses import HTMLResponse, RedirectResponse
 
     from office_cli.server._app import static_dir
@@ -36,36 +36,15 @@ def register_routes(app: Any, service: SeatService) -> None:
         return {"offices": [_office_to_dict(office) for office in service.offices.values()]}
 
     @app.get("/api/floors/{floor_id}")
-    def get_floor(floor_id: str, as_of: str = "", asOf: str = "") -> dict:
-        # Accept both ``as_of`` (Python convention) and ``asOf`` (camelCase
-        # used by the SPA URL surface so direct-API callers see the same
-        # contract). When both are passed, ``as_of`` wins.
-        raw = as_of or asOf
-        floor, office_id = _resolve_floor(service, floor_id)
-        if floor is None:
-            raise HTTPException(
-                status_code=404,
-                detail={
-                    "error": f"unknown floor: {floor_id}",
-                    "remediation": "GET /api/offices to see available floor ids",
-                },
-            )
-        if raw:
-            as_of_value = parse_iso_date(raw, field="as_of", example="?as_of=2026-07-01")
-            explicit = True
-        else:
-            as_of_value = today_iso_date(service._clock)
-            explicit = False
-        seats = [_redact(a) for a in service.list_seats(floor=floor_id, as_of=as_of_value)]
-        return {
-            "floor": _floor_to_dict(floor, office_id),
-            "svg_url": f"/svgs/{floor.svg.name}",
-            "seats": seats,
-            # Echo the date back only when the caller asked for one — this
-            # is what the frontend uses to decide whether to surface the
-            # banner.
-            "as_of": as_of_value if explicit else None,
-        }
+    def get_floor(
+        floor_id: str,
+        as_of: str = "",
+        # Accept ``?asOf=`` (camelCase) as an alias so direct-API callers
+        # using the SPA URL convention work without translation. When both
+        # are passed, ``as_of`` wins.
+        as_of_camel: str = Query("", alias="asOf"),
+    ) -> dict:
+        return _build_floor_response(service, floor_id, as_of or as_of_camel, HTTPException)
 
     @app.get("/", response_class=RedirectResponse)
     def root() -> str:
@@ -121,6 +100,46 @@ def register_routes(app: Any, service: SeatService) -> None:
 
     # Stash so static_dir() callers (tests) can find it consistently.
     app.state.static_dir = static_dir()
+
+
+def _build_floor_response(
+    service: SeatService,
+    floor_id: str,
+    raw_as_of: str,
+    http_exception: Any,
+) -> dict[str, Any]:
+    """Pure builder for the ``/api/floors/{id}`` JSON body.
+
+    Lifted out of the closure inside :func:`register_routes` so the
+    closure stays small (and the analyzer's cognitive-complexity ceiling
+    stays satisfied as more routes accumulate).
+    """
+    floor, office_id = _resolve_floor(service, floor_id)
+    if floor is None:
+        raise http_exception(
+            status_code=404,
+            detail={
+                "error": f"unknown floor: {floor_id}",
+                "remediation": "GET /api/offices to see available floor ids",
+            },
+        )
+    if raw_as_of:
+        as_of_value: str | None = parse_iso_date(
+            raw_as_of, field="as_of", example="?as_of=2026-07-01"
+        )
+        explicit = True
+    else:
+        as_of_value = today_iso_date(service._clock)
+        explicit = False
+    seats = [_redact(a) for a in service.list_seats(floor=floor_id, as_of=as_of_value)]
+    return {
+        "floor": _floor_to_dict(floor, office_id),
+        "svg_url": f"/svgs/{floor.svg.name}",
+        "seats": seats,
+        # Echo the date back only when the caller asked for one — this is
+        # what the frontend uses to decide whether to surface the banner.
+        "as_of": as_of_value if explicit else None,
+    }
 
 
 def _office_to_dict(office: Office) -> dict[str, Any]:

--- a/office_cli/server/static/app.js
+++ b/office_cli/server/static/app.js
@@ -36,6 +36,7 @@ const state = {
   knownFloorIds: new Set(),
   currentFloorId: null,
   currentOfficeId: null,
+  currentAsOf: null,
   seats: [],
   fuse: null,
 };
@@ -74,6 +75,7 @@ function pushUrl(office, floor, seat) {
 // strictly-character-classed token.
 const FLOOR_ID_RE = /^[A-Za-z0-9._-]+$/;
 const SVG_NAME_RE = /^[A-Za-z0-9._-]+\.svg$/;
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 function checkResponse(r, label) {
   if (!r.ok) {
@@ -87,12 +89,19 @@ async function fetchOffices() {
   return (await checkResponse(r, "/api/offices")).json();
 }
 
-async function fetchFloor(floorId) {
+async function fetchFloor(floorId, asOf) {
   if (!FLOOR_ID_RE.test(floorId)) {
     throw new Error(`refusing to fetch floor with unexpected id: ${floorId}`);
   }
-  const r = await fetch(`/api/floors/${floorId}`);
-  return (await checkResponse(r, `/api/floors/${floorId}`)).json();
+  let url = `/api/floors/${floorId}`;
+  if (asOf) {
+    if (!ISO_DATE_RE.test(asOf)) {
+      throw new Error(`refusing to fetch floor with unexpected as_of: ${asOf}`);
+    }
+    url += `?as_of=${asOf}`;
+  }
+  const r = await fetch(url);
+  return (await checkResponse(r, url)).json();
 }
 
 async function fetchSvgByName(svgName) {
@@ -324,15 +333,17 @@ function inlineSvg(svgText) {
   return svg;
 }
 
-async function loadFloor(officeId, floorId) {
+async function loadFloor(officeId, floorId, asOf) {
   // Validate against the offices index so a tainted URL cannot drive a
-  // fetch to an arbitrary path. fetchFloor itself also validates the id.
+  // fetch to an arbitrary path. fetchFloor itself also validates the id
+  // and as_of.
   if (!state.knownFloorIds.has(floorId)) {
     throw new Error(`unknown floor: ${floorId}`);
   }
-  const data = await fetchFloor(floorId);
+  const data = await fetchFloor(floorId, asOf);
   state.currentOfficeId = officeId;
   state.currentFloorId = floorId;
+  state.currentAsOf = asOf || null;
   state.seats = data.seats;
   state.fuse = globalThis.Fuse
     ? new globalThis.Fuse(state.seats.map(searchableSeat), FUSE_OPTIONS)
@@ -373,7 +384,7 @@ async function loadOffices() {
   els.floorPicker.addEventListener("change", async () => {
     const [officeId, floorId] = els.floorPicker.value.split("|");
     try {
-      await loadFloor(officeId, floorId);
+      await loadFloor(officeId, floorId, urlState().asOf);
       pushUrl(officeId, floorId, null);
     } catch (err) {
       showError(err);
@@ -392,7 +403,7 @@ function showAsOfBanner(date) {
     return;
   }
   els.banner.hidden = false;
-  els.banner.textContent = `as-of ${date} is parsed but not yet enforced (Stage 6).`;
+  els.banner.textContent = `Showing seat map as of ${date}.`;
 }
 
 function showError(err) {
@@ -402,14 +413,18 @@ function showError(err) {
 
 async function syncFromUrl() {
   const u = urlState();
+  if (u.asOf && !ISO_DATE_RE.test(u.asOf)) {
+    showError(new Error(`asOf must be YYYY-MM-DD, got: ${u.asOf}`));
+    return;
+  }
   showAsOfBanner(u.asOf);
   if (!u.office || !u.floor) return;
   if (!state.knownFloorIds.has(u.floor)) {
     showError(new Error(`unknown floor: ${u.floor}`));
     return;
   }
-  if (state.currentFloorId !== u.floor) {
-    await loadFloor(u.office, u.floor);
+  if (state.currentFloorId !== u.floor || state.currentAsOf !== u.asOf) {
+    await loadFloor(u.office, u.floor, u.asOf);
     setFloorPickerValue(u.office, u.floor);
   }
   if (u.seat) {

--- a/office_cli/slack/_app.py
+++ b/office_cli/slack/_app.py
@@ -61,7 +61,7 @@ def _resolve_and_lookup(
     if target.email:
         email = target.email
         label = email
-        return _lookup(service, email, label)
+        return _lookup(service, email, label, as_of=target.as_of or None)
 
     user_id = target.user_id or command.get("user_id") or body.get("user_id", "")
     if not user_id:
@@ -73,7 +73,7 @@ def _resolve_and_lookup(
     # When the caller asked about themselves, label as "you"; otherwise
     # use the @-mention so Slack renders the name.
     label = "you" if target.self_lookup else f"<@{user_id}>"
-    return _lookup(service, email, label)
+    return _lookup(service, email, label, as_of=target.as_of or None)
 
 
 def _email_from_user_id(client: Any, user_id: str) -> tuple[str, str]:
@@ -90,11 +90,17 @@ def _email_from_user_id(client: Any, user_id: str) -> tuple[str, str]:
     return email, ""
 
 
-def _lookup(service: SeatService, email: str, label: str) -> tuple[list[dict[str, Any]], str]:
+def _lookup(
+    service: SeatService,
+    email: str,
+    label: str,
+    *,
+    as_of: str | None = None,
+) -> tuple[list[dict[str, Any]], str]:
     # Both blocks and the `text` fallback use ``label`` so we never leak
     # the resolved profile email through the screen-reader / older-client
     # rendering path — it would defeat the redaction the blocks rely on.
-    assignment = service.whereis(email)
+    assignment = service.whereis(email, as_of=as_of)
     if assignment is None:
         return _blocks.no_seat(label), f"no seat for {label}"
     if assignment.hidden:

--- a/office_cli/slack/_app.py
+++ b/office_cli/slack/_app.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from office_cli._dates import parse_iso_date, today_iso_date
+from office_cli.cli._errors import OfficeError
 from office_cli.seats import SeatService
 from office_cli.slack import _blocks
 from office_cli.slack._resolve import ParsedTarget, parse_target
@@ -58,10 +60,18 @@ def _resolve_and_lookup(
     if not target.ok:
         return _blocks.parse_failed(target.raw), "couldn't parse"
 
+    # Resolve the as-of date once — when the caller didn't pass a date,
+    # default to today (matches the CLI default; the trailing-token regex
+    # is permissive about month/day, so calendar-validate it explicitly).
+    try:
+        as_of = _resolve_as_of(service, target.as_of)
+    except OfficeError as err:
+        return _blocks.parse_failed(f"{target.as_of} — {err.message}"), "bad date"
+
     if target.email:
         email = target.email
         label = email
-        return _lookup(service, email, label, as_of=target.as_of or None)
+        return _lookup(service, email, label, as_of=as_of)
 
     user_id = target.user_id or command.get("user_id") or body.get("user_id", "")
     if not user_id:
@@ -73,7 +83,17 @@ def _resolve_and_lookup(
     # When the caller asked about themselves, label as "you"; otherwise
     # use the @-mention so Slack renders the name.
     label = "you" if target.self_lookup else f"<@{user_id}>"
-    return _lookup(service, email, label, as_of=target.as_of or None)
+    return _lookup(service, email, label, as_of=as_of)
+
+
+def _resolve_as_of(service: SeatService, raw: str) -> str:
+    """Calendar-validate ``raw`` if non-empty, else fall back to today.
+
+    Uses the service's clock so test injections continue to work.
+    """
+    if raw:
+        return parse_iso_date(raw, field="as-of date", example="2026-07-01")
+    return today_iso_date(service._clock)
 
 
 def _email_from_user_id(client: Any, user_id: str) -> tuple[str, str]:

--- a/office_cli/slack/_resolve.py
+++ b/office_cli/slack/_resolve.py
@@ -34,6 +34,10 @@ _MENTION_RE = re.compile(r"<@(?P<user_id>[UW][A-Z0-9]+)(?:\|[^>]*)?>")
 # Domain labels intentionally exclude `.` so the literal `\.` separators
 # are unambiguous — no overlapping classes, no super-linear backtracking.
 _EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}")
+# Trailing ``YYYY-MM-DD`` token. Anchored to a word boundary at the end
+# of the string so we only peel the date when it is the last token; an
+# email or mention preceding it stays intact.
+_TRAILING_DATE_RE = re.compile(r"(?:^|\s)(?P<date>\d{4}-\d{2}-\d{2})\s*$")
 
 
 @dataclass(frozen=True)
@@ -43,13 +47,16 @@ class ParsedTarget:
     Exactly one of ``user_id`` / ``email`` is set when the parse succeeds;
     both are empty when the text was not parseable. ``self_lookup`` flags
     the no-arg case so the caller can read the invoker's own ``user_id``
-    from the command body.
+    from the command body. ``as_of`` is the optional trailing
+    ``YYYY-MM-DD`` token (Stage 6); empty when the caller did not pass a
+    date.
     """
 
     user_id: str = ""
     email: str = ""
     self_lookup: bool = False
     raw: str = ""
+    as_of: str = ""
 
     @property
     def ok(self) -> bool:
@@ -61,11 +68,13 @@ def parse_target(text: str) -> ParsedTarget:
 
     Mention parsing happens *before* email parsing so a "user with
     `<@U123>` profile email" mention does not slip through as plain
-    text. Whitespace-only / empty text → ``self_lookup``. Input over
-    :data:`_MAX_INPUT_LEN` short-circuits to a parse failure with the
-    raw input truncated for the response message — defense in depth
-    against runaway regex evaluation, even though both regexes are
-    constructed to run in linear time.
+    text. Whitespace-only / empty text → ``self_lookup``. A trailing
+    ``YYYY-MM-DD`` token is peeled before mention/email parsing so
+    ``/whereis alice@x 2026-07-01`` and ``/whereis 2026-07-01`` both
+    work. Input over :data:`_MAX_INPUT_LEN` short-circuits to a parse
+    failure with the raw input truncated for the response message —
+    defense in depth against runaway regex evaluation, even though both
+    regexes are constructed to run in linear time.
     """
     raw = text or ""
     if len(raw) > _MAX_INPUT_LEN:
@@ -74,12 +83,20 @@ def parse_target(text: str) -> ParsedTarget:
     if not stripped:
         return ParsedTarget(self_lookup=True, raw="")
 
+    as_of = ""
+    date_match = _TRAILING_DATE_RE.search(stripped)
+    if date_match:
+        as_of = date_match["date"]
+        stripped = stripped[: date_match.start()].strip()
+        if not stripped:
+            return ParsedTarget(self_lookup=True, raw=raw.strip(), as_of=as_of)
+
     mention = _MENTION_RE.search(stripped)
     if mention:
-        return ParsedTarget(user_id=mention["user_id"], raw=stripped)
+        return ParsedTarget(user_id=mention["user_id"], raw=raw.strip(), as_of=as_of)
 
     email = _EMAIL_RE.search(stripped)
     if email:
-        return ParsedTarget(email=email.group(0), raw=stripped)
+        return ParsedTarget(email=email.group(0), raw=raw.strip(), as_of=as_of)
 
-    return ParsedTarget(raw=stripped)
+    return ParsedTarget(raw=raw.strip(), as_of=as_of)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.5.0"
+version = "0.6.0"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_seats.py
+++ b/tests/test_cli_seats.py
@@ -65,3 +65,58 @@ def test_list_text_smoke(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> 
     assert rc == 0
     out = capsys.readouterr().out
     assert "5-T-01" in out
+
+
+def test_assign_with_from_and_as_of_filter(
+    data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue #10 acceptance — assign --from in the future, then list --as-of."""
+    rc = main(
+        [
+            "seats",
+            "assign",
+            "5-T-01",
+            "alice@example.com",
+            "--from",
+            "2026-07-01",
+            *_data(data_dir),
+        ]
+    )
+    assert rc == 0
+    capsys.readouterr()
+
+    # --as-of before the window: row renders vacant.
+    rc = main(["seats", "list", "--json", "--as-of", "2026-06-30", *_data(data_dir)])
+    assert rc == 0
+    seats = {s["seat_id"]: s for s in json.loads(capsys.readouterr().out)["seats"]}
+    assert seats["5-T-01"]["employee_email"] is None
+
+    # --as-of inside the window: row visible.
+    rc = main(["seats", "list", "--json", "--as-of", "2026-07-15", *_data(data_dir)])
+    assert rc == 0
+    seats = {s["seat_id"]: s for s in json.loads(capsys.readouterr().out)["seats"]}
+    assert seats["5-T-01"]["employee_email"] == "alice@example.com"
+
+
+def test_assign_rejects_inverted_window(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(
+        [
+            "seats",
+            "assign",
+            "5-T-01",
+            "alice@example.com",
+            "--from",
+            "2026-08-01",
+            "--until",
+            "2026-07-01",
+            *_data(data_dir),
+        ]
+    )
+    assert rc == 1
+    assert "before" in capsys.readouterr().err
+
+
+def test_list_rejects_malformed_as_of(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["seats", "list", "--as-of", "tomorrow", *_data(data_dir)])
+    assert rc == 1
+    assert "--as-of" in capsys.readouterr().err

--- a/tests/test_cli_whereis.py
+++ b/tests/test_cli_whereis.py
@@ -51,3 +51,65 @@ def test_whereis_text(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> Non
     assert rc == 0
     out = capsys.readouterr().out
     assert "5-T-01" in out
+
+
+def test_whereis_as_of_filters(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    main(
+        [
+            "seats",
+            "assign",
+            "5-T-01",
+            "alice@example.com",
+            "--from",
+            "2026-07-01",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    capsys.readouterr()
+    # Before the effective window: no seat.
+    rc = main(
+        [
+            "whereis",
+            "alice@example.com",
+            "--as-of",
+            "2026-06-01",
+            "--json",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["assignment"] is None
+    # Inside the window: the row.
+    rc = main(
+        [
+            "whereis",
+            "alice@example.com",
+            "--as-of",
+            "2026-07-15",
+            "--json",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["assignment"]["seat_id"] == "5-T-01"
+
+
+def test_whereis_rejects_malformed_as_of(
+    data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = main(
+        [
+            "whereis",
+            "alice@example.com",
+            "--as-of",
+            "yesterday",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc == 1
+    assert "--as-of" in capsys.readouterr().err

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,0 +1,103 @@
+"""Tests for ``office_cli._dates``."""
+
+from __future__ import annotations
+
+import pytest
+
+from office_cli._dates import (
+    is_effective,
+    parse_iso_date,
+    today_iso_date,
+    validate_window,
+)
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+from office_cli.seats import Assignment
+
+
+def test_parse_iso_date_accepts_valid() -> None:
+    assert parse_iso_date("2026-07-01", field="--as-of") == "2026-07-01"
+    assert parse_iso_date("2026-12-31", field="--from") == "2026-12-31"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "2026-7-1",  # missing zero pad
+        "2026/07/01",  # wrong separator
+        "07-01-2026",  # wrong order
+        "2026-07-01T00:00:00Z",  # full ISO
+        "2026-13-01",  # bad month
+        "2026-02-30",  # not a real date
+        "",
+        "today",
+    ],
+)
+def test_parse_iso_date_rejects_malformed(bad: str) -> None:
+    with pytest.raises(OfficeError) as exc:
+        parse_iso_date(bad, field="--as-of")
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "--as-of" in exc.value.message
+
+
+def test_today_iso_date_strips_time_from_clock() -> None:
+    assert today_iso_date(lambda: "2026-05-01T12:34:56Z") == "2026-05-01"
+
+
+def test_today_iso_date_default() -> None:
+    # Just check shape — UTC today is fine for this assertion.
+    out = today_iso_date()
+    assert len(out) == 10
+    assert out[4] == "-" and out[7] == "-"
+
+
+def test_is_effective_window_inclusive() -> None:
+    a = Assignment(
+        seat_id="5-T-01",
+        floor="tlv-floor-5",
+        effective_from="2026-07-01",
+        effective_until="2026-08-31",
+    )
+    assert is_effective(a, "2026-07-01") is True
+    assert is_effective(a, "2026-08-31") is True
+    assert is_effective(a, "2026-06-30") is False
+    assert is_effective(a, "2026-09-01") is False
+
+
+def test_is_effective_open_bounds() -> None:
+    a = Assignment(seat_id="5-T-01", floor="tlv-floor-5")  # both empty
+    assert is_effective(a, "1999-01-01") is True
+    assert is_effective(a, "2099-01-01") is True
+
+    a_from = Assignment(seat_id="5-T-01", floor="tlv-floor-5", effective_from="2026-07-01")
+    assert is_effective(a_from, "2026-06-30") is False
+    assert is_effective(a_from, "2099-12-31") is True
+
+    a_until = Assignment(seat_id="5-T-01", floor="tlv-floor-5", effective_until="2026-07-01")
+    assert is_effective(a_until, "2026-07-02") is False
+    assert is_effective(a_until, "1999-01-01") is True
+
+
+def test_is_effective_strips_legacy_full_iso() -> None:
+    """Pre-Stage-6 rows store ``effective_from`` as a full ISO timestamp."""
+    a = Assignment(
+        seat_id="5-T-01",
+        floor="tlv-floor-5",
+        effective_from="2026-07-01T00:00:01Z",
+    )
+    # Without prefix-stripping, the lex comparison "2026-07-01T..." > "2026-07-01"
+    # would mark the row as not yet effective on its start day. Strip it.
+    assert is_effective(a, "2026-07-01") is True
+
+
+def test_validate_window_accepts_valid() -> None:
+    validate_window("2026-07-01", "2026-08-01")
+    validate_window("2026-07-01", "")
+    validate_window("", "2026-07-01")
+    validate_window("", "")
+
+
+def test_validate_window_rejects_inverted() -> None:
+    with pytest.raises(OfficeError) as exc:
+        validate_window("2026-08-01", "2026-07-01")
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "before" in exc.value.message

--- a/tests/test_seats_service_effective_dates.py
+++ b/tests/test_seats_service_effective_dates.py
@@ -1,0 +1,108 @@
+"""Tests for the Stage 6 effective-date filter in :class:`SeatService`."""
+
+from __future__ import annotations
+
+from itertools import count
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+from office_cli.seats import build_service
+
+
+def _service(data_dir: Path):
+    counter = count(1)
+
+    def clock() -> str:
+        return f"2026-05-01T00:00:{next(counter):02d}Z"
+
+    s = build_service(data_dir)
+    s._clock = clock  # noqa: SLF001 — deterministic for tests
+    return s
+
+
+def test_assign_default_effective_from_is_today_date_only(data_dir: Path) -> None:
+    s = _service(data_dir)
+    a = s.assign("5-T-01", "alice@example.com")
+    assert a.effective_from == "2026-05-01"
+    assert a.effective_until == ""
+    # ``last_updated`` keeps the full ISO timestamp.
+    assert a.last_updated.startswith("2026-05-01T")
+
+
+def test_assign_with_explicit_window(data_dir: Path) -> None:
+    s = _service(data_dir)
+    a = s.assign(
+        "5-T-01",
+        "alice@example.com",
+        effective_from="2026-07-01",
+        effective_until="2026-12-31",
+    )
+    assert a.effective_from == "2026-07-01"
+    assert a.effective_until == "2026-12-31"
+
+
+def test_assign_rejects_inverted_window(data_dir: Path) -> None:
+    s = _service(data_dir)
+    with pytest.raises(OfficeError) as exc:
+        s.assign(
+            "5-T-01",
+            "alice@example.com",
+            effective_from="2026-08-01",
+            effective_until="2026-07-01",
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+
+
+def test_whereis_filters_by_as_of(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com", effective_from="2026-07-01")
+
+    # Default (today, 2026-05-01): the assignment is not yet effective.
+    assert s.whereis("alice@example.com", as_of="2026-05-01") is None
+    # Future date inside the window: returned.
+    a = s.whereis("alice@example.com", as_of="2026-07-15")
+    assert a is not None
+    assert a.seat_id == "5-T-01"
+    # No filter at all: returns the underlying row regardless of date.
+    assert s.whereis("alice@example.com") is not None
+
+
+def test_list_seats_filters_by_as_of(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com", effective_from="2026-07-01")
+    s.assign("5-T-02", "bob@example.com")  # default = today
+
+    by_id_pre = {row.seat_id: row for row in s.list_seats(as_of="2026-06-30")}
+    # Alice's future-dated row is hidden as vacant.
+    assert by_id_pre["5-T-01"].employee_email == ""
+    # Bob's row is effective today (2026-05-01) — but as_of=2026-06-30 still
+    # falls inside [2026-05-01, ∞).
+    assert by_id_pre["5-T-02"].employee_email == "bob@example.com"
+
+    by_id_post = {row.seat_id: row for row in s.list_seats(as_of="2026-07-15")}
+    assert by_id_post["5-T-01"].employee_email == "alice@example.com"
+    assert by_id_post["5-T-02"].employee_email == "bob@example.com"
+
+
+def test_list_seats_no_as_of_unchanged(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com", effective_from="2026-07-01")
+    by_id = {row.seat_id: row for row in s.list_seats()}
+    # Without ``as_of``, the row is returned as-stored — no filtering.
+    assert by_id["5-T-01"].employee_email == "alice@example.com"
+
+
+def test_list_seats_until_excludes_after(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign(
+        "5-T-01",
+        "alice@example.com",
+        effective_from="2026-07-01",
+        effective_until="2026-08-31",
+    )
+    inside = {r.seat_id: r for r in s.list_seats(as_of="2026-08-01")}
+    after = {r.seat_id: r for r in s.list_seats(as_of="2026-09-01")}
+    assert inside["5-T-01"].employee_email == "alice@example.com"
+    assert after["5-T-01"].employee_email == ""

--- a/tests/test_seats_service_effective_dates.py
+++ b/tests/test_seats_service_effective_dates.py
@@ -72,7 +72,8 @@ def test_whereis_filters_by_as_of(data_dir: Path) -> None:
 def test_list_seats_filters_by_as_of(data_dir: Path) -> None:
     s = _service(data_dir)
     s.assign("5-T-01", "alice@example.com", effective_from="2026-07-01")
-    s.assign("5-T-02", "bob@example.com")  # default = today
+    # Bob: no explicit window, so effective_from defaults to today.
+    s.assign("5-T-02", "bob@example.com")
 
     by_id_pre = {row.seat_id: row for row in s.list_seats(as_of="2026-06-30")}
     # Alice's future-dated row is hidden as vacant.

--- a/tests/test_server_app.py
+++ b/tests/test_server_app.py
@@ -114,6 +114,31 @@ def test_get_floor_with_as_of_filters(data_dir: Path) -> None:
         assert body["as_of"] is None
 
 
+def test_get_floor_defaults_to_today_filter(data_dir: Path) -> None:
+    """No ``as_of`` query param → server defaults to today (using its clock)."""
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com", effective_from="2099-01-01")
+    with TestClient(build_app(s, data_dir=data_dir)) as c:
+        body = c.get("/api/floors/tlv-floor-5").json()
+    seats = {x["seat_id"]: x for x in body["seats"]}
+    # The future-dated row is hidden as vacant under the default-today filter.
+    assert seats["5-T-01"]["employee_email"] is None
+    # When the caller did not pass ``as_of``, the response echoes ``null`` so
+    # the frontend knows not to surface the banner.
+    assert body["as_of"] is None
+
+
+def test_get_floor_accepts_camelcase_asof(data_dir: Path) -> None:
+    """``?asOf=`` is honored alongside ``?as_of=`` for direct-API callers."""
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com", effective_from="2026-07-01")
+    with TestClient(build_app(s, data_dir=data_dir)) as c:
+        body = c.get("/api/floors/tlv-floor-5?asOf=2026-07-15").json()
+    seats = {x["seat_id"]: x for x in body["seats"]}
+    assert seats["5-T-01"]["employee_email"] == "alice@example.com"
+    assert body["as_of"] == "2026-07-15"
+
+
 def test_get_floor_rejects_malformed_as_of(data_dir: Path) -> None:
     with _client(data_dir) as c:
         r = c.get("/api/floors/tlv-floor-5?as_of=tomorrow")

--- a/tests/test_server_app.py
+++ b/tests/test_server_app.py
@@ -95,6 +95,34 @@ def test_autovacate_flows_through(data_dir: Path) -> None:
     assert seats["5-T-01"]["employee_email"] is None
 
 
+def test_get_floor_with_as_of_filters(data_dir: Path) -> None:
+    """Stage 6 — the server honors ``?as_of=`` and pipes it into the service."""
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com", effective_from="2026-07-01")
+    with TestClient(build_app(s, data_dir=data_dir)) as c:
+        # Before the window: row renders vacant.
+        body = c.get("/api/floors/tlv-floor-5?as_of=2026-06-30").json()
+        seats = {x["seat_id"]: x for x in body["seats"]}
+        assert seats["5-T-01"]["employee_email"] is None
+        assert body["as_of"] == "2026-06-30"
+        # Inside the window: row visible.
+        body = c.get("/api/floors/tlv-floor-5?as_of=2026-07-15").json()
+        seats = {x["seat_id"]: x for x in body["seats"]}
+        assert seats["5-T-01"]["employee_email"] == "alice@example.com"
+        # No ``as_of`` at all: as_of in response is null.
+        body = c.get("/api/floors/tlv-floor-5").json()
+        assert body["as_of"] is None
+
+
+def test_get_floor_rejects_malformed_as_of(data_dir: Path) -> None:
+    with _client(data_dir) as c:
+        r = c.get("/api/floors/tlv-floor-5?as_of=tomorrow")
+        assert r.status_code == 400
+        body = r.json()
+        assert "as_of" in body["error"]
+        assert "remediation" in body
+
+
 def test_unknown_floor_returns_404(data_dir: Path) -> None:
     with _client(data_dir) as c:
         r = c.get("/api/floors/no-such-floor")

--- a/tests/test_slack_app.py
+++ b/tests/test_slack_app.py
@@ -237,6 +237,34 @@ def test_users_info_missing_email_renders_clear_message(data_dir: Path) -> None:
     assert "users:read.email" in text  # remediation hint surfaced
 
 
+def test_trailing_date_filters_via_as_of(data_dir: Path) -> None:
+    """Stage 6 — trailing ``YYYY-MM-DD`` token filters via the effective window."""
+    service = _service_with_active(data_dir, "alice@example.com")
+    service.assign("5-T-01", "alice@example.com", effective_from="2026-07-01")
+    app = build_app(service, app=FakeSlackApp())
+
+    # Before the window — handler should report "no seat".
+    client_pre = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alice@example.com 2026-06-30"},
+        client=client_pre,
+    )
+    assert "No seat assigned" in _block_text(_last_blocks(client_pre))
+
+    # Inside the window — the seat should appear.
+    client_post = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alice@example.com 2026-07-15"},
+        client=client_post,
+    )
+    text = _block_text(_last_blocks(client_post))
+    assert "5-T-01" in text
+
+
 def test_deep_link_button_when_base_url_set(
     data_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_slack_app.py
+++ b/tests/test_slack_app.py
@@ -237,6 +237,37 @@ def test_users_info_missing_email_renders_clear_message(data_dir: Path) -> None:
     assert "users:read.email" in text  # remediation hint surfaced
 
 
+def test_no_trailing_date_defaults_to_today_filter(data_dir: Path) -> None:
+    """Slack defaults ``as_of`` to today so a future-dated row is hidden."""
+    service = _service_with_active(data_dir, "alice@example.com")
+    service.assign("5-T-01", "alice@example.com", effective_from="2099-01-01")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alice@example.com"},
+        client=client,
+    )
+    assert "No seat assigned" in _block_text(_last_blocks(client))
+
+
+def test_invalid_calendar_date_rejected(data_dir: Path) -> None:
+    """Trailing tokens that match the regex but aren't real dates surface as parse failures."""
+    service = _service_with_active(data_dir, "alice@example.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alice@example.com 2026-02-30"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    # parse_failed block surfaces the bad date in the message.
+    assert "2026-02-30" in text
+
+
 def test_trailing_date_filters_via_as_of(data_dir: Path) -> None:
     """Stage 6 — trailing ``YYYY-MM-DD`` token filters via the effective window."""
     service = _service_with_active(data_dir, "alice@example.com")

--- a/tests/test_slack_resolve.py
+++ b/tests/test_slack_resolve.py
@@ -86,6 +86,36 @@ def test_overlong_input_short_circuits() -> None:
     assert target.raw.endswith("…")  # truncated marker
 
 
+def test_trailing_date_with_email() -> None:
+    target = parse_target("alice@x.com 2026-07-01")
+    assert target.email == "alice@x.com"
+    assert target.as_of == "2026-07-01"
+
+
+def test_trailing_date_with_mention() -> None:
+    target = parse_target("<@U123|alice> 2026-07-01")
+    assert target.user_id == "U123"
+    assert target.as_of == "2026-07-01"
+
+
+def test_trailing_date_only_is_self_lookup() -> None:
+    target = parse_target("2026-07-01")
+    assert target.self_lookup is True
+    assert target.as_of == "2026-07-01"
+
+
+def test_no_trailing_date_means_empty_as_of() -> None:
+    assert parse_target("alice@x.com").as_of == ""
+    assert parse_target("").as_of == ""
+
+
+def test_date_in_middle_not_peeled() -> None:
+    """Only a trailing date is peeled — a mid-string date stays in the text."""
+    target = parse_target("2026-07-01 alice@x.com")
+    assert target.email == "alice@x.com"
+    assert target.as_of == ""
+
+
 def test_redos_pathological_input_completes_quickly() -> None:
     """Adversarial input that would have been polynomial under the old
     `[A-Za-z0-9.-]+\\.[A-Za-z]{2,}` shape now matches/fails in linear

--- a/uv.lock
+++ b/uv.lock
@@ -569,7 +569,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
Closes #10.

## Summary

Wires the `effective_from` / `effective_until` window through
`SeatService.list_seats` / `.whereis` / `.assign` and all three surfaces:

- **CLI**: `office seats list --as-of`, `office whereis --as-of`,
  `office seats assign --from / --until`. Defaults to today when
  `--as-of` is omitted.
- **Web**: `GET /api/floors/{id}?as_of=YYYY-MM-DD`; malformed dates
  surface as `400 {error, remediation}`. Frontend banner copy switches
  from "not yet enforced" to "Showing seat map as of YYYY-MM-DD."
- **Slack**: `/whereis` accepts an optional trailing `YYYY-MM-DD` token —
  `/whereis alice@x 2026-07-01`, `/whereis @alice 2026-07-01`, and
  `/whereis 2026-07-01` (self lookup) all work.

Storage shape: `effective_from` / `effective_until` are now **date-only**
(`YYYY-MM-DD`); `last_updated` and audit-log timestamps stay full ISO-
8601. Pre-Stage-6 rows that wrote a full ISO timestamp into
`effective_from` keep working — `is_effective` strips the `T...` suffix
before comparison.

New `office_cli._dates` module: `parse_iso_date`, `today_iso_date`,
`is_effective`, `validate_window`. All malformed-date paths raise
`OfficeError(EXIT_USER_ERROR)` with a clear remediation. Bumped to 0.6.0.

## Test plan

- [x] 202 tests pass (`uv run pytest -n auto -q`)
- [x] black / isort / flake8 / bandit / markdownlint all clean
- [x] CLI acceptance smoke (issue #10 checklist):
      - assign with `--from 2026-07-01`, `whereis` (default today) → "no seat"
      - `whereis --as-of 2026-07-15` → returns the seat
      - `seats list --as-of 2026-06-30` → vacant
      - `seats list --as-of 2026-07-15` → assigned
- [x] Web acceptance smoke against the running server:
      - `?as_of=2026-06-30` → `employee_email: null`
      - `?as_of=2026-07-15` → `employee_email: "alice@example.com"`
      - `?as_of=tomorrow` → `400 {error, remediation}`

- Claude