### PR TITLE
feat: v1 seating Stage 7 — SSO + roles (viewer / editor / planning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-01
+
+### Added
+
+- v1 seating Stage 7 — SSO + roles
+  ([#11](https://github.com/agentculture/office-agent/issues/11)).
+  Three roles: `viewer` (default — sees `hidden=TRUE` seats as
+  "occupied (private)"), `editor` (HR/IT — full details on hidden
+  seats), `planning` (facilities — same as editor in v1; the
+  draft-SVG and future-dated carve-outs from issue #1 are deferred).
+- New `office_cli._roles` module: `RolesConfig`, `resolve_roles`,
+  `role_for_email`, `is_full_access`. Roles map lives in
+  `data/offices.yaml` under a top-level `roles:` block.
+- `SeatService.list_seats(role=...)` and `whereis(email, role=...)`
+  apply role-aware redaction at view time: viewer callers see hidden
+  rows with cleared `employee_email` / `notes` and `redacted=True`.
+  CLI passes no role and stays unrestricted.
+- New optional extra: `pip install office-cli[sso]` pulls
+  `authlib>=1.3`, `itsdangerous>=2.1`, and `httpx>=0.27`. The
+  package still imports cleanly without it.
+- Web SSO: new `office_cli.server._auth` module with `OIDCConfig`,
+  `resolve_oidc`, `register_auth_routes`, `current_user`. When all
+  five env vars (`OIDC_ISSUER`, `OIDC_CLIENT_ID`,
+  `OIDC_CLIENT_SECRET`, `OIDC_REDIRECT_URL`, `SESSION_SECRET`) are
+  set, `office serve` enables a SessionMiddleware-backed login flow;
+  unauthenticated browsers are redirected to `/auth/login` and back
+  to the originating URL after callback.
+- Web auth-disabled mode for local dev / tests — when OIDC env vars
+  are unset, the server runs without redirects. An optional
+  `X-Test-Role` header drives role-aware behavior so tests can
+  exercise viewer / editor / planning without sessions. The header
+  is **only** honored when OIDC is disabled.
+- `GET /api/floors/{id}` now returns a `user: {email, role}` field
+  (or `null` when unauthenticated) so the SPA can render the signed-
+  in identity in the header. Stage 7 adds a small `#user-info` slot
+  with a logout button to the SPA shell.
+- Slack `/whereis` resolves the calling user's email via the existing
+  `users.info` flow and looks up their role. Hidden seats render as
+  "occupied (private)" for viewer callers; editor/planning callers
+  see the full block.
+
+### Changed
+
+- `Assignment` gains a non-persisted `redacted: bool = False` flag
+  set by the service when role-aware redaction is applied. CSV /
+  Sheets stores keep their existing column shape (`redacted` is a
+  view-time signal only).
+
 ## [0.6.0] - 2026-05-01
 
 ### Added
@@ -197,7 +245,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   preserving the SVG ID contract and architectural guardrails for the v1
   seating system (issue #1).
 
-[Unreleased]: https://github.com/agentculture/office-agent/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/agentculture/office-agent/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/agentculture/office-agent/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/agentculture/office-agent/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/agentculture/office-agent/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/agentculture/office-agent/compare/v0.3.0...v0.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,12 +39,14 @@ office-agent/
 │   │   └── _commands/           # learn, explain, whoami, floors, seats, whereis
 │   ├── _config.py               # resolve_data_dir() / --data-dir / OFFICE_DATA_DIR
 │   ├── _dates.py                # parse_iso_date / today_iso_date / is_effective (Stage 6)
+│   ├── _roles.py                # RolesConfig / role_for_email / is_full_access (Stage 7)
 │   ├── offices/                 # offices.yaml loader + Office/Floor/Cluster/Room
 │   ├── floors/                  # SVG parse + ID contract + validator
 │   ├── seats/                   # AssignmentStore + Csv/Sheets stores + AuditLog + SeatService
 │   ├── people/                  # Employee + EmployeeDirectory (Stub + BambooHR backends)
 │   ├── slack/                   # `/whereis` Bolt app + Socket Mode runner (optional [slack] extra)
 │   ├── server/                  # FastAPI seat-map server + vanilla-JS frontend (optional [web] extra)
+│   │                            # Stage 7: SSO + role-aware redaction (optional [sso] extra)
 │   └── explain/                 # Markdown catalog for `office explain <path>`
 ├── data/offices.yaml            # office / floor / cluster topology
 ├── floors/                      # human-traced floor SVGs
@@ -61,7 +63,7 @@ office-agent/
 ```bash
 uv sync                           # install runtime + dev deps
 uv run pytest -n auto -v          # full suite, parallel
-uv run office --version           # 0.6.0
+uv run office --version           # 0.7.0
 uv run office learn               # agent affordance
 uv run office whoami              # auth probe stub
 uv run office floors validate floors/tlv-floor-5.svg
@@ -142,7 +144,7 @@ Lessons paid for in advance — don't relitigate without a reason:
 - **Audit log is append-only.** Seat changes never overwrite history; "who used to sit at 5-T-01?" must return chronological history.
 - **Multi-office from day one.** No hardcoded `tlv`. Adding a floor = drop SVG + add `data/offices.yaml` entry, no code change.
 - **Future-dated assignments**: the data model carries `effective_from` / `effective_until` and Stage 6 enforces them at the service layer. `office seats assign --from / --until`, `office whereis --as-of`, `office seats list --as-of`, `?asOf=YYYY-MM-DD` on the web map, and a trailing `YYYY-MM-DD` token on Slack `/whereis` all flow through the same window check. `effective_*` is stored as `YYYY-MM-DD` (date precision, no time); `last_updated` and audit timestamps stay full ISO-8601.
-- **`hidden=TRUE`** rows show as "occupied (private)" to viewers; full details only to the `editor` / `planning` roles.
+- **`hidden=TRUE`** rows show as "occupied (private)" to viewers; full details only to the `editor` / `planning` roles. Stage 7 enforces this end-to-end. Roles map lives in `data/offices.yaml` under `roles:`. The CLI is operator-only and unrestricted (`role=None` → no redaction). Web SSO is opt-in via `OIDC_*`/`SESSION_SECRET` env vars; when unset, the server runs in auth-disabled mode (local dev). Tests use `X-Test-Role: viewer|editor|planning` to drive role-aware behavior; this header is **only** honored when OIDC is disabled.
 - **Out of scope for v1**: hot-desking / desk booking, native mobile app, visitor/badge/sensor integration, in-app SVG editor.
 
 ## Picking up issue #1

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ BambooHR; assignments live in a Google Sheet (v1) or DynamoDB (v2). The
 CLI exposes the same operations as the Slack `/whereis` command and the
 web map.
 
-> **Status — v0.6.0.** Stages 1–6 of the v1 seating system are in:
+> **Status — v0.7.0.** Stages 1–7 of the v1 seating system are in:
 > floor SVG parser/validator, CSV / Google Sheets-backed assignment
 > store with append-only audit log, BambooHR-backed `EmployeeDirectory`
 > with the auto-vacate killer feature, CLI verbs (`floors`, `seats`,
 > `whereis`), a Slack `/whereis` slash-command listener, a search-first
-> web map, and effective-date enforcement. SSO/roles and DynamoDB
-> land in later stages. See
+> web map, effective-date enforcement, and SSO + role-aware redaction.
+> DynamoDB lands in Stage 8. See
 > [issue #1](https://github.com/agentculture/office-agent/issues/1).
 
 ## Naming surfaces
@@ -162,6 +162,49 @@ shows the same view, deep-linkable.
 `effective_from` / `effective_until` are stored as `YYYY-MM-DD` (date
 precision); `last_updated` and audit-log timestamps stay full ISO-8601.
 Empty bounds mean "always begins" / "no end".
+
+### SSO + roles
+
+The web frontend can be gated behind your IdP via OIDC. Three roles
+are recognized: `viewer` (default — sees `hidden=TRUE` seats as
+"occupied (private)"), `editor` (HR/IT — full details on hidden
+seats), and `planning` (facilities — same as editor in v1).
+
+```bash
+pip install office-cli[sso,web]
+export OIDC_ISSUER=https://your-idp.example.com
+export OIDC_CLIENT_ID=office-agent
+export OIDC_CLIENT_SECRET=xxx
+export OIDC_REDIRECT_URL=https://office.example.com/auth/callback
+export SESSION_SECRET=$(openssl rand -hex 32)
+office serve --port 8000
+```
+
+Role mapping lives in `data/offices.yaml` under a top-level `roles:`
+block:
+
+```yaml
+roles:
+  editor:
+    - "hr-it@tipalti.com"
+    - "alice@tipalti.com"
+  planning:
+    - "facilities@tipalti.com"
+```
+
+Anything not listed is `viewer` — including unmatched authenticated
+users.
+
+When the OIDC env vars are unset, `office serve` runs in
+**auth-disabled** mode: no redirects, no session middleware, every
+request is anonymous. This is the default for local dev. An optional
+`X-Test-Role: editor` request header drives role-aware behavior in
+that mode (useful for `curl` smoke tests). The header is **only**
+honored when OIDC is disabled.
+
+The CLI is operator-only and **always** unrestricted (no role flag).
+Slack `/whereis` resolves the calling user's role from their email
+via the same roles map.
 
 ## Adding a new floor
 

--- a/data/offices.yaml
+++ b/data/offices.yaml
@@ -8,6 +8,16 @@
 # - each cluster declares an integer capacity; the build warns if it does not
 #   match the count of seat ids in the SVG;
 # - rooms list architect ids verbatim (`5.18`).
+#
+# Stage 7 — SSO + roles (issue #11). Optional `roles:` block maps
+# emails to elevated roles. Anything not listed is `viewer` (the default
+# — sees `hidden=TRUE` seats as "occupied (private)"). Example:
+#
+#   roles:
+#     editor:
+#       - "hr-it@tipalti.com"
+#     planning:
+#       - "facilities@tipalti.com"
 
 offices:
   - id: tlv

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture — v0.6.0 (Stages 1–6)
+# Architecture — v0.7.0 (Stages 1–7)
 
 `office` ships in stages on top of issue
 [#1](https://github.com/agentculture/office-agent/issues/1). This document
@@ -259,13 +259,51 @@ The `effective_from` / `effective_until` columns reserved by Stage 1 +
   with a remediation, and the web routes map that to
   `400 {error, remediation}` via the existing handler.
 
+## Stage 7 — implemented in v0.7.0
+
+SSO + roles ([#11](https://github.com/agentculture/office-agent/issues/11)).
+Three roles: `viewer` (default — sees `hidden=TRUE` seats as
+"occupied (private)"), `editor` (HR/IT — full details on hidden
+seats), `planning` (facilities — same as editor in v1).
+
+- `office_cli/_roles.py`: `RolesConfig`, `resolve_roles`,
+  `role_for_email`, `is_full_access`. Roles map lives in
+  `data/offices.yaml` under a top-level `roles:` block —
+  `editor: [...]` / `planning: [...]` lists of emails. Anything not
+  listed is `viewer`.
+- `SeatService.list_seats(role=...)` and `whereis(role=...)` apply
+  role-aware redaction at view time. `role=None` (CLI default) is
+  unrestricted; `role="viewer"` clears `employee_email` / `notes`
+  on `hidden=TRUE` rows and sets `redacted=True` (a non-persisted
+  view-time flag on `Assignment`). Surface renderers consult
+  `redacted` to render the `"(private)"` placeholder.
+- Web SSO via `office_cli/server/_auth.py` — `OIDCConfig`,
+  `register_auth_routes` (using `authlib.integrations.starlette_client`).
+  When all five env vars (`OIDC_ISSUER`, `OIDC_CLIENT_ID`,
+  `OIDC_CLIENT_SECRET`, `OIDC_REDIRECT_URL`, `SESSION_SECRET`) are
+  set, the SPA shell route requires auth and unauth browsers are
+  redirected through the IdP.
+- Auth-disabled mode: when OIDC env vars are unset, the server runs
+  without redirects (local dev). Tests use the `X-Test-Role`
+  header to drive role-aware behavior; the header is **only**
+  honored when OIDC is disabled (production sets the env vars and
+  ignores it).
+- Slack `/whereis` resolves the calling user's email via the
+  existing `users.info` flow and looks up their role from
+  `RolesConfig`. The block-level "occupied (private)" path is now
+  gated on `assignment.redacted`, not on `assignment.hidden`, so
+  editor / planning callers see the full block.
+- Audit-log redaction is explicitly out of scope (issue #11) — the
+  audit log is operator-internal and append-only; full data is OK.
+- The planning role's draft-SVG and future-dated visibility carve-outs
+  from issue #1 stay deferred.
+
 ## Deferred surfaces
 
 Each is a separate issue/PR.
 
 | Stage              | Surface                                       | Notes                                                                   |
 | ------------------ | --------------------------------------------- | ----------------------------------------------------------------------- |
-| 7. SSO + roles     | viewer / editor / planning                    | Drives whether `hidden=TRUE` rows expose details.                       |
 | 8. DynamoDB        | `office_cli.seats.DynamoStore`                | Migration script from Sheets, kept identical Protocol.                  |
 
 ## Operating notes

--- a/office_cli/_roles.py
+++ b/office_cli/_roles.py
@@ -1,0 +1,134 @@
+"""Role mapping for the v1 seating system (Stage 7, issue #11).
+
+Three roles are recognized:
+
+* :data:`VIEWER` — everyone (default). Sees ``hidden=TRUE`` seats as
+  ``"occupied (private)"`` with no email/notes.
+* :data:`EDITOR` — HR/IT. Sees full details on hidden seats.
+* :data:`PLANNING` — facilities team. Same as editor in v1; the
+  draft-SVG and future-dated carve-outs from issue #1 are deferred.
+
+The role for a given email is resolved at view time. The mapping lives
+in ``data/offices.yaml`` under a top-level ``roles:`` block, e.g.::
+
+    roles:
+      editor: ["hr-it@tipalti.com", "alice@tipalti.com"]
+      planning: ["facilities@tipalti.com"]
+
+Anything not listed → ``viewer``. The CLI is operator-only and is
+treated as unrestricted (it passes ``role=None`` to the service).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+
+VIEWER = "viewer"
+EDITOR = "editor"
+PLANNING = "planning"
+_ROLES = (VIEWER, EDITOR, PLANNING)
+_CONFIGURABLE = (EDITOR, PLANNING)
+_SHAPE_HINT = "see docs/architecture.md for the expected shape"
+
+
+@dataclass(frozen=True)
+class RolesConfig:
+    """Resolved role-to-emails mapping.
+
+    Both fields hold lowercased emails so lookup is case-insensitive
+    without per-call work. ``viewer`` is the default for any email
+    that does not appear in either set.
+    """
+
+    editor: frozenset[str] = field(default_factory=frozenset)
+    planning: frozenset[str] = field(default_factory=frozenset)
+
+
+def resolve_roles(data_dir: Path) -> RolesConfig:
+    """Read the ``roles:`` block from ``data/offices.yaml``.
+
+    Missing block / empty file → empty config (everyone is viewer).
+    Malformed shape (e.g. ``editor:`` is a string instead of a list)
+    raises :class:`OfficeError(EXIT_USER_ERROR)` with a remediation.
+    """
+    yaml_path = data_dir / "data" / "offices.yaml"
+    if not yaml_path.is_file():
+        return RolesConfig()
+    with yaml_path.open("r", encoding="utf-8") as f:
+        try:
+            raw = yaml.safe_load(f) or {}
+        except yaml.YAMLError:
+            return RolesConfig()
+    block = raw.get("roles") or {}
+    if not isinstance(block, dict):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="roles must be a mapping in offices.yaml",
+            remediation=_SHAPE_HINT,
+        )
+    return RolesConfig(
+        editor=_emails(block.get("editor"), key="roles.editor"),
+        planning=_emails(block.get("planning"), key="roles.planning"),
+    )
+
+
+def role_for_email(roles: RolesConfig, email: str) -> str:
+    """Return the role for ``email``. Defaults to ``viewer``.
+
+    Lookup is case-insensitive — the parsed config already lowercases
+    the configured emails; we lowercase the input here.
+    """
+    if not email:
+        return VIEWER
+    needle = email.strip().lower()
+    if needle in roles.editor:
+        return EDITOR
+    if needle in roles.planning:
+        return PLANNING
+    return VIEWER
+
+
+def is_full_access(role: str | None) -> bool:
+    """Return True iff ``role`` sees full details on hidden seats.
+
+    ``role=None`` is the CLI-style unrestricted case. Editor and
+    planning both see everything in v1; the planning carve-outs from
+    issue #1 (draft SVGs, future-dated visibility) land later.
+    """
+    return role is None or role in (EDITOR, PLANNING)
+
+
+def _emails(value: object, *, key: str) -> frozenset[str]:
+    """Coerce a YAML list-of-strings into a lowercased frozenset.
+
+    Empty / None → empty set. A non-list value raises
+    :class:`OfficeError`.
+    """
+    if value is None:
+        return frozenset()
+    if not isinstance(value, list):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"{key} must be a list of emails",
+            remediation=_SHAPE_HINT,
+        )
+    return frozenset(_normalize(value, key=key))
+
+
+def _normalize(emails: Iterable[object], *, key: str) -> Iterable[str]:
+    for email in emails:
+        if not isinstance(email, str):
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"{key} entries must be strings; got {type(email).__name__}",
+                remediation=_SHAPE_HINT,
+            )
+        normalized = email.strip().lower()
+        if normalized:
+            yield normalized

--- a/office_cli/cli/_commands/slack_serve.py
+++ b/office_cli/cli/_commands/slack_serve.py
@@ -57,7 +57,10 @@ def cmd_slack_serve(args: argparse.Namespace) -> int:
     from office_cli.slack import build_app, run_socket_mode
 
     app = App(token=bot_token)
-    build_app(service, app=app)
+    # Pass ``data_dir`` so build_app auto-resolves the roles map from
+    # ``data/offices.yaml``. Without this, every Slack caller would be
+    # treated as ``viewer`` regardless of the editor/planning lists.
+    build_app(service, app=app, data_dir=data_dir)
     emit_diagnostic("Slack /whereis listener starting (Socket Mode)…")
     run_socket_mode(app, app_token)
     return 0

--- a/office_cli/seats/_models.py
+++ b/office_cli/seats/_models.py
@@ -15,6 +15,11 @@ class Assignment:
     notes: str = ""
     effective_from: str = ""
     effective_until: str = ""
+    # View-time flag — set by SeatService when role-aware redaction
+    # blanked the email/notes. Surface renderers consult this to render
+    # "(private)" instead of "(vacant)" for a redacted hidden seat.
+    # Never persisted (CSV/Sheets stores write only their FIELDNAMES).
+    redacted: bool = False
 
     @property
     def is_vacant(self) -> bool:
@@ -30,6 +35,7 @@ class Assignment:
             "notes": self.notes,
             "effective_from": self.effective_from or None,
             "effective_until": self.effective_until or None,
+            "redacted": self.redacted,
         }
 
 

--- a/office_cli/seats/_service.py
+++ b/office_cli/seats/_service.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from typing import Iterable, cast
 
 from office_cli._dates import is_effective, today_iso_date, validate_window
+from office_cli._roles import is_full_access
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 from office_cli.floors import FloorSvg
 from office_cli.offices import Office
@@ -58,6 +59,7 @@ class SeatService:
         only_vacant: bool = False,
         only_occupied: bool = False,
         as_of: str | None = None,
+        role: str | None = None,
     ) -> list[Assignment]:
         existing = {a.seat_id: a for a in self.store.list()}
         out: list[Assignment] = []
@@ -68,12 +70,19 @@ class SeatService:
             if as_of is not None and not is_effective(a, as_of):
                 a = Assignment(seat_id=seat_id, floor=floor_id)
             a = self._apply_autovacate(a)
+            a = _apply_role_redaction(a, role)
             if not _row_matches_occupancy(a, only_vacant, only_occupied):
                 continue
             out.append(a)
         return out
 
-    def whereis(self, email: str, *, as_of: str | None = None) -> Assignment | None:
+    def whereis(
+        self,
+        email: str,
+        *,
+        as_of: str | None = None,
+        role: str | None = None,
+    ) -> Assignment | None:
         if not self.directory.is_active(email):
             return None
         a = self.store.by_email(email)
@@ -81,7 +90,7 @@ class SeatService:
             return None
         if as_of is not None and not is_effective(a, as_of):
             return None
-        return a
+        return _apply_role_redaction(a, role)
 
     def _apply_autovacate(self, a: Assignment) -> Assignment:
         """Return ``a`` with ``employee_email`` cleared if the employee is
@@ -323,3 +332,46 @@ def _row_matches_occupancy(a: Assignment, only_vacant: bool, only_occupied: bool
     if only_occupied and a.is_vacant:
         return False
     return True
+
+
+def _apply_role_redaction(a: Assignment, role: str | None) -> Assignment:
+    """Stage 7 view-time redaction for ``hidden=TRUE`` rows.
+
+    ``role=None`` is the unrestricted CLI default — pass through. Editor
+    and planning see full details (``is_full_access``). Viewer sees a
+    redacted row: blank ``employee_email`` / ``notes`` and ``redacted=True``
+    so the surface renderer can show ``"(private)"`` instead of
+    ``"(vacant)"``.
+
+    A hidden-but-vacant row has nothing to hide — ``redacted`` stays
+    ``False`` so the surface renders it as a regular vacant seat, not
+    as ``"(private)"``. Notes still get scrubbed (the privacy intent on
+    the row stands even when there's no occupant — Qodo Q4 from
+    Stage 5).
+    """
+    if not a.hidden or is_full_access(role):
+        return a
+    if not a.employee_email:
+        # Hidden + vacant: no email to hide; only scrub notes.
+        return Assignment(
+            seat_id=a.seat_id,
+            floor=a.floor,
+            employee_email="",
+            last_updated=a.last_updated,
+            hidden=True,
+            notes="",
+            effective_from=a.effective_from,
+            effective_until=a.effective_until,
+            redacted=False,
+        )
+    return Assignment(
+        seat_id=a.seat_id,
+        floor=a.floor,
+        employee_email="",
+        last_updated=a.last_updated,
+        hidden=True,
+        notes="",
+        effective_from=a.effective_from,
+        effective_until=a.effective_until,
+        redacted=True,
+    )

--- a/office_cli/server/_app.py
+++ b/office_cli/server/_app.py
@@ -19,25 +19,28 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from office_cli._roles import RolesConfig
+from office_cli._roles import RolesConfig, resolve_roles
 from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
 from office_cli.seats import SeatService
 from office_cli.server._auth import (
-    OIDCConfig,
     install_session_middleware,
     register_auth_routes,
+    resolve_oidc,
 )
 from office_cli.server._routes import register_routes
 
 _STATIC_DIR = Path(__file__).parent / "static"
 
 
+_AUTO = object()
+
+
 def build_app(
     service: SeatService,
     *,
     data_dir: Path | None = None,
-    oidc: OIDCConfig | None = None,
-    roles: RolesConfig | None = None,
+    oidc: Any = _AUTO,
+    roles: Any = _AUTO,
 ) -> Any:
     """Construct the FastAPI app for ``service``.
 
@@ -45,9 +48,11 @@ def build_app(
     static SVG content. When omitted, the location is inferred from the
     first floor's ``svg`` path.
 
-    ``oidc`` enables the SSO flow when set. ``None`` keeps auth
-    disabled (dev / tests). ``roles`` is the role-mapping config; when
-    ``None`` everyone is treated as ``viewer``.
+    ``oidc`` enables the SSO flow when set. The default sentinel
+    ``_AUTO`` calls :func:`resolve_oidc` to pick up the env-based
+    configuration; pass ``None`` explicitly to force auth-disabled mode
+    (used by tests). ``roles`` follows the same pattern: ``_AUTO``
+    resolves from ``data/offices.yaml``, ``None`` keeps it empty.
     """
     try:
         from fastapi import FastAPI
@@ -60,6 +65,10 @@ def build_app(
         ) from err
 
     floors_dir = _floors_dir(service, data_dir)
+    if oidc is _AUTO:
+        oidc = resolve_oidc()
+    if roles is _AUTO:
+        roles = resolve_roles(data_dir) if data_dir is not None else RolesConfig()
     app = FastAPI(title="office", docs_url=None, redoc_url=None)
     roles_cfg = roles or RolesConfig()
     if oidc is not None:

--- a/office_cli/server/_app.py
+++ b/office_cli/server/_app.py
@@ -1,15 +1,17 @@
 """Build the FastAPI app for ``office serve``.
 
-The app has three concerns:
+The app has four concerns:
 
 * the JSON API (``/api/offices``, ``/api/floors/{id}``);
 * serving the floor SVGs as static files;
-* serving the SPA shell + the bundled static assets at ``/static``.
+* serving the SPA shell + the bundled static assets at ``/static``;
+* (Stage 7) optional SSO + role-aware redaction.
 
 ``fastapi`` is imported lazily so the parent package can be loaded
 without the ``[web]`` extra installed (matches the pattern used by
 :mod:`office_cli.seats.sheets`, :mod:`office_cli.people.bamboohr`, and
-:mod:`office_cli.slack`).
+:mod:`office_cli.slack`). ``authlib`` and ``itsdangerous`` (the
+``[sso]`` extra) are imported lazily inside :mod:`office_cli.server._auth`.
 """
 
 from __future__ import annotations
@@ -17,19 +19,35 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from office_cli._roles import RolesConfig
 from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
 from office_cli.seats import SeatService
+from office_cli.server._auth import (
+    OIDCConfig,
+    install_session_middleware,
+    register_auth_routes,
+)
 from office_cli.server._routes import register_routes
 
 _STATIC_DIR = Path(__file__).parent / "static"
 
 
-def build_app(service: SeatService, *, data_dir: Path | None = None) -> Any:
+def build_app(
+    service: SeatService,
+    *,
+    data_dir: Path | None = None,
+    oidc: OIDCConfig | None = None,
+    roles: RolesConfig | None = None,
+) -> Any:
     """Construct the FastAPI app for ``service``.
 
     ``data_dir`` is used to resolve the ``floors/`` directory served as
     static SVG content. When omitted, the location is inferred from the
     first floor's ``svg`` path.
+
+    ``oidc`` enables the SSO flow when set. ``None`` keeps auth
+    disabled (dev / tests). ``roles`` is the role-mapping config; when
+    ``None`` everyone is treated as ``viewer``.
     """
     try:
         from fastapi import FastAPI
@@ -43,7 +61,11 @@ def build_app(service: SeatService, *, data_dir: Path | None = None) -> Any:
 
     floors_dir = _floors_dir(service, data_dir)
     app = FastAPI(title="office", docs_url=None, redoc_url=None)
-    register_routes(app, service)
+    roles_cfg = roles or RolesConfig()
+    if oidc is not None:
+        install_session_middleware(app, oidc)
+        register_auth_routes(app, oidc, roles_cfg)
+    register_routes(app, service, oidc=oidc, roles=roles_cfg)
     app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
     # Mount under ``/svgs`` (not ``/floors``) so the bare ``/floors/{id}``
     # route below — used as a redirect entry point for Slack deep links —

--- a/office_cli/server/_auth.py
+++ b/office_cli/server/_auth.py
@@ -7,9 +7,13 @@ Three modes of operation:
   (or, when an ``X-Test-Role`` header is present, a synthetic test
   user with that role). This is the default for local dev and tests.
 * **Auth enabled** (``oidc`` is an :class:`OIDCConfig`): a signed-cookie
-  session middleware is mounted, ``/auth/login`` /
-  ``/auth/callback`` / ``/auth/logout`` routes register, and
-  ``require_user`` redirects unauthenticated requests to login.
+  session middleware is mounted, and ``/auth/login`` /
+  ``/auth/callback`` / ``/auth/logout`` routes register. The SPA
+  shell route in :mod:`office_cli.server._routes` consults
+  :func:`current_user` and emits a 302 redirect to ``/auth/login`` for
+  anonymous browsers — the actual gate lives there, not in this
+  module, so the auth helpers can be shared between the SPA path and
+  the JSON API (which never redirects, only role-redacts).
 
 The OIDC integration uses :mod:`authlib.integrations.starlette_client`,
 imported lazily so the package loads cleanly without the ``[sso]``
@@ -81,14 +85,24 @@ def resolve_oidc(env: dict[str, str] | None = None) -> OIDCConfig | None:
 
 
 def install_session_middleware(app: Any, oidc: OIDCConfig) -> None:
-    """Register Starlette's signed-cookie SessionMiddleware on ``app``."""
+    """Register Starlette's signed-cookie SessionMiddleware on ``app``.
+
+    Cookie defaults are production-secure: ``Secure`` flag set, lax
+    same-site. Operators behind an HTTP reverse proxy in staging /
+    internal environments can set ``OIDC_COOKIE_SECURE=false`` to drop
+    the ``Secure`` flag — required because browsers reject ``Secure``
+    cookies over HTTP. Default stays ``true`` so a production
+    misconfig fails-closed (no cookie set, login loops) rather than
+    silently sending session bytes over plain HTTP.
+    """
     from starlette.middleware.sessions import SessionMiddleware
 
+    secure = os.environ.get("OIDC_COOKIE_SECURE", "true").strip().lower() != "false"
     app.add_middleware(
         SessionMiddleware,
         secret_key=oidc.session_secret,
         same_site="lax",
-        https_only=True,
+        https_only=secure,
         session_cookie="office_session",
     )
 

--- a/office_cli/server/_auth.py
+++ b/office_cli/server/_auth.py
@@ -1,0 +1,184 @@
+"""SSO + role resolution for the FastAPI seat-map server (Stage 7).
+
+Three modes of operation:
+
+* **Auth disabled** (``oidc=None``): no SessionMiddleware, no
+  ``/auth/*`` routes, no redirects. ``current_user`` returns ``None``
+  (or, when an ``X-Test-Role`` header is present, a synthetic test
+  user with that role). This is the default for local dev and tests.
+* **Auth enabled** (``oidc`` is an :class:`OIDCConfig`): a signed-cookie
+  session middleware is mounted, ``/auth/login`` /
+  ``/auth/callback`` / ``/auth/logout`` routes register, and
+  ``require_user`` redirects unauthenticated requests to login.
+
+The OIDC integration uses :mod:`authlib.integrations.starlette_client`,
+imported lazily so the package loads cleanly without the ``[sso]``
+extra installed (mirrors :mod:`office_cli.server._app` and
+:mod:`office_cli.slack._app`).
+
+The ``X-Test-Role`` header is honored **only when auth is disabled** —
+once OIDC is configured, the session is the sole source of identity.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from office_cli._roles import VIEWER, RolesConfig, role_for_email
+from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
+
+_OIDC_ENV_VARS = (
+    "OIDC_ISSUER",
+    "OIDC_CLIENT_ID",
+    "OIDC_CLIENT_SECRET",
+    "OIDC_REDIRECT_URL",
+    "SESSION_SECRET",
+)
+_TEST_ROLE_HEADER = "x-test-role"
+_SESSION_USER_KEY = "user"
+
+
+@dataclass(frozen=True)
+class OIDCConfig:
+    """Resolved OIDC configuration. All five env vars are required."""
+
+    issuer: str
+    client_id: str
+    client_secret: str
+    redirect_url: str
+    session_secret: str
+
+
+def resolve_oidc(env: dict[str, str] | None = None) -> OIDCConfig | None:
+    """Build an :class:`OIDCConfig` from env, or return ``None``.
+
+    Returns ``None`` when **none** of the env vars are set (auth-disabled
+    mode). Returns a populated config when **all five** are set. When
+    only some are set, raises :class:`OfficeError(EXIT_ENV_ERROR)` so
+    operators get a clear hint instead of a silently-disabled IdP.
+    """
+    e = env if env is not None else os.environ
+    present = {name: e.get(name, "").strip() for name in _OIDC_ENV_VARS}
+    set_count = sum(1 for v in present.values() if v)
+    if set_count == 0:
+        return None
+    if set_count != len(_OIDC_ENV_VARS):
+        missing = [name for name, v in present.items() if not v]
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message=f"OIDC is partially configured; missing: {', '.join(missing)}",
+            remediation=("set all five OIDC_*/SESSION_SECRET vars, or unset all to disable SSO"),
+        )
+    return OIDCConfig(
+        issuer=present["OIDC_ISSUER"],
+        client_id=present["OIDC_CLIENT_ID"],
+        client_secret=present["OIDC_CLIENT_SECRET"],
+        redirect_url=present["OIDC_REDIRECT_URL"],
+        session_secret=present["SESSION_SECRET"],
+    )
+
+
+def install_session_middleware(app: Any, oidc: OIDCConfig) -> None:
+    """Register Starlette's signed-cookie SessionMiddleware on ``app``."""
+    from starlette.middleware.sessions import SessionMiddleware
+
+    app.add_middleware(
+        SessionMiddleware,
+        secret_key=oidc.session_secret,
+        same_site="lax",
+        https_only=True,
+        session_cookie="office_session",
+    )
+
+
+def register_auth_routes(app: Any, oidc: OIDCConfig, roles: RolesConfig) -> None:
+    """Register ``/auth/login``, ``/auth/callback``, ``/auth/logout``.
+
+    The OIDC client is constructed via :class:`authlib.integrations.starlette_client.OAuth`.
+    ``next`` is whitelist-validated to prevent open-redirect.
+    """
+    from authlib.integrations.starlette_client import OAuth
+    from fastapi import Request
+    from fastapi.responses import RedirectResponse
+
+    oauth = OAuth()
+    oauth.register(
+        name="office",
+        client_id=oidc.client_id,
+        client_secret=oidc.client_secret,
+        server_metadata_url=f"{oidc.issuer.rstrip('/')}/.well-known/openid-configuration",
+        client_kwargs={"scope": "openid email profile"},
+    )
+
+    @app.get("/auth/login")
+    async def auth_login(request: Request, next: str = "/"):
+        request.session["next"] = _safe_next(next)
+        client = oauth.create_client("office")
+        return await client.authorize_redirect(request, oidc.redirect_url)
+
+    @app.get("/auth/callback")
+    async def auth_callback(request: Request):
+        client = oauth.create_client("office")
+        token = await client.authorize_access_token(request)
+        userinfo = token.get("userinfo") or {}
+        email = (userinfo.get("email") or "").strip()
+        if not email:
+            # The IdP didn't return an email claim — surface a clear 400
+            # rather than letting the session land empty.
+            raise OfficeError(
+                code=EXIT_ENV_ERROR,
+                message="OIDC token has no email claim",
+                remediation="check the IdP scope configuration (need 'openid email')",
+            )
+        role = role_for_email(roles, email)
+        request.session[_SESSION_USER_KEY] = {"email": email, "role": role}
+        return RedirectResponse(url=request.session.pop("next", "/"), status_code=302)
+
+    @app.post("/auth/logout")
+    async def auth_logout(request: Request):
+        request.session.pop(_SESSION_USER_KEY, None)
+        return RedirectResponse(url="/", status_code=302)
+
+
+def current_user(request: Any, *, oidc: OIDCConfig | None) -> dict[str, str] | None:
+    """Return the ``{email, role}`` dict for this request, or ``None``.
+
+    With OIDC enabled, the session is the sole source. Without OIDC,
+    the ``X-Test-Role`` header (if present) yields a synthetic user —
+    this is intentional so unit tests can drive role-aware behavior
+    without sessions.
+    """
+    if oidc is not None:
+        try:
+            user = request.session.get(_SESSION_USER_KEY)
+        except (AttributeError, AssertionError):
+            # ``session`` is unavailable when SessionMiddleware is missing.
+            return None
+        return user if user else None
+    test_role = request.headers.get(_TEST_ROLE_HEADER, "").strip().lower()
+    if test_role:
+        return {"email": f"test+{test_role}@example.com", "role": test_role}
+    return None
+
+
+def role_from_user(user: dict[str, str] | None) -> str:
+    """Default to viewer when there's no user (anonymous browsing)."""
+    if not user:
+        return VIEWER
+    return user.get("role") or VIEWER
+
+
+def _safe_next(raw: str) -> str:
+    """Whitelist-validate a ``next`` URL.
+
+    Returns ``"/"`` if ``raw`` is missing, doesn't start with ``/``, or
+    starts with ``//`` / ``/\\`` (which would target an external host).
+    Anti-open-redirect.
+    """
+    if not raw or not raw.startswith("/"):
+        return "/"
+    if raw.startswith("//") or raw.startswith("/\\"):
+        return "/"
+    return raw

--- a/office_cli/server/_routes.py
+++ b/office_cli/server/_routes.py
@@ -11,6 +11,7 @@ is treated as a ``viewer``.
 
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from office_cli._dates import parse_iso_date, today_iso_date
 from office_cli._roles import RolesConfig
@@ -89,20 +90,9 @@ def register_routes(
 
     @app.get("/offices/{office_id}/floors/{floor_id}", response_class=HTMLResponse)
     def spa_shell(request: Request, office_id: str, floor_id: str):
-        # The shell is the same regardless of office/floor — the path
-        # parameters are read by app.js from globalThis.location. We
-        # still validate them server-side so an invalid URL surfaces
-        # 404 rather than rendering a broken empty map.
-        floor, declared_office = _resolve_floor(service, floor_id)
-        if floor is None or declared_office != office_id:
-            raise HTTPException(status_code=404, detail="unknown office or floor")
-        # Stage 7: redirect anonymous browsers to SSO when auth is on.
-        if oidc is not None and current_user(request, oidc=oidc) is None:
-            next_url = request.url.path
-            if request.url.query:
-                next_url += f"?{request.url.query}"
-            return RedirectResponse(url=f"/auth/login?next={next_url}", status_code=302)
-        return HTMLResponse(content=shell_html)
+        return _spa_shell_response(
+            service, oidc, request, office_id, floor_id, shell_html, HTTPException
+        )
 
     @app.exception_handler(OfficeError)
     async def office_error_handler(_request, err: OfficeError):
@@ -115,6 +105,37 @@ def register_routes(
 
     # Stash so static_dir() callers (tests) can find it consistently.
     app.state.static_dir = static_dir()
+
+
+def _spa_shell_response(
+    service: SeatService,
+    oidc: Any,
+    request: Any,
+    office_id: str,
+    floor_id: str,
+    shell_html: str,
+    http_exception: Any,
+) -> Any:
+    """Validate the SPA URL, then either serve the shell or redirect to SSO.
+
+    Lifted out of the closure inside :func:`register_routes` so the
+    closure stays small (Sonar S3776). The redirect path URL-encodes
+    ``next`` so an originating URL with ``&``-separated query params
+    round-trips through the IdP intact (Qodo Q1 on PR #20).
+    """
+    from fastapi.responses import HTMLResponse, RedirectResponse
+
+    floor, declared_office = _resolve_floor(service, floor_id)
+    if floor is None or declared_office != office_id:
+        raise http_exception(status_code=404, detail="unknown office or floor")
+    if oidc is not None and current_user(request, oidc=oidc) is None:
+        next_url = request.url.path
+        if request.url.query:
+            next_url += f"?{request.url.query}"
+        # Quote the whole path+query as a single value so any embedded
+        # ``&`` / ``?`` / ``=`` characters survive the round-trip.
+        return RedirectResponse(url=f"/auth/login?next={quote(next_url, safe='')}", status_code=302)
+    return HTMLResponse(content=shell_html)
 
 
 def _build_floor_response(

--- a/office_cli/server/_routes.py
+++ b/office_cli/server/_routes.py
@@ -1,12 +1,19 @@
 """HTTP routes for the seat-map server.
 
 The endpoints are intentionally thin — they map ``SeatService`` /
-``Office`` / ``Floor`` shapes to plain JSON, applying the **server-side
-redaction** for ``hidden=TRUE`` rows so the frontend never sees a
-private email or note.
+``Office`` / ``Floor`` shapes to plain JSON.
 
-Stage 7 will introduce role-based unredaction; until then every caller
-is treated as a ``viewer``.
+Role-aware redaction (Stage 7) is applied at the **service** layer:
+``SeatService.list_seats(role=...)`` clears the email + notes on
+``hidden=TRUE`` rows when the caller's role is ``viewer`` and sets a
+``redacted=True`` flag on the returned :class:`Assignment`. This
+module's :func:`_redact` helper just maps that view-time state onto
+the API JSON shape — the redacted hidden row gets the
+``"(private)"`` placeholder, while editor/planning callers see full
+details with ``redacted=False``.
+
+Anonymous browsers (no session) default to ``viewer`` via
+:func:`office_cli.server._auth.role_from_user`.
 """
 
 from pathlib import Path
@@ -226,6 +233,7 @@ def _redact(a: Assignment) -> dict[str, Any]:
             "employee_email": _PRIVATE_PLACEHOLDER,
             "last_updated": a.last_updated,
             "hidden": True,
+            "redacted": True,
             "notes": "",
             "effective_from": a.effective_from or None,
             "effective_until": a.effective_until or None,
@@ -240,6 +248,7 @@ def _redact(a: Assignment) -> dict[str, Any]:
             "employee_email": a.employee_email or None,
             "last_updated": a.last_updated,
             "hidden": True,
+            "redacted": False,
             "notes": a.notes if a.employee_email else "",
             "effective_from": a.effective_from or None,
             "effective_until": a.effective_until or None,
@@ -250,6 +259,7 @@ def _redact(a: Assignment) -> dict[str, Any]:
         "employee_email": a.employee_email or None,
         "last_updated": a.last_updated,
         "hidden": False,
+        "redacted": False,
         "notes": a.notes,
         "effective_from": a.effective_from or None,
         "effective_until": a.effective_until or None,

--- a/office_cli/server/_routes.py
+++ b/office_cli/server/_routes.py
@@ -9,27 +9,34 @@ Stage 7 will introduce role-based unredaction; until then every caller
 is treated as a ``viewer``.
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 from typing import Any
 
 from office_cli._dates import parse_iso_date, today_iso_date
+from office_cli._roles import RolesConfig
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 from office_cli.offices import Floor, Office
 from office_cli.seats import Assignment, SeatService
+from office_cli.server._auth import OIDCConfig, current_user, role_from_user
 
 _PRIVATE_PLACEHOLDER = "(private)"
 _SHELL_PATH = Path(__file__).parent / "static" / "index.html"
 
 
-def register_routes(app: Any, service: SeatService) -> None:
-    from fastapi import HTTPException, Query
+def register_routes(
+    app: Any,
+    service: SeatService,
+    *,
+    oidc: OIDCConfig | None = None,
+    roles: RolesConfig | None = None,
+) -> None:
+    from fastapi import HTTPException, Query, Request
     from fastapi.responses import HTMLResponse, RedirectResponse
 
     from office_cli.server._app import static_dir
 
     shell_html = _SHELL_PATH.read_text(encoding="utf-8")
+    _ = roles  # Reserved for future surface-side role config; service applies redaction.
 
     @app.get("/api/offices")
     def get_offices() -> dict:
@@ -37,6 +44,7 @@ def register_routes(app: Any, service: SeatService) -> None:
 
     @app.get("/api/floors/{floor_id}")
     def get_floor(
+        request: Request,
         floor_id: str,
         as_of: str = "",
         # Accept ``?asOf=`` (camelCase) as an alias so direct-API callers
@@ -44,7 +52,8 @@ def register_routes(app: Any, service: SeatService) -> None:
         # are passed, ``as_of`` wins.
         as_of_camel: str = Query("", alias="asOf"),
     ) -> dict:
-        return _build_floor_response(service, floor_id, as_of or as_of_camel, HTTPException)
+        user = current_user(request, oidc=oidc)
+        return _build_floor_response(service, floor_id, as_of or as_of_camel, HTTPException, user)
 
     @app.get("/", response_class=RedirectResponse)
     def root() -> str:
@@ -79,7 +88,7 @@ def register_routes(app: Any, service: SeatService) -> None:
         return RedirectResponse(url=target, status_code=307)
 
     @app.get("/offices/{office_id}/floors/{floor_id}", response_class=HTMLResponse)
-    def spa_shell(office_id: str, floor_id: str) -> str:
+    def spa_shell(request: Request, office_id: str, floor_id: str):
         # The shell is the same regardless of office/floor — the path
         # parameters are read by app.js from globalThis.location. We
         # still validate them server-side so an invalid URL surfaces
@@ -87,7 +96,13 @@ def register_routes(app: Any, service: SeatService) -> None:
         floor, declared_office = _resolve_floor(service, floor_id)
         if floor is None or declared_office != office_id:
             raise HTTPException(status_code=404, detail="unknown office or floor")
-        return shell_html
+        # Stage 7: redirect anonymous browsers to SSO when auth is on.
+        if oidc is not None and current_user(request, oidc=oidc) is None:
+            next_url = request.url.path
+            if request.url.query:
+                next_url += f"?{request.url.query}"
+            return RedirectResponse(url=f"/auth/login?next={next_url}", status_code=302)
+        return HTMLResponse(content=shell_html)
 
     @app.exception_handler(OfficeError)
     async def office_error_handler(_request, err: OfficeError):
@@ -107,6 +122,7 @@ def _build_floor_response(
     floor_id: str,
     raw_as_of: str,
     http_exception: Any,
+    user: dict[str, str] | None,
 ) -> dict[str, Any]:
     """Pure builder for the ``/api/floors/{id}`` JSON body.
 
@@ -131,7 +147,8 @@ def _build_floor_response(
     else:
         as_of_value = today_iso_date(service._clock)
         explicit = False
-    seats = [_redact(a) for a in service.list_seats(floor=floor_id, as_of=as_of_value)]
+    role = role_from_user(user)
+    seats = [_redact(a) for a in service.list_seats(floor=floor_id, as_of=as_of_value, role=role)]
     return {
         "floor": _floor_to_dict(floor, office_id),
         "svg_url": f"/svgs/{floor.svg.name}",
@@ -139,6 +156,7 @@ def _build_floor_response(
         # Echo the date back only when the caller asked for one — this is
         # what the frontend uses to decide whether to surface the banner.
         "as_of": as_of_value if explicit else None,
+        "user": user,
     }
 
 
@@ -167,27 +185,51 @@ def _floor_to_dict(floor: Floor, office_id: str) -> dict[str, Any]:
 
 
 def _redact(a: Assignment) -> dict[str, Any]:
-    """Server-side redaction for ``hidden=TRUE`` rows.
+    """Stage 7 — surface mapping for an Assignment.
 
-    The frontend never sees a private email or note. Notes are scrubbed
-    whenever ``hidden=True`` regardless of whether ``employee_email`` is
-    populated — a privately-flagged seat that happens to be vacant must
-    not leak the operator's notes either. Stage 7 will pass a role
-    argument that lifts this for editors / planning users.
+    Role-aware redaction is now done in :class:`SeatService` (it sets
+    ``redacted=True`` for hidden rows when the caller's role is
+    ``viewer``). This helper just maps that view-time state to the API
+    JSON shape: redacted hidden rows render with the ``"(private)"``
+    placeholder; everything else passes through.
+
+    A non-redacted hidden row exists when the caller is editor/planning
+    (full details) or when the row is hidden but vacant (Qodo Q4 from
+    Stage 5 — notes are still scrubbed for all callers since the row's
+    privacy intent stands).
     """
+    if a.redacted:
+        return {
+            "seat_id": a.seat_id,
+            "floor": a.floor,
+            "employee_email": _PRIVATE_PLACEHOLDER,
+            "last_updated": a.last_updated,
+            "hidden": True,
+            "notes": "",
+            "effective_from": a.effective_from or None,
+            "effective_until": a.effective_until or None,
+        }
     if a.hidden:
-        email_out: str | None = _PRIVATE_PLACEHOLDER if a.employee_email else None
-        notes_out = ""
-    else:
-        email_out = a.employee_email or None
-        notes_out = a.notes
+        # Editor/planning view (or hidden-but-vacant seat). Email passes
+        # through; notes still scrubbed when there's no occupant so a
+        # privately-flagged empty seat doesn't leak the operator's notes.
+        return {
+            "seat_id": a.seat_id,
+            "floor": a.floor,
+            "employee_email": a.employee_email or None,
+            "last_updated": a.last_updated,
+            "hidden": True,
+            "notes": a.notes if a.employee_email else "",
+            "effective_from": a.effective_from or None,
+            "effective_until": a.effective_until or None,
+        }
     return {
         "seat_id": a.seat_id,
         "floor": a.floor,
-        "employee_email": email_out,
+        "employee_email": a.employee_email or None,
         "last_updated": a.last_updated,
-        "hidden": a.hidden,
-        "notes": notes_out,
+        "hidden": False,
+        "notes": a.notes,
         "effective_from": a.effective_from or None,
         "effective_until": a.effective_until or None,
     }

--- a/office_cli/server/static/app.js
+++ b/office_cli/server/static/app.js
@@ -29,6 +29,7 @@ const els = {
   detail: document.getElementById("detail"),
   banner: document.getElementById("banner"),
   floorPicker: document.getElementById("floor-picker"),
+  userInfo: document.getElementById("user-info"),
 };
 
 const state = {
@@ -345,6 +346,7 @@ async function loadFloor(officeId, floorId, asOf) {
   state.currentFloorId = floorId;
   state.currentAsOf = asOf || null;
   state.seats = data.seats;
+  renderUserInfo(data.user || null);
   state.fuse = globalThis.Fuse
     ? new globalThis.Fuse(state.seats.map(searchableSeat), FUSE_OPTIONS)
     : null;
@@ -394,6 +396,30 @@ async function loadOffices() {
 
 function setFloorPickerValue(officeId, floorId) {
   els.floorPicker.value = `${officeId}|${floorId}`;
+}
+
+function renderUserInfo(user) {
+  // Stage 7: header slot showing the signed-in email + role + a logout
+  // link. Hidden when the API response carries `user: null` (auth-
+  // disabled mode for local dev).
+  if (!els.userInfo) return;
+  els.userInfo.replaceChildren();
+  if (!user) {
+    els.userInfo.hidden = true;
+    return;
+  }
+  els.userInfo.hidden = false;
+  els.userInfo.appendChild(el("span", { className: "user-email" }, user.email || ""));
+  els.userInfo.appendChild(el("span", { className: "user-role" }, ` (${user.role || "viewer"})`));
+  const logout = el("button", { type: "button", className: "logout" }, "Sign out");
+  logout.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", { method: "POST", redirect: "manual" });
+    } finally {
+      globalThis.location.reload();
+    }
+  });
+  els.userInfo.appendChild(logout);
 }
 
 function showAsOfBanner(date) {

--- a/office_cli/server/static/index.html
+++ b/office_cli/server/static/index.html
@@ -13,6 +13,7 @@
     <div class="brand">office</div>
     <input id="search" type="search" placeholder="Search seats, people, rooms…" autocomplete="off">
     <select id="floor-picker" aria-label="Switch floor"></select>
+    <div id="user-info" class="user-info" hidden></div>
   </header>
   <div id="banner" class="banner" hidden></div>
   <div class="layout">

--- a/office_cli/slack/_app.py
+++ b/office_cli/slack/_app.py
@@ -8,28 +8,40 @@ real Bolt app, so this module never needs the SDK at import time.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Callable
 
 from office_cli._dates import parse_iso_date, today_iso_date
-from office_cli._roles import RolesConfig, role_for_email
+from office_cli._roles import RolesConfig, resolve_roles, role_for_email
 from office_cli.cli._errors import OfficeError
 from office_cli.seats import SeatService
 from office_cli.slack import _blocks
 from office_cli.slack._resolve import ParsedTarget, parse_target
+
+_AUTO = object()
 
 
 def build_app(
     service: SeatService,
     *,
     app: Any | None = None,
-    roles: RolesConfig | None = None,
+    roles: Any = None,
+    data_dir: Path | None = None,
 ) -> Any:
     """Register the ``/whereis`` listener and return the configured app.
 
     If ``app`` is ``None`` we construct a default ``slack_bolt.App``
     (which reads ``SLACK_BOT_TOKEN`` from the env). Tests pass a fake
     app exposing only ``.command(name)``.
+
+    ``roles`` is the role-mapping config. ``None`` (the default) keeps
+    every caller as ``viewer`` — the Stage 4–6 behavior. Pass an
+    explicit :class:`RolesConfig`, or pass ``data_dir`` to auto-resolve
+    from ``data/offices.yaml`` (production path used by ``office
+    slack-serve``).
     """
+    if roles is None and data_dir is not None:
+        roles = resolve_roles(data_dir)
     if app is None:
         from slack_bolt import App
 

--- a/office_cli/slack/_app.py
+++ b/office_cli/slack/_app.py
@@ -11,13 +11,19 @@ from __future__ import annotations
 from typing import Any, Callable
 
 from office_cli._dates import parse_iso_date, today_iso_date
+from office_cli._roles import RolesConfig, role_for_email
 from office_cli.cli._errors import OfficeError
 from office_cli.seats import SeatService
 from office_cli.slack import _blocks
 from office_cli.slack._resolve import ParsedTarget, parse_target
 
 
-def build_app(service: SeatService, *, app: Any | None = None) -> Any:
+def build_app(
+    service: SeatService,
+    *,
+    app: Any | None = None,
+    roles: RolesConfig | None = None,
+) -> Any:
     """Register the ``/whereis`` listener and return the configured app.
 
     If ``app`` is ``None`` we construct a default ``slack_bolt.App``
@@ -34,7 +40,7 @@ def build_app(service: SeatService, *, app: Any | None = None) -> Any:
         ack()
         text = command.get("text", "")
         target = parse_target(text)
-        blocks, label = _resolve_and_lookup(service, client, body, command, target)
+        blocks, label = _resolve_and_lookup(service, client, body, command, target, roles)
         # ``command`` is the slash-command payload and is the canonical
         # source for ``channel_id``/``user_id``; ``body`` is the Bolt-
         # wrapped envelope and may differ in some adapter shapes. Prefer
@@ -55,6 +61,7 @@ def _resolve_and_lookup(
     body: dict,
     command: dict,
     target: ParsedTarget,
+    roles: RolesConfig | None,
 ) -> tuple[list[dict[str, Any]], str]:
     """Resolve a :class:`ParsedTarget` to an email + label and run lookup."""
     if not target.ok:
@@ -68,10 +75,15 @@ def _resolve_and_lookup(
     except OfficeError as err:
         return _blocks.parse_failed(f"{target.as_of} — {err.message}"), "bad date"
 
+    # Resolve the caller's role from their Slack profile email + the roles
+    # config. When ``roles`` is None or the caller's email can't be
+    # fetched, default to viewer (matches Stage 4–6 behavior).
+    role = _resolve_caller_role(client, body, command, roles)
+
     if target.email:
         email = target.email
         label = email
-        return _lookup(service, email, label, as_of=as_of)
+        return _lookup(service, email, label, as_of=as_of, role=role)
 
     user_id = target.user_id or command.get("user_id") or body.get("user_id", "")
     if not user_id:
@@ -83,7 +95,23 @@ def _resolve_and_lookup(
     # When the caller asked about themselves, label as "you"; otherwise
     # use the @-mention so Slack renders the name.
     label = "you" if target.self_lookup else f"<@{user_id}>"
-    return _lookup(service, email, label, as_of=as_of)
+    return _lookup(service, email, label, as_of=as_of, role=role)
+
+
+def _resolve_caller_role(client: Any, body: dict, command: dict, roles: RolesConfig | None) -> str:
+    """Identify the slash-command caller and resolve their role.
+
+    Defaults to viewer when ``roles`` is not configured or when the
+    caller's profile email isn't fetchable. The redaction at the service
+    layer is keyed on this role.
+    """
+    if roles is None:
+        return "viewer"
+    caller_user_id = command.get("user_id") or body.get("user_id", "")
+    if not caller_user_id:
+        return "viewer"
+    email, _reason = _email_from_user_id(client, caller_user_id)
+    return role_for_email(roles, email)
 
 
 def _resolve_as_of(service: SeatService, raw: str) -> str:
@@ -116,13 +144,18 @@ def _lookup(
     label: str,
     *,
     as_of: str | None = None,
+    role: str | None = None,
 ) -> tuple[list[dict[str, Any]], str]:
     # Both blocks and the `text` fallback use ``label`` so we never leak
     # the resolved profile email through the screen-reader / older-client
     # rendering path — it would defeat the redaction the blocks rely on.
-    assignment = service.whereis(email, as_of=as_of)
+    assignment = service.whereis(email, as_of=as_of, role=role)
     if assignment is None:
         return _blocks.no_seat(label), f"no seat for {label}"
-    if assignment.hidden:
+    # Stage 7: a ``redacted=True`` assignment carries the privacy
+    # treatment the service applied for viewer callers. ``hidden`` alone
+    # is no longer enough to gate the private block — editors and
+    # planning callers see hidden seats with full details.
+    if assignment.redacted:
         return _blocks.hidden_private(assignment, target_label=label), "occupied (private)"
     return _blocks.occupied(assignment, target_label=label), f"{label} → {assignment.seat_id}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.6.0"
+version = "0.7.0"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"
@@ -24,6 +24,11 @@ slack = ["slack-bolt>=1.18", "slack-sdk>=3.27"]
 web = [
     "fastapi>=0.110",
     "uvicorn>=0.30",
+]
+sso = [
+    "authlib>=1.3",
+    "itsdangerous>=2.1",
+    "httpx>=0.27",
 ]
 
 [project.urls]
@@ -54,6 +59,10 @@ dev = [
     # without installing the optional extra.
     "fastapi>=0.110",
     "httpx>=0.28",
+    # Stage 7 — SSO. CI exercises the auth-enabled path via TestClient
+    # against a stub OIDC config; we never hit a real IdP.
+    "authlib>=1.3",
+    "itsdangerous>=2.1",
 ]
 
 [tool.coverage.run]

--- a/tests/test_roles_config.py
+++ b/tests/test_roles_config.py
@@ -1,0 +1,109 @@
+"""Tests for ``office_cli._roles``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from office_cli._roles import (
+    EDITOR,
+    PLANNING,
+    VIEWER,
+    RolesConfig,
+    is_full_access,
+    resolve_roles,
+    role_for_email,
+)
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+
+
+def _write_yaml(data_dir: Path, body: str) -> None:
+    (data_dir / "data").mkdir(parents=True, exist_ok=True)
+    (data_dir / "data" / "offices.yaml").write_text(body, encoding="utf-8")
+
+
+def test_resolve_missing_yaml_returns_empty_config(tmp_path: Path) -> None:
+    cfg = resolve_roles(tmp_path)
+    assert cfg == RolesConfig()
+
+
+def test_resolve_no_roles_block(tmp_path: Path) -> None:
+    _write_yaml(tmp_path, "offices: []\n")
+    cfg = resolve_roles(tmp_path)
+    assert cfg == RolesConfig()
+
+
+def test_resolve_basic_mapping(tmp_path: Path) -> None:
+    _write_yaml(
+        tmp_path,
+        """
+roles:
+  editor:
+    - "alice@tipalti.com"
+    - "HR-IT@tipalti.com"
+  planning:
+    - "Facilities@tipalti.com"
+""",
+    )
+    cfg = resolve_roles(tmp_path)
+    # Emails normalize to lowercase at parse time.
+    assert "alice@tipalti.com" in cfg.editor
+    assert "hr-it@tipalti.com" in cfg.editor
+    assert "facilities@tipalti.com" in cfg.planning
+
+
+def test_role_for_email_case_insensitive(tmp_path: Path) -> None:
+    cfg = RolesConfig(editor=frozenset({"alice@tipalti.com"}))
+    assert role_for_email(cfg, "alice@tipalti.com") == EDITOR
+    assert role_for_email(cfg, "ALICE@TIPALTI.COM") == EDITOR
+    assert role_for_email(cfg, " Alice@Tipalti.com ") == EDITOR
+    assert role_for_email(cfg, "bob@tipalti.com") == VIEWER
+    assert role_for_email(cfg, "") == VIEWER
+
+
+def test_role_for_email_planning(tmp_path: Path) -> None:
+    cfg = RolesConfig(planning=frozenset({"facilities@x.com"}))
+    assert role_for_email(cfg, "facilities@x.com") == PLANNING
+
+
+def test_resolve_rejects_string_value(tmp_path: Path) -> None:
+    _write_yaml(
+        tmp_path,
+        """
+roles:
+  editor: "alice@tipalti.com"
+""",
+    )
+    with pytest.raises(OfficeError) as exc:
+        resolve_roles(tmp_path)
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "list" in exc.value.message
+
+
+def test_resolve_rejects_non_string_entry(tmp_path: Path) -> None:
+    _write_yaml(
+        tmp_path,
+        """
+roles:
+  editor:
+    - 123
+""",
+    )
+    with pytest.raises(OfficeError) as exc:
+        resolve_roles(tmp_path)
+    assert exc.value.code == EXIT_USER_ERROR
+
+
+def test_resolve_rejects_string_block(tmp_path: Path) -> None:
+    _write_yaml(tmp_path, "roles: oops\n")
+    with pytest.raises(OfficeError):
+        resolve_roles(tmp_path)
+
+
+def test_is_full_access() -> None:
+    assert is_full_access(None) is True  # CLI default
+    assert is_full_access(EDITOR) is True
+    assert is_full_access(PLANNING) is True
+    assert is_full_access(VIEWER) is False
+    assert is_full_access("unknown") is False

--- a/tests/test_seats_service_roles.py
+++ b/tests/test_seats_service_roles.py
@@ -1,0 +1,124 @@
+"""Tests for the Stage 7 role-aware redaction in :class:`SeatService`."""
+
+from __future__ import annotations
+
+from itertools import count
+from pathlib import Path
+
+from office_cli.seats import build_service
+
+
+def _service(data_dir: Path):
+    counter = count(1)
+
+    def clock() -> str:
+        return f"2026-05-01T00:00:{next(counter):02d}Z"
+
+    s = build_service(data_dir)
+    s._clock = clock  # noqa: SLF001 — deterministic for tests
+    return s
+
+
+def test_default_role_unrestricted(data_dir: Path) -> None:
+    """``role=None`` (CLI default) shows full data on hidden rows."""
+    s = _service(data_dir)
+    s.assign("5-T-01", "exec@example.com", hidden=True, note="exec note")
+    rows = {r.seat_id: r for r in s.list_seats()}
+    row = rows["5-T-01"]
+    assert row.employee_email == "exec@example.com"
+    assert row.notes == "exec note"
+    assert row.redacted is False
+
+
+def test_viewer_redacts_hidden(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "exec@example.com", hidden=True, note="exec note")
+    rows = {r.seat_id: r for r in s.list_seats(role="viewer")}
+    row = rows["5-T-01"]
+    assert row.employee_email == ""
+    assert row.notes == ""
+    assert row.hidden is True
+    assert row.redacted is True
+
+
+def test_editor_sees_full_hidden(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "exec@example.com", hidden=True, note="exec note")
+    rows = {r.seat_id: r for r in s.list_seats(role="editor")}
+    row = rows["5-T-01"]
+    assert row.employee_email == "exec@example.com"
+    assert row.notes == "exec note"
+    assert row.redacted is False
+
+
+def test_planning_matches_editor_in_v1(data_dir: Path) -> None:
+    """Planning role gets editor-equivalent visibility for v1."""
+    s = _service(data_dir)
+    s.assign("5-T-01", "exec@example.com", hidden=True)
+    rows = {r.seat_id: r for r in s.list_seats(role="planning")}
+    assert rows["5-T-01"].employee_email == "exec@example.com"
+    assert rows["5-T-01"].redacted is False
+
+
+def test_viewer_non_hidden_unchanged(data_dir: Path) -> None:
+    """Viewer sees non-hidden rows in full."""
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com")
+    rows = {r.seat_id: r for r in s.list_seats(role="viewer")}
+    assert rows["5-T-01"].employee_email == "alice@example.com"
+    assert rows["5-T-01"].redacted is False
+
+
+def test_viewer_hidden_vacant_does_not_render_private(data_dir: Path) -> None:
+    """Hidden + vacant has nothing to hide → ``redacted`` stays False."""
+    s = _service(data_dir)
+    from office_cli.seats import Assignment
+
+    s.store.upsert(
+        Assignment(
+            seat_id="5-T-01",
+            floor="tlv-floor-5",
+            employee_email="",
+            hidden=True,
+            notes="reserved",
+        )
+    )
+    rows = {r.seat_id: r for r in s.list_seats(role="viewer")}
+    row = rows["5-T-01"]
+    assert row.employee_email == ""
+    assert row.redacted is False
+    # The privacy intent on the row stands — notes are still scrubbed.
+    assert row.notes == ""
+
+
+def test_whereis_viewer_redacts(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "exec@example.com", hidden=True)
+    a = s.whereis("exec@example.com", role="viewer")
+    assert a is not None
+    assert a.employee_email == ""
+    assert a.redacted is True
+
+
+def test_whereis_editor_returns_full(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "exec@example.com", hidden=True)
+    a = s.whereis("exec@example.com", role="editor")
+    assert a is not None
+    assert a.employee_email == "exec@example.com"
+    assert a.redacted is False
+
+
+def test_role_with_as_of_filter(data_dir: Path) -> None:
+    """Stage 6 + Stage 7: date filter runs first, then role redaction.
+
+    A future-dated hidden row, queried before its window opens, looks
+    vacant regardless of role — because the date filter blanks the
+    occupant before the role check ever sees it.
+    """
+    s = _service(data_dir)
+    s.assign("5-T-01", "exec@example.com", hidden=True, effective_from="2099-01-01")
+    rows = {r.seat_id: r for r in s.list_seats(role="viewer", as_of="2026-05-01")}
+    row = rows["5-T-01"]
+    assert row.employee_email == ""
+    assert row.redacted is False  # not redacted, just not yet effective

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -1,0 +1,47 @@
+"""Tests for the SSO config resolution + auth middleware (Stage 7)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError  # noqa: E402
+from office_cli.server._auth import OIDCConfig, resolve_oidc  # noqa: E402
+
+_ALL_VARS = {
+    "OIDC_ISSUER": "https://idp.example.com",
+    "OIDC_CLIENT_ID": "office-agent",
+    "OIDC_CLIENT_SECRET": "shh",
+    "OIDC_REDIRECT_URL": "https://office.example.com/auth/callback",
+    "SESSION_SECRET": "x" * 32,
+}
+
+
+def test_resolve_returns_none_when_empty() -> None:
+    assert resolve_oidc({}) is None
+
+
+def test_resolve_returns_config_when_all_present() -> None:
+    cfg = resolve_oidc(_ALL_VARS)
+    assert isinstance(cfg, OIDCConfig)
+    assert cfg.issuer == "https://idp.example.com"
+    assert cfg.client_id == "office-agent"
+
+
+def test_resolve_rejects_partial_config() -> None:
+    partial = dict(_ALL_VARS)
+    del partial["OIDC_CLIENT_SECRET"]
+    with pytest.raises(OfficeError) as exc:
+        resolve_oidc(partial)
+    assert exc.value.code == EXIT_ENV_ERROR
+    assert "OIDC_CLIENT_SECRET" in exc.value.message
+
+
+def test_resolve_treats_blank_as_missing() -> None:
+    """All-blank → None; some-blank → partial-config error."""
+    assert resolve_oidc({k: "" for k in _ALL_VARS}) is None
+    partial = dict(_ALL_VARS)
+    partial["SESSION_SECRET"] = "   "
+    with pytest.raises(OfficeError):
+        resolve_oidc(partial)

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -45,3 +45,52 @@ def test_resolve_treats_blank_as_missing() -> None:
     partial["SESSION_SECRET"] = "   "
     with pytest.raises(OfficeError):
         resolve_oidc(partial)
+
+
+def test_session_cookie_secure_default_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``OIDC_COOKIE_SECURE`` defaults to true (production-secure)."""
+    from starlette.applications import Starlette
+
+    from office_cli.server._auth import install_session_middleware
+
+    monkeypatch.delenv("OIDC_COOKIE_SECURE", raising=False)
+    cfg = OIDCConfig(
+        issuer="https://idp.example.com",
+        client_id="cid",
+        client_secret="csecret",
+        redirect_url="https://office.example.com/auth/callback",
+        session_secret="x" * 32,
+    )
+    app = Starlette()
+    install_session_middleware(app, cfg)
+    # Inspect the user_middleware list — Starlette stores them in order.
+    secure_flags = [
+        mw.kwargs.get("https_only")
+        for mw in app.user_middleware
+        if mw.cls.__name__ == "SessionMiddleware"
+    ]
+    assert secure_flags == [True]
+
+
+def test_session_cookie_secure_opt_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``OIDC_COOKIE_SECURE=false`` lets staging (HTTP) work without a loop."""
+    from starlette.applications import Starlette
+
+    from office_cli.server._auth import install_session_middleware
+
+    monkeypatch.setenv("OIDC_COOKIE_SECURE", "false")
+    cfg = OIDCConfig(
+        issuer="https://idp.example.com",
+        client_id="cid",
+        client_secret="csecret",
+        redirect_url="https://office.example.com/auth/callback",
+        session_secret="x" * 32,
+    )
+    app = Starlette()
+    install_session_middleware(app, cfg)
+    secure_flags = [
+        mw.kwargs.get("https_only")
+        for mw in app.user_middleware
+        if mw.cls.__name__ == "SessionMiddleware"
+    ]
+    assert secure_flags == [False]

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -40,7 +40,7 @@ def test_resolve_rejects_partial_config() -> None:
 
 def test_resolve_treats_blank_as_missing() -> None:
     """All-blank → None; some-blank → partial-config error."""
-    assert resolve_oidc({k: "" for k in _ALL_VARS}) is None
+    assert resolve_oidc(dict.fromkeys(_ALL_VARS, "")) is None
     partial = dict(_ALL_VARS)
     partial["SESSION_SECRET"] = "   "
     with pytest.raises(OfficeError):

--- a/tests/test_server_role_filter.py
+++ b/tests/test_server_role_filter.py
@@ -101,6 +101,54 @@ def test_non_hidden_unaffected_by_role(data_dir: Path) -> None:
             assert seats["5-T-01"]["employee_email"] == "alice@example.com"
 
 
+def test_redacted_field_in_json(data_dir: Path) -> None:
+    """Stage 7 — the API response carries a ``redacted: bool`` flag.
+
+    Frontend clients use it to render ``"(private)"`` vs ``"(vacant)"``
+    correctly under the new Stage 7 semantics where ``hidden=True`` no
+    longer implies viewer-style redaction.
+    """
+    s = _service(data_dir)
+    s.assign("5-T-01", "exec@example.com", hidden=True)
+    s.assign("5-T-02", "alice@example.com")
+    with TestClient(build_app(s, data_dir=data_dir)) as c:
+        viewer_body = c.get("/api/floors/tlv-floor-5", headers={"X-Test-Role": "viewer"}).json()
+        editor_body = c.get("/api/floors/tlv-floor-5", headers={"X-Test-Role": "editor"}).json()
+    viewer_seats = {x["seat_id"]: x for x in viewer_body["seats"]}
+    editor_seats = {x["seat_id"]: x for x in editor_body["seats"]}
+    # Hidden + viewer → redacted: True.
+    assert viewer_seats["5-T-01"]["redacted"] is True
+    # Hidden + editor → redacted: False (full visibility).
+    assert editor_seats["5-T-01"]["redacted"] is False
+    # Non-hidden → redacted: False, regardless of role.
+    assert viewer_seats["5-T-02"]["redacted"] is False
+    assert editor_seats["5-T-02"]["redacted"] is False
+
+
+def test_build_app_auto_resolves_roles_from_yaml(tmp_path: Path) -> None:
+    """``build_app(data_dir=...)`` reads ``roles:`` from ``data/offices.yaml``."""
+    import shutil
+
+    src = Path(__file__).parent / "fixtures"
+    target = tmp_path / "office-data"
+    shutil.copytree(src, target)
+    (target / "seats").mkdir(exist_ok=True)
+    # Append a roles block to the fixture YAML.
+    yaml_path = target / "data" / "offices.yaml"
+    yaml_path.write_text(
+        yaml_path.read_text(encoding="utf-8") + "\nroles:\n  editor:\n    - alice@example.com\n",
+        encoding="utf-8",
+    )
+    s = _service(target)
+    s.assign("5-T-01", "exec@example.com", hidden=True)
+    # No explicit ``roles=`` — build_app auto-resolves from data_dir.
+    with TestClient(build_app(s, data_dir=target)) as c:
+        # No header → anonymous → viewer → redacted.
+        body = c.get("/api/floors/tlv-floor-5").json()
+    seats = {x["seat_id"]: x for x in body["seats"]}
+    assert seats["5-T-01"]["redacted"] is True
+
+
 def test_user_field_null_when_no_session(data_dir: Path) -> None:
     s = _service(data_dir)
     with TestClient(build_app(s, data_dir=data_dir)) as c:

--- a/tests/test_server_role_filter.py
+++ b/tests/test_server_role_filter.py
@@ -1,0 +1,156 @@
+"""End-to-end role-aware redaction tests via TestClient.
+
+Auth-disabled mode is the default — the ``X-Test-Role`` header drives
+which role the request is treated as. Production sets OIDC env and
+this header is ignored (verified separately in
+``test_server_auth.py``).
+"""
+
+from __future__ import annotations
+
+from itertools import count
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from office_cli.seats import build_service  # noqa: E402
+from office_cli.server import build_app  # noqa: E402
+
+
+def _service(data_dir: Path):
+    counter = count(1)
+
+    def clock() -> str:
+        return f"2026-05-01T00:00:{next(counter):02d}Z"
+
+    s = build_service(data_dir)
+    s._clock = clock  # noqa: SLF001
+    return s
+
+
+def _client(data_dir: Path) -> TestClient:
+    return TestClient(build_app(_service(data_dir), data_dir=data_dir))
+
+
+def test_default_no_header_is_viewer(data_dir: Path) -> None:
+    """No ``X-Test-Role`` header → viewer (default redaction applies)."""
+    s = _service(data_dir)
+    s.assign("5-T-01", "exec@example.com", hidden=True, note="exec note")
+    with TestClient(build_app(s, data_dir=data_dir)) as c:
+        body = c.get("/api/floors/tlv-floor-5").json()
+    seats = {x["seat_id"]: x for x in body["seats"]}
+    assert seats["5-T-01"]["employee_email"] == "(private)"
+    assert seats["5-T-01"]["notes"] == ""
+
+
+def test_viewer_header_redacts(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "exec@example.com", hidden=True)
+    with TestClient(build_app(s, data_dir=data_dir)) as c:
+        body = c.get(
+            "/api/floors/tlv-floor-5",
+            headers={"X-Test-Role": "viewer"},
+        ).json()
+    seats = {x["seat_id"]: x for x in body["seats"]}
+    assert seats["5-T-01"]["employee_email"] == "(private)"
+    # Response carries the user identity for the SPA to render.
+    assert body["user"]["role"] == "viewer"
+
+
+def test_editor_header_sees_full(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "exec@example.com", hidden=True, note="exec note")
+    with TestClient(build_app(s, data_dir=data_dir)) as c:
+        body = c.get(
+            "/api/floors/tlv-floor-5",
+            headers={"X-Test-Role": "editor"},
+        ).json()
+    seats = {x["seat_id"]: x for x in body["seats"]}
+    assert seats["5-T-01"]["employee_email"] == "exec@example.com"
+    assert seats["5-T-01"]["notes"] == "exec note"
+    assert body["user"]["role"] == "editor"
+
+
+def test_planning_header_sees_full(data_dir: Path) -> None:
+    """Planning is editor-equivalent in v1."""
+    s = _service(data_dir)
+    s.assign("5-T-01", "exec@example.com", hidden=True)
+    with TestClient(build_app(s, data_dir=data_dir)) as c:
+        body = c.get(
+            "/api/floors/tlv-floor-5",
+            headers={"X-Test-Role": "planning"},
+        ).json()
+    seats = {x["seat_id"]: x for x in body["seats"]}
+    assert seats["5-T-01"]["employee_email"] == "exec@example.com"
+
+
+def test_non_hidden_unaffected_by_role(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com")
+    with TestClient(build_app(s, data_dir=data_dir)) as c:
+        for role in ("viewer", "editor", "planning"):
+            body = c.get(
+                "/api/floors/tlv-floor-5",
+                headers={"X-Test-Role": role},
+            ).json()
+            seats = {x["seat_id"]: x for x in body["seats"]}
+            assert seats["5-T-01"]["employee_email"] == "alice@example.com"
+
+
+def test_user_field_null_when_no_session(data_dir: Path) -> None:
+    s = _service(data_dir)
+    with TestClient(build_app(s, data_dir=data_dir)) as c:
+        body = c.get("/api/floors/tlv-floor-5").json()
+    assert body["user"] is None
+
+
+def test_sso_redirects_unauth_browser(data_dir: Path) -> None:
+    """Stage 7 acceptance — unauth browser → 302 to ``/auth/login?next=...``.
+
+    Uses a stub OIDC config; we never reach the real IdP because the
+    spa_shell redirect happens before any auth-route call.
+    """
+    pytest.importorskip("authlib")
+    from office_cli.server._auth import OIDCConfig
+
+    oidc = OIDCConfig(
+        issuer="https://idp.example.com",
+        client_id="cid",
+        client_secret="csecret",
+        redirect_url="https://office.example.com/auth/callback",
+        session_secret="x" * 32,
+    )
+    s = _service(data_dir)
+    with TestClient(build_app(s, data_dir=data_dir, oidc=oidc)) as c:
+        r = c.get("/offices/tlv/floors/tlv-floor-5", follow_redirects=False)
+    assert r.status_code == 302
+    assert r.headers["location"].startswith("/auth/login?next=/offices/tlv/floors/tlv-floor-5")
+
+
+def test_sso_test_role_header_ignored_when_oidc_enabled(data_dir: Path) -> None:
+    """The ``X-Test-Role`` escape hatch must NOT work in production mode."""
+    pytest.importorskip("authlib")
+    from office_cli.server._auth import OIDCConfig
+
+    oidc = OIDCConfig(
+        issuer="https://idp.example.com",
+        client_id="cid",
+        client_secret="csecret",
+        redirect_url="https://office.example.com/auth/callback",
+        session_secret="x" * 32,
+    )
+    s = _service(data_dir)
+    s.assign("5-T-01", "exec@example.com", hidden=True)
+    with TestClient(build_app(s, data_dir=data_dir, oidc=oidc)) as c:
+        body = c.get(
+            "/api/floors/tlv-floor-5",
+            headers={"X-Test-Role": "editor"},
+        ).json()
+    seats = {x["seat_id"]: x for x in body["seats"]}
+    # With OIDC enabled and no session, the caller is anonymous → viewer.
+    # The X-Test-Role header is ignored; redaction stays in force.
+    assert seats["5-T-01"]["employee_email"] == "(private)"

--- a/tests/test_server_role_filter.py
+++ b/tests/test_server_role_filter.py
@@ -128,7 +128,37 @@ def test_sso_redirects_unauth_browser(data_dir: Path) -> None:
     with TestClient(build_app(s, data_dir=data_dir, oidc=oidc)) as c:
         r = c.get("/offices/tlv/floors/tlv-floor-5", follow_redirects=False)
     assert r.status_code == 302
-    assert r.headers["location"].startswith("/auth/login?next=/offices/tlv/floors/tlv-floor-5")
+    # ``next`` is URL-encoded so embedded ``&`` / ``?`` / ``=`` round-trip.
+    assert r.headers["location"] == "/auth/login?next=%2Foffices%2Ftlv%2Ffloors%2Ftlv-floor-5"
+
+
+def test_sso_redirect_preserves_query_params(data_dir: Path) -> None:
+    """Qodo Q1 on PR #20 — original URL with ``&``-joined query params
+    must round-trip through the redirect intact.
+    """
+    pytest.importorskip("authlib")
+    from office_cli.server._auth import OIDCConfig
+
+    oidc = OIDCConfig(
+        issuer="https://idp.example.com",
+        client_id="cid",
+        client_secret="csecret",
+        redirect_url="https://office.example.com/auth/callback",
+        session_secret="x" * 32,
+    )
+    s = _service(data_dir)
+    with TestClient(build_app(s, data_dir=data_dir, oidc=oidc)) as c:
+        r = c.get(
+            "/offices/tlv/floors/tlv-floor-5?seat=5-T-01&asOf=2026-07-01",
+            follow_redirects=False,
+        )
+    assert r.status_code == 302
+    # Decode the next param to check the original URL survives.
+    from urllib.parse import parse_qs, urlparse
+
+    location = r.headers["location"]
+    next_param = parse_qs(urlparse(location).query)["next"][0]
+    assert next_param == "/offices/tlv/floors/tlv-floor-5?seat=5-T-01&asOf=2026-07-01"
 
 
 def test_sso_test_role_header_ignored_when_oidc_enabled(data_dir: Path) -> None:

--- a/tests/test_slack_app.py
+++ b/tests/test_slack_app.py
@@ -268,6 +268,64 @@ def test_invalid_calendar_date_rejected(data_dir: Path) -> None:
     assert "2026-02-30" in text
 
 
+def test_editor_caller_sees_hidden_seat_in_full(data_dir: Path) -> None:
+    """Stage 7: an editor-role caller via the roles map sees the email."""
+    from office_cli._roles import RolesConfig
+
+    service = _service_with_active(data_dir, "exec@example.com", "alice@example.com")
+    service.assign("5-T-04", "exec@example.com", hidden=True)
+    roles = RolesConfig(editor=frozenset({"alice@example.com"}))
+    app = build_app(service, app=FakeSlackApp(), roles=roles)
+    # ``alice@example.com`` is the caller (resolved via users.info on U999),
+    # asking about the hidden seat.
+    client = FakeSlackClient(users={"U999": {"profile": {"email": "alice@example.com"}}})
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "exec@example.com", "user_id": "U999"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    # Editor caller — the hidden block path is bypassed; full occupancy details visible.
+    assert "exec@example.com" in text
+
+
+def test_viewer_caller_sees_private_for_mention(data_dir: Path) -> None:
+    """A non-editor caller asking about ``@user`` (a mention) sees ``occupied (private)``.
+
+    This is the issue-#11 acceptance shape: the caller types
+    ``/whereis @bob``, the handler resolves the mention to bob's email
+    via ``users.info``, then redacts in the response because the
+    caller's role is viewer. The block-level text uses the mention
+    (``<@U…>``) as the label — never bob's email.
+    """
+    from office_cli._roles import RolesConfig
+
+    service = _service_with_active(data_dir, "exec@example.com")
+    service.assign("5-T-04", "exec@example.com", hidden=True)
+    # Caller (U999 / bob) is NOT in the editor list → stays viewer.
+    # Target (U123 / exec) is the @-mention.
+    roles = RolesConfig(editor=frozenset({"hr@example.com"}))
+    app = build_app(service, app=FakeSlackApp(), roles=roles)
+    client = FakeSlackClient(
+        users={
+            "U999": {"profile": {"email": "bob@example.com"}},
+            "U123": {"profile": {"email": "exec@example.com"}},
+        }
+    )
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "<@U123|exec>", "user_id": "U999"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "occupied (private)" in text
+    # The mention label was used in the response, not the resolved email.
+    assert "exec@example.com" not in text
+    assert "<@U123>" in text
+
+
 def test_trailing_date_filters_via_as_of(data_dir: Path) -> None:
     """Stage 6 — trailing ``YYYY-MM-DD`` token filters via the effective window."""
     service = _service_with_active(data_dir, "alice@example.com")

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,19 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
+]
+
+[[package]]
 name = "bandit"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -520,6 +533,27 @@ wheels = [
 ]
 
 [[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -569,7 +603,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
@@ -586,6 +620,11 @@ slack = [
     { name = "slack-bolt" },
     { name = "slack-sdk" },
 ]
+sso = [
+    { name = "authlib" },
+    { name = "httpx" },
+    { name = "itsdangerous" },
+]
 web = [
     { name = "fastapi" },
     { name = "uvicorn" },
@@ -593,12 +632,14 @@ web = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "authlib" },
     { name = "bandit" },
     { name = "black" },
     { name = "fastapi" },
     { name = "flake8" },
     { name = "httpx" },
     { name = "isort" },
+    { name = "itsdangerous" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
@@ -606,24 +647,29 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "authlib", marker = "extra == 'sso'", specifier = ">=1.3" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.110" },
     { name = "gspread", marker = "extra == 'sheets'", specifier = ">=6.0" },
+    { name = "httpx", marker = "extra == 'sso'", specifier = ">=0.27" },
+    { name = "itsdangerous", marker = "extra == 'sso'", specifier = ">=2.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", marker = "extra == 'bamboohr'", specifier = ">=2.31" },
     { name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.18" },
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.30" },
 ]
-provides-extras = ["sheets", "bamboohr", "slack", "web"]
+provides-extras = ["sheets", "bamboohr", "slack", "web", "sso"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "authlib", specifier = ">=1.3" },
     { name = "bandit", specifier = ">=1.7.5" },
     { name = "black", specifier = ">=23.7.0" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "flake8", specifier = ">=6.1" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "isort", specifier = ">=5.12.0" },
+    { name = "itsdangerous", specifier = ">=2.1" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=4.1" },
     { name = "pytest-xdist", specifier = ">=3.0" },


### PR DESCRIPTION
Closes #11.

## Summary

Three roles with view-time redaction:

- **viewer** (default, safe-by-default): hidden=TRUE seats render as
  "(private)" with no email/notes.
- **editor**: full details on hidden seats. HR/IT use case.
- **planning**: same as editor in v1; the draft-SVG and future-dated
  carve-outs from issue #1 are deferred per the issue's note.

### Where the gate lives

- New `office_cli/_roles.py` — `RolesConfig`, `resolve_roles`,
  `role_for_email`, `is_full_access`. Roles map lives in
  `data/offices.yaml` under a top-level `roles:` block.
- `SeatService.list_seats(role=...)` and `whereis(role=...)` apply
  redaction at view time. `role=None` (CLI default) is
  unrestricted. Surface renderers consult `Assignment.redacted` (a
  non-persisted view-time flag) to render the "(private)"
  placeholder.

### Web SSO

- `office_cli/server/_auth.py` — `OIDCConfig`, `resolve_oidc`,
  `register_auth_routes` (using
  `authlib.integrations.starlette_client`).
- When all five env vars (`OIDC_ISSUER`, `OIDC_CLIENT_ID`,
  `OIDC_CLIENT_SECRET`, `OIDC_REDIRECT_URL`, `SESSION_SECRET`) are
  set, the SPA shell route requires auth and unauth browsers are
  redirected through the IdP.
- Auth-disabled mode for local dev / tests: when OIDC env is
  unset, no redirects, no session middleware. Tests use the
  `X-Test-Role` header — only honored in auth-disabled mode.

### Slack roles

- Slack `/whereis` resolves the calling user's email via the existing
  `users.info` call and looks up their role from `RolesConfig`.
- The "(private)" block path is now gated on `assignment.redacted`,
  not on `hidden`, so editor/planning callers see hidden seats in
  full.

### Extras + version

- New `[sso]` extra pulls `authlib>=1.3`, `itsdangerous>=2.1`,
  `httpx>=0.27`. Package still imports cleanly without it.
- Bumped to **0.7.0**.

## Test plan

- [x] 238 tests pass (`uv run pytest -n auto -q`)
- [x] black / isort / flake8 / bandit / markdownlint all clean
- [x] CLI smoke (CLI is unrestricted): `office seats list` shows
      hidden details with no role.
- [x] Web smoke (auth-disabled mode):
      - viewer (no header) → `employee_email: "(private)"`
      - editor (`X-Test-Role: editor`) → `employee_email: <real>`,
        `notes: <real>`, `user: {role: "editor"}`
- [x] SSO redirect: `test_sso_redirects_unauth_browser` validates a
      302 to `/auth/login?next=...` against a stub OIDC config.
- [x] X-Test-Role escape hatch is ignored once OIDC is enabled
      (`test_sso_test_role_header_ignored_when_oidc_enabled`).
- [x] Slack: editor caller via `roles=RolesConfig(editor={...})` sees
      the email; non-editor caller sees "(private)" via @mention.

## Out of scope (deferred)

- Planning role's draft-SVG view + future-dated visibility carve-outs
  (issue #1 stretch).
- Audit-log redaction (issue #11 explicit).
- Per-office role scoping (one global role-map).
- API-token auth for non-browser callers (CLI is the supported path).

- Claude