### PR TITLE
feat: v1 seating Stage 8 — DynamoDB store + bi-directional Sheets sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-01
+
+### Added
+
+- v1 seating Stage 8 — DynamoDB store + bi-directional Sheets sync
+  ([#12](https://github.com/agentculture/office-agent/issues/12)).
+  New `office_cli.seats.dynamo` subpackage: `DynamoStore`,
+  `DynamoAuditLog`, `DynamoClient` Protocol, `Boto3DynamoClient`
+  production impl. Same Protocol shape and 5-minute TTL cache as
+  the Sheets store, so the read path is identical across backends.
+- `StorageConfig` extends to `type: "dynamo"` with
+  `table_assignments`, `table_audit`, `region`. Configurable via
+  `data/offices.yaml` `storage.dynamo:` block or env overrides
+  (`OFFICE_DYNAMO_ASSIGNMENTS`, `OFFICE_DYNAMO_AUDIT`,
+  `OFFICE_DYNAMO_REGION`). AWS credentials follow the standard
+  chain (`AWS_PROFILE`, IAM role, etc) — never in YAML.
+- New CLI verb `office seats migrate --from {csv,sheets,dynamo}
+  --to {csv,sheets,dynamo} [--dry-run] [--audit-append] [--json]`
+  for one-shot import/export between any two backends. Idempotent
+  for assignments (upsert by `seat_id`); audit idempotency is
+  target-dependent (Dynamo PK+SK dedups; CSV/Sheets append-only —
+  command bails out if the target audit log is non-empty unless
+  `--audit-append` is passed).
+- New CLI verb `office seats sync --primary {sheets,dynamo}
+  [--dry-run] [--json]` for bi-directional reconciliation between
+  Sheets and Dynamo. Last-write-wins per row by `last_updated`.
+  `--primary` is the tie-breaker when `last_updated` matches but
+  content diverges. Idempotent: re-running converges. Operators
+  run periodically (cron / GitHub Action) to keep the spreadsheet
+  UI and the Dynamo runtime in agreement.
+- `office_cli/seats/_sync.py`: pure `reconcile(left, right, *, primary,
+  ...)` returning a `SyncPlan`. No I/O at the reconciliation layer
+  so unit tests stay fast and surface-neutral.
+- New optional extra: `pip install office-cli[dynamo]` pulls
+  `boto3>=1.34`. Package still imports cleanly without it (lazy
+  `boto3` import inside `Boto3DynamoClient.__init__`).
+- `office_cli.seats.build_backends_for_type(data_dir, store_type)`
+  exposed as a public helper for the migrate / sync verbs.
+
+### Notes
+
+- **Sheets stays a first-class runtime backend.** Stage 8 does not
+  deprecate `OFFICE_STORE=sheets` — operators who prefer the
+  spreadsheet UI as the primary editor can keep using it. The
+  migrate + sync verbs make Sheets and Dynamo interoperable, not
+  exclusive.
+- **GSI on `employee_email`** is documented as Stage-9 hardening.
+  The v1 read path is `scan` + in-memory filter (5-minute cache),
+  matching Sheets behavior exactly.
+
 ## [0.7.0] - 2026-05-01
 
 ### Added
@@ -245,7 +295,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   preserving the SVG ID contract and architectural guardrails for the v1
   seating system (issue #1).
 
-[Unreleased]: https://github.com/agentculture/office-agent/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/agentculture/office-agent/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/agentculture/office-agent/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/agentculture/office-agent/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/agentculture/office-agent/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/agentculture/office-agent/compare/v0.4.0...v0.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@ office-agent/
 │   ├── _roles.py                # RolesConfig / role_for_email / is_full_access (Stage 7)
 │   ├── offices/                 # offices.yaml loader + Office/Floor/Cluster/Room
 │   ├── floors/                  # SVG parse + ID contract + validator
-│   ├── seats/                   # AssignmentStore + Csv/Sheets stores + AuditLog + SeatService
+│   ├── seats/                   # AssignmentStore + Csv/Sheets/Dynamo stores + AuditLog + SeatService
+│   │                            # Stage 8: bi-directional sync via `office seats sync`
 │   ├── people/                  # Employee + EmployeeDirectory (Stub + BambooHR backends)
 │   ├── slack/                   # `/whereis` Bolt app + Socket Mode runner (optional [slack] extra)
 │   ├── server/                  # FastAPI seat-map server + vanilla-JS frontend (optional [web] extra)
@@ -63,7 +64,7 @@ office-agent/
 ```bash
 uv sync                           # install runtime + dev deps
 uv run pytest -n auto -v          # full suite, parallel
-uv run office --version           # 0.7.0
+uv run office --version           # 0.8.0
 uv run office learn               # agent affordance
 uv run office whoami              # auth probe stub
 uv run office floors validate floors/tlv-floor-5.svg
@@ -140,7 +141,7 @@ Rules: IDs unique within a file; floor number first; cluster letter uppercase; s
 Lessons paid for in advance — don't relitigate without a reason:
 
 - **BambooHR is the source of truth for people.** Never store name/email/role/photo locally; pull on request, cache 5 minutes. Offboarding in BambooHR must auto-vacate the seat without anyone editing the Sheet — this is the killer feature, verify it end-to-end.
-- **The Google Sheet is the CMS.** Don't build an in-app editor for assignments. Don't build an in-app SVG editor either — Inkscape is the editor for layouts.
+- **The Google Sheet is the CMS.** Don't build an in-app editor for assignments. Don't build an in-app SVG editor either — Inkscape is the editor for layouts. Stage 8 adds DynamoDB as a second runtime backend, but Sheets stays a first-class option — `office seats migrate --from X --to Y` (one-shot) and `office seats sync --primary {sheets,dynamo}` (bi-directional last-write-wins) keep them interoperable.
 - **Audit log is append-only.** Seat changes never overwrite history; "who used to sit at 5-T-01?" must return chronological history.
 - **Multi-office from day one.** No hardcoded `tlv`. Adding a floor = drop SVG + add `data/offices.yaml` entry, no code change.
 - **Future-dated assignments**: the data model carries `effective_from` / `effective_until` and Stage 6 enforces them at the service layer. `office seats assign --from / --until`, `office whereis --as-of`, `office seats list --as-of`, `?asOf=YYYY-MM-DD` on the web map, and a trailing `YYYY-MM-DD` token on Slack `/whereis` all flow through the same window check. `effective_*` is stored as `YYYY-MM-DD` (date precision, no time); `last_updated` and audit timestamps stay full ISO-8601.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ BambooHR; assignments live in a Google Sheet (v1) or DynamoDB (v2). The
 CLI exposes the same operations as the Slack `/whereis` command and the
 web map.
 
-> **Status — v0.7.0.** Stages 1–7 of the v1 seating system are in:
-> floor SVG parser/validator, CSV / Google Sheets-backed assignment
-> store with append-only audit log, BambooHR-backed `EmployeeDirectory`
-> with the auto-vacate killer feature, CLI verbs (`floors`, `seats`,
-> `whereis`), a Slack `/whereis` slash-command listener, a search-first
-> web map, effective-date enforcement, and SSO + role-aware redaction.
-> DynamoDB lands in Stage 8. See
+> **Status — v0.8.0.** Stages 1–8 of the v1 seating system are in:
+> floor SVG parser/validator, CSV / Google Sheets / DynamoDB-backed
+> assignment store with append-only audit log, BambooHR-backed
+> `EmployeeDirectory` with the auto-vacate killer feature, CLI verbs
+> (`floors`, `seats`, `whereis`), a Slack `/whereis` slash-command
+> listener, a search-first web map, effective-date enforcement,
+> SSO + role-aware redaction, and bi-directional Sheets ↔ Dynamo
+> sync. See
 > [issue #1](https://github.com/agentculture/office-agent/issues/1).
 
 ## Naming surfaces
@@ -162,6 +163,66 @@ shows the same view, deep-linkable.
 `effective_from` / `effective_until` are stored as `YYYY-MM-DD` (date
 precision); `last_updated` and audit-log timestamps stay full ISO-8601.
 Empty bounds mean "always begins" / "no end".
+
+### DynamoDB backend + Sheets sync
+
+`office` ships three storage backends behind a single Protocol: CSV
+(default), Google Sheets, and DynamoDB. They are interchangeable
+runtime backends; pick one via `OFFICE_STORE` or
+`storage.type` in `data/offices.yaml`.
+
+```bash
+pip install office-cli[dynamo]
+export OFFICE_STORE=dynamo
+export OFFICE_DYNAMO_ASSIGNMENTS=office-assignments
+export OFFICE_DYNAMO_AUDIT=office-audit-log
+export OFFICE_DYNAMO_REGION=us-east-1
+# AWS creds via AWS_PROFILE / IAM role / standard chain
+office seats list
+```
+
+YAML:
+
+```yaml
+storage:
+  type: dynamo
+  dynamo:
+    table_assignments: office-assignments
+    table_audit: office-audit-log
+    region: us-east-1
+    cache_ttl_seconds: 300
+```
+
+The `office-assignments` table is keyed on `seat_id`. The
+`office-audit-log` table is keyed on `seat_id` (PK) + `timestamp`
+(SK) so re-running migrations doesn't duplicate audit rows.
+
+#### One-shot import/export
+
+```bash
+# Bootstrap Dynamo from Sheets:
+office seats migrate --from sheets --to dynamo --dry-run   # preview
+office seats migrate --from sheets --to dynamo
+
+# Snapshot Dynamo back to Sheets for offline review:
+office seats migrate --from dynamo --to sheets --audit-append
+```
+
+#### Bi-directional sync (Sheets ↔ Dynamo)
+
+Sheets stays the human-friendly editor; Dynamo is the runtime read
+path. Run `office seats sync` periodically (cron / GitHub Action) to
+reconcile both sides via last-write-wins on `last_updated`:
+
+```bash
+# Pick the tie-breaker side when last_updated matches but content
+# diverges (rare). The reconcile is idempotent — re-running converges.
+office seats sync --primary sheets --dry-run
+office seats sync --primary sheets
+```
+
+The CLI is the supported sync entry point; there is no always-on
+daemon (a Stage-9+ addition if needed).
 
 ### SSO + roles
 

--- a/data/offices.yaml
+++ b/data/offices.yaml
@@ -18,6 +18,19 @@
 #       - "hr-it@tipalti.com"
 #     planning:
 #       - "facilities@tipalti.com"
+#
+# Stage 8 — DynamoDB backend (issue #12). Selectable via
+# `storage.type: dynamo`. Sheets remains a first-class option; use
+# `office seats migrate` for one-shot copy, or `office seats sync`
+# for periodic bi-directional reconciliation. Example:
+#
+#   storage:
+#     type: dynamo
+#     dynamo:
+#       table_assignments: office-assignments
+#       table_audit: office-audit-log
+#       region: us-east-1
+#       cache_ttl_seconds: 300
 
 offices:
   - id: tlv

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Architecture — v0.7.0 (Stages 1–7)
+# Architecture — v0.8.0 (Stages 1–8)
 
 `office` ships in stages on top of issue
 [#1](https://github.com/agentculture/office-agent/issues/1). This document
@@ -298,13 +298,47 @@ seats), `planning` (facilities — same as editor in v1).
 - The planning role's draft-SVG and future-dated visibility carve-outs
   from issue #1 stay deferred.
 
+## Stage 8 — implemented in v0.8.0
+
+DynamoDB store + bi-directional Sheets sync
+([#12](https://github.com/agentculture/office-agent/issues/12)).
+
+- `office_cli/seats/dynamo/`: `DynamoStore` + `DynamoAuditLog` behind
+  the same `AssignmentStore` / `AuditLog` Protocols as the Sheets
+  backend. The `DynamoClient` Protocol exposes only the four
+  operations the store + audit need (`scan_all`, `put_item`,
+  `batch_put`, `query_by_pk`); `Boto3DynamoClient` is the production
+  implementation with lazy `boto3` import. Tests use a hand-rolled
+  `FakeDynamoClient` (no `moto` dependency).
+- Schema: `office-assignments` table keyed on `seat_id`;
+  `office-audit-log` keyed on (`seat_id`, `timestamp`). The audit
+  PK+SK pair makes `put_item` idempotent — re-runs of `migrate`
+  overwrite the same rows rather than duplicating them.
+- Read path: `DynamoStore.list()` does one `scan` and caches with a
+  5-minute TTL, identical to `SheetsStore`. `by_email` filters in
+  memory. A GSI on `employee_email` is documented as Stage-9
+  hardening but not required for v1 scale.
+- `office seats migrate --from {csv,sheets,dynamo} --to {csv,sheets,dynamo}
+  [--dry-run] [--audit-append]`: one-shot import/export between any
+  two backends. Idempotent for assignments (upsert by `seat_id`);
+  audit idempotency is target-dependent.
+- `office seats sync --primary {sheets,dynamo} [--dry-run]`:
+  bi-directional reconciliation between Sheets and Dynamo with
+  last-write-wins per row by `last_updated`. `office_cli/seats/_sync.py`
+  hosts the pure `reconcile()` reconciler — no I/O at the
+  reconciliation layer.
+- **Sheets stays a first-class runtime backend**. Stage 8 adds
+  Dynamo as an alternative; it does not deprecate Sheets. Operators
+  who prefer the spreadsheet UI as their primary editor keep using
+  it. The migrate + sync verbs make them interoperable.
+
 ## Deferred surfaces
 
 Each is a separate issue/PR.
 
 | Stage              | Surface                                       | Notes                                                                   |
 | ------------------ | --------------------------------------------- | ----------------------------------------------------------------------- |
-| 8. DynamoDB        | `office_cli.seats.DynamoStore`                | Migration script from Sheets, kept identical Protocol.                  |
+| 9. GSI + observability | `employee_email` GSI on `office-assignments` | Drops the `scan` + in-memory filter for `by_email`.                     |
 
 ## Operating notes
 

--- a/office_cli/_config.py
+++ b/office_cli/_config.py
@@ -90,19 +90,30 @@ class StorageConfig:
     region: str = ""
 
 
-def resolve_storage(data_dir: Path) -> StorageConfig:
+def resolve_storage(data_dir: Path, *, type_override: str | None = None) -> StorageConfig:
     """Pick the storage backend from offices.yaml + env overrides.
 
     Defaults to ``csv``. Sheets requires both a spreadsheet id and a
     service-account JSON path; we error early if either is missing so
     operators get a clear hint instead of an opaque gspread error.
+
+    ``type_override`` lets callers force a specific backend type
+    (csv / sheets / dynamo) without mutating the environment. The
+    migrate / sync verbs use this to construct source + target pairs.
     """
     yaml_cfg = _read_storage_block(data_dir)
-    store_type = (
-        (os.environ.get("OFFICE_STORE") or _str_field(yaml_cfg, "type", prefix="storage") or "csv")
-        .strip()
-        .lower()
-    )
+    if type_override is not None:
+        store_type = type_override.strip().lower()
+    else:
+        store_type = (
+            (
+                os.environ.get("OFFICE_STORE")
+                or _str_field(yaml_cfg, "type", prefix="storage")
+                or "csv"
+            )
+            .strip()
+            .lower()
+        )
 
     if store_type == "csv":
         return StorageConfig(type="csv")

--- a/office_cli/_config.py
+++ b/office_cli/_config.py
@@ -38,6 +38,7 @@ from office_cli.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, OfficeError
 _SHAPE_HINT = "see docs/architecture.md for the expected shape"
 _BAMBOOHR_TTL_MAX_SECONDS = 300
 _PREFIX_SHEETS = "storage.sheets"
+_PREFIX_DYNAMO = "storage.dynamo"
 _PREFIX_BAMBOOHR = "directory.bamboohr"
 
 
@@ -79,10 +80,14 @@ def audit_log_csv(data_dir: Path) -> Path:
 class StorageConfig:
     """Resolved storage backend for the seat service."""
 
-    type: str  # "csv" | "sheets"
+    type: str  # "csv" | "sheets" | "dynamo"
     spreadsheet_id: str = ""
     service_account: Path | None = None
     cache_ttl_seconds: int = 300
+    # Dynamo-specific. Empty for csv / sheets backends.
+    table_assignments: str = ""
+    table_audit: str = ""
+    region: str = ""
 
 
 def resolve_storage(data_dir: Path) -> StorageConfig:
@@ -102,11 +107,17 @@ def resolve_storage(data_dir: Path) -> StorageConfig:
     if store_type == "csv":
         return StorageConfig(type="csv")
 
+    if store_type == "dynamo":
+        return _resolve_dynamo(yaml_cfg)
+
     if store_type != "sheets":
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=f"unknown storage type: {store_type!r}",
-            remediation="set storage.type to 'csv' or 'sheets' in offices.yaml or OFFICE_STORE",
+            remediation=(
+                "set storage.type to 'csv', 'sheets', or 'dynamo' "
+                "in offices.yaml or OFFICE_STORE"
+            ),
         )
 
     sheets_cfg = yaml_cfg.get("sheets")
@@ -146,6 +157,60 @@ def resolve_storage(data_dir: Path) -> StorageConfig:
         type="sheets",
         spreadsheet_id=spreadsheet_id,
         service_account=sa_path,
+        cache_ttl_seconds=ttl,
+    )
+
+
+def _resolve_dynamo(yaml_cfg: dict) -> StorageConfig:
+    """Build a ``type: dynamo`` :class:`StorageConfig` from YAML + env."""
+    dynamo_cfg = yaml_cfg.get("dynamo")
+    if dynamo_cfg is None:
+        dynamo_cfg = {}
+    if not isinstance(dynamo_cfg, dict):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="storage.dynamo must be a mapping in offices.yaml",
+            remediation=_SHAPE_HINT,
+        )
+    table_assignments = (
+        os.environ.get("OFFICE_DYNAMO_ASSIGNMENTS")
+        or _str_field(dynamo_cfg, "table_assignments", prefix=_PREFIX_DYNAMO)
+        or ""
+    ).strip()
+    table_audit = (
+        os.environ.get("OFFICE_DYNAMO_AUDIT")
+        or _str_field(dynamo_cfg, "table_audit", prefix=_PREFIX_DYNAMO)
+        or ""
+    ).strip()
+    region = (
+        os.environ.get("OFFICE_DYNAMO_REGION")
+        or _str_field(dynamo_cfg, "region", prefix=_PREFIX_DYNAMO)
+        or ""
+    ).strip()
+    if not table_assignments:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message="storage.type=dynamo requires a table_assignments name",
+            remediation="set OFFICE_DYNAMO_ASSIGNMENTS or storage.dynamo.table_assignments",
+        )
+    if not table_audit:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message="storage.type=dynamo requires a table_audit name",
+            remediation="set OFFICE_DYNAMO_AUDIT or storage.dynamo.table_audit",
+        )
+    if not region:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message="storage.type=dynamo requires an AWS region",
+            remediation="set OFFICE_DYNAMO_REGION or storage.dynamo.region",
+        )
+    ttl = _int_field(dynamo_cfg, "cache_ttl_seconds", 300, prefix=_PREFIX_DYNAMO)
+    return StorageConfig(
+        type="dynamo",
+        table_assignments=table_assignments,
+        table_audit=table_audit,
+        region=region,
         cache_ttl_seconds=ttl,
     )
 

--- a/office_cli/cli/_commands/migrate.py
+++ b/office_cli/cli/_commands/migrate.py
@@ -1,0 +1,165 @@
+"""``office seats migrate`` — one-shot import/export between stores.
+
+Any-to-any. Reads from the ``--from`` backend and upserts into the
+``--to`` backend. Used to bootstrap Dynamo from Sheets, snapshot
+Dynamo back to Sheets for offline review, etc. Audit log is preserved
+through the migration.
+
+Idempotency:
+
+* **Assignments**: ``upsert_many`` keys by ``seat_id`` — re-runs are
+  safe.
+* **Audit**: idempotent when the **target** is Dynamo (PK + SK key
+  dedups). Sheets / CSV append-only stores will duplicate audit rows
+  on a re-run, so the command bails out early if the target audit log
+  is non-empty unless the operator passes ``--audit-append``.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from office_cli._config import add_data_dir_arg, resolve_data_dir
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+from office_cli.cli._output import emit_diagnostic, emit_result
+from office_cli.seats import build_backends_for_type
+
+_VALID_TYPES = ("csv", "sheets", "dynamo")
+
+
+def cmd_migrate(args: argparse.Namespace) -> int:
+    if args.from_type == args.to_type:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"--from and --to are both {args.from_type!r}",
+            remediation="pick a different target backend",
+        )
+    _validate_type("--from", args.from_type)
+    _validate_type("--to", args.to_type)
+
+    data_dir = resolve_data_dir(args)
+    src_store, src_audit = build_backends_for_type(data_dir, args.from_type)
+    tgt_store, tgt_audit = build_backends_for_type(data_dir, args.to_type)
+
+    src_assignments = src_store.list()
+    src_audit_entries = src_audit.all()
+
+    tgt_existing = {a.seat_id: a for a in tgt_store.list()}
+    new = [a for a in src_assignments if a.seat_id not in tgt_existing]
+    overwritten = [
+        a for a in src_assignments if a.seat_id in tgt_existing and tgt_existing[a.seat_id] != a
+    ]
+    unchanged = len(src_assignments) - len(new) - len(overwritten)
+
+    audit_target_size = len(tgt_audit.all())
+    if (
+        args.to_type in ("csv", "sheets")
+        and audit_target_size
+        and not args.audit_append
+        and not args.dry_run
+    ):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"target audit log is non-empty ({audit_target_size} rows); "
+                f"appending would duplicate rows on re-run"
+            ),
+            remediation=(
+                "clear the target audit log first, or pass --audit-append "
+                "to accept the duplication"
+            ),
+        )
+
+    if args.dry_run:
+        emit_diagnostic(
+            f"DRY RUN: {args.from_type} → {args.to_type}: "
+            f"{len(new)} new, {len(overwritten)} overwritten, "
+            f"{unchanged} unchanged; {len(src_audit_entries)} audit rows"
+        )
+        if args.json:
+            emit_result(
+                {
+                    "from": args.from_type,
+                    "to": args.to_type,
+                    "dry_run": True,
+                    "assignments_new": len(new),
+                    "assignments_overwritten": len(overwritten),
+                    "assignments_unchanged": unchanged,
+                    "audit_rows": len(src_audit_entries),
+                },
+                json_mode=True,
+            )
+        return 0
+
+    tgt_store.upsert_many(src_assignments)
+    tgt_audit.append_many(src_audit_entries)
+
+    summary = {
+        "from": args.from_type,
+        "to": args.to_type,
+        "dry_run": False,
+        "assignments_written": len(src_assignments),
+        "audit_rows_written": len(src_audit_entries),
+    }
+    if args.json:
+        emit_result(summary, json_mode=True)
+    else:
+        emit_result(
+            f"migrated {len(src_assignments)} assignments and "
+            f"{len(src_audit_entries)} audit rows from "
+            f"{args.from_type} to {args.to_type}",
+            json_mode=False,
+        )
+    return 0
+
+
+def _validate_type(flag: str, value: str) -> None:
+    if value not in _VALID_TYPES:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"{flag} must be one of {', '.join(_VALID_TYPES)}; got {value!r}",
+            remediation=f"pass {flag} csv | sheets | dynamo",
+        )
+
+
+def register(parent: argparse._SubParsersAction) -> None:
+    p = parent.add_parser(
+        "migrate",
+        help="One-shot import/export between storage backends.",
+        description=(
+            "Copy assignments and audit-log rows from --from to --to. "
+            "Source / target are any of csv, sheets, dynamo (and they "
+            "must differ). Idempotent for assignments; audit "
+            "idempotency is target-dependent (see --audit-append)."
+        ),
+    )
+    p.add_argument(
+        "--from",
+        dest="from_type",
+        required=True,
+        choices=_VALID_TYPES,
+        help="Source backend.",
+    )
+    p.add_argument(
+        "--to",
+        dest="to_type",
+        required=True,
+        choices=_VALID_TYPES,
+        help="Target backend.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Read source + target, print the diff, write nothing.",
+    )
+    p.add_argument(
+        "--audit-append",
+        action="store_true",
+        help=(
+            "Allow appending audit rows even when the target log is "
+            "non-empty (duplicates likely on csv/sheets targets)."
+        ),
+    )
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    add_data_dir_arg(p)
+    p.set_defaults(func=cmd_migrate)

--- a/office_cli/cli/_commands/seats.py
+++ b/office_cli/cli/_commands/seats.py
@@ -6,6 +6,8 @@ import argparse
 
 from office_cli._config import add_data_dir_arg, resolve_data_dir
 from office_cli._dates import parse_iso_date, today_iso_date
+from office_cli.cli._commands import migrate as _migrate_cmd
+from office_cli.cli._commands import sync as _sync_cmd
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 from office_cli.cli._output import emit_result
 from office_cli.seats import build_service
@@ -185,6 +187,10 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_history.add_argument("--json", action="store_true")
     add_data_dir_arg(p_history)
     p_history.set_defaults(func=cmd_history)
+
+    # Stage 8: import/export across backends + bi-directional sync.
+    _migrate_cmd.register(inner)
+    _sync_cmd.register(inner)
 
     p.set_defaults(func=lambda args: _missing_subcommand(p))
 

--- a/office_cli/cli/_commands/sync.py
+++ b/office_cli/cli/_commands/sync.py
@@ -64,7 +64,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
 
     if plan.ties:
         emit_diagnostic(
-            f"sync: {len(plan.ties)} content tie(s) on {primary} side: " f"{', '.join(plan.ties)}"
+            f"sync: {len(plan.ties)} content tie(s) on {primary} side: " + ", ".join(plan.ties)
         )
 
     if args.dry_run:
@@ -115,7 +115,7 @@ def register(parent: argparse._SubParsersAction) -> None:
         "--primary",
         required=True,
         choices=("sheets", "dynamo"),
-        help=("Tie-breaker when last_updated matches on both sides " "but content diverged."),
+        help="Tie-breaker when last_updated matches on both sides but content diverged.",
     )
     p.add_argument(
         "--dry-run",

--- a/office_cli/cli/_commands/sync.py
+++ b/office_cli/cli/_commands/sync.py
@@ -1,0 +1,127 @@
+"""``office seats sync`` — bi-directional reconciliation between Sheets and Dynamo.
+
+Operator workflow: Sheets is the human-friendly editor; Dynamo is the
+runtime read path. ``office seats sync`` keeps them in agreement via
+last-write-wins on ``last_updated``. Run periodically (cron / GitHub
+Action). The ``--primary`` flag picks the tie-breaker when both sides
+have an identical ``last_updated`` but diverged content (rare).
+
+Idempotency: re-running converges. The reconciler computes the
+minimal set of writes per side; once both sides agree the plan is
+empty and the verb is a no-op.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from office_cli._config import add_data_dir_arg, resolve_data_dir
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+from office_cli.cli._output import emit_diagnostic, emit_result
+from office_cli.seats import build_backends_for_type
+from office_cli.seats._sync import reconcile
+
+_PRIMARY_TO_TYPE = {"sheets": "sheets", "dynamo": "dynamo"}
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    primary = args.primary
+    if primary not in _PRIMARY_TO_TYPE:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"--primary must be 'sheets' or 'dynamo'; got {primary!r}",
+            remediation="pass --primary sheets | dynamo",
+        )
+
+    data_dir = resolve_data_dir(args)
+    sheets_store, sheets_audit = build_backends_for_type(data_dir, "sheets")
+    dynamo_store, dynamo_audit = build_backends_for_type(data_dir, "dynamo")
+
+    sheets_rows = sheets_store.list()
+    dynamo_rows = dynamo_store.list()
+    sheets_audit_rows = sheets_audit.all()
+    dynamo_audit_rows = dynamo_audit.all()
+
+    # Map "sheets" / "dynamo" to "left" / "right" so the reconciler
+    # stays surface-neutral. Sheets is the left side by convention.
+    plan = reconcile(
+        left=sheets_rows,
+        right=dynamo_rows,
+        left_audit=sheets_audit_rows,
+        right_audit=dynamo_audit_rows,
+        primary="left" if primary == "sheets" else "right",
+    )
+
+    summary = {
+        "primary": primary,
+        "dry_run": args.dry_run,
+        "sheets_writes": len(plan.write_left),
+        "dynamo_writes": len(plan.write_right),
+        "sheets_audit_appends": len(plan.audit_left),
+        "dynamo_audit_appends": len(plan.audit_right),
+        "ties": list(plan.ties),
+    }
+
+    if plan.ties:
+        emit_diagnostic(
+            f"sync: {len(plan.ties)} content tie(s) on {primary} side: " f"{', '.join(plan.ties)}"
+        )
+
+    if args.dry_run:
+        emit_diagnostic(
+            f"DRY RUN: sheets ← {len(plan.write_left)} rows, "
+            f"dynamo ← {len(plan.write_right)} rows; "
+            f"audit appends sheets={len(plan.audit_left)}, "
+            f"dynamo={len(plan.audit_right)}"
+        )
+        if args.json:
+            emit_result(summary, json_mode=True)
+        return 0
+
+    if plan.write_left:
+        sheets_store.upsert_many(plan.write_left)
+    if plan.write_right:
+        dynamo_store.upsert_many(plan.write_right)
+    if plan.audit_left:
+        sheets_audit.append_many(plan.audit_left)
+    if plan.audit_right:
+        dynamo_audit.append_many(plan.audit_right)
+
+    if args.json:
+        emit_result(summary, json_mode=True)
+    else:
+        emit_result(
+            f"synced: sheets ← {len(plan.write_left)}, "
+            f"dynamo ← {len(plan.write_right)}; "
+            f"audit appends sheets={len(plan.audit_left)}, "
+            f"dynamo={len(plan.audit_right)}",
+            json_mode=False,
+        )
+    return 0
+
+
+def register(parent: argparse._SubParsersAction) -> None:
+    p = parent.add_parser(
+        "sync",
+        help="Bi-directional reconciliation between Sheets and Dynamo.",
+        description=(
+            "Reconcile assignments and audit-log rows between the Sheets "
+            "and Dynamo backends with last-write-wins per row by "
+            "`last_updated`. Run periodically to keep the spreadsheet UI "
+            "and the Dynamo runtime in agreement. Idempotent."
+        ),
+    )
+    p.add_argument(
+        "--primary",
+        required=True,
+        choices=("sheets", "dynamo"),
+        help=("Tie-breaker when last_updated matches on both sides " "but content diverged."),
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the reconciliation plan, write nothing.",
+    )
+    p.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    add_data_dir_arg(p)
+    p.set_defaults(func=cmd_sync)

--- a/office_cli/seats/__init__.py
+++ b/office_cli/seats/__init__.py
@@ -41,6 +41,7 @@ __all__ = [
     "DirectoryConfig",
     "SeatService",
     "StorageConfig",
+    "build_backends_for_type",
     "build_service",
 ]
 
@@ -124,23 +125,13 @@ def _build_backends(data_dir: Path, cfg: StorageConfig):
     )
 
 
-def build_backends_for_type(data_dir: Path, store_type: str):
+def build_backends_for_type(data_dir: Path, store_type: str) -> tuple[AssignmentStore, AuditLog]:
     """Resolve a ``StorageConfig`` for ``store_type`` and build (store, audit).
 
     Used by ``office seats migrate`` and ``office seats sync`` to spin up
-    a source / target pair driven by ``--from`` / ``--to`` flags. Reads
-    the same env / YAML config as :func:`build_service` would for that
-    type, with the type override applied last.
+    a source / target pair driven by ``--from`` / ``--to`` flags. Threads
+    the type override into :func:`resolve_storage` directly, so no
+    environment mutation is involved (safe for concurrent use).
     """
-    import os as _os  # local — avoid widening the module-level surface.
-
-    prior = _os.environ.get("OFFICE_STORE")
-    _os.environ["OFFICE_STORE"] = store_type
-    try:
-        cfg = resolve_storage(data_dir)
-    finally:
-        if prior is None:
-            _os.environ.pop("OFFICE_STORE", None)
-        else:
-            _os.environ["OFFICE_STORE"] = prior
+    cfg = resolve_storage(data_dir, type_override=store_type)
     return _build_backends(data_dir, cfg)

--- a/office_cli/seats/__init__.py
+++ b/office_cli/seats/__init__.py
@@ -94,6 +94,23 @@ def _build_backends(data_dir: Path, cfg: StorageConfig):
             CsvStore(assignments_csv(data_dir)),
             CsvAuditLog(audit_log_csv(data_dir)),
         )
+    if cfg.type == "dynamo":
+        # Lazy import — boto3 (and therefore the dynamo shim) is optional.
+        from office_cli.seats.dynamo import (
+            Boto3DynamoClient,
+            DynamoAuditLog,
+            DynamoStore,
+        )
+
+        client = Boto3DynamoClient(region=cfg.region)
+        return (
+            DynamoStore(
+                client,
+                table=cfg.table_assignments,
+                cache_ttl_seconds=cfg.cache_ttl_seconds,
+            ),
+            DynamoAuditLog(client, table=cfg.table_audit),
+        )
     # Lazy import — gspread (and therefore the sheets shim) is optional.
     from office_cli.seats.sheets import GspreadClient, SheetsAuditLog, SheetsStore
 
@@ -105,3 +122,25 @@ def _build_backends(data_dir: Path, cfg: StorageConfig):
         SheetsStore(client, cache_ttl_seconds=cfg.cache_ttl_seconds),
         SheetsAuditLog(client),
     )
+
+
+def build_backends_for_type(data_dir: Path, store_type: str):
+    """Resolve a ``StorageConfig`` for ``store_type`` and build (store, audit).
+
+    Used by ``office seats migrate`` and ``office seats sync`` to spin up
+    a source / target pair driven by ``--from`` / ``--to`` flags. Reads
+    the same env / YAML config as :func:`build_service` would for that
+    type, with the type override applied last.
+    """
+    import os as _os  # local — avoid widening the module-level surface.
+
+    prior = _os.environ.get("OFFICE_STORE")
+    _os.environ["OFFICE_STORE"] = store_type
+    try:
+        cfg = resolve_storage(data_dir)
+    finally:
+        if prior is None:
+            _os.environ.pop("OFFICE_STORE", None)
+        else:
+            _os.environ["OFFICE_STORE"] = prior
+    return _build_backends(data_dir, cfg)

--- a/office_cli/seats/_sync.py
+++ b/office_cli/seats/_sync.py
@@ -1,0 +1,122 @@
+"""Pure last-write-wins reconciliation for the bi-directional ``sync`` verb.
+
+The reconciler operates on two snapshots — a left and a right list of
+:class:`Assignment` rows + a left and a right list of :class:`AuditEntry`
+rows — and computes the writes needed on each side to bring them into
+agreement. No I/O happens here; the CLI driver applies the plan.
+
+Per-row policy is **last-write-wins** by ``last_updated`` ISO-8601
+string (lexicographic compare is correct for ISO-8601). Rare ties on
+identical ``last_updated`` but diverged content fall back to the
+``primary`` argument so the operator picks the tie-breaker.
+
+Audit entries union into both sides, deduped by
+``(seat_id, timestamp, action, employee_email)``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from office_cli.seats._models import Assignment, AuditEntry
+
+
+@dataclass(frozen=True)
+class SyncPlan:
+    """Result of comparing left and right snapshots.
+
+    ``write_left`` / ``write_right`` are the new or updated assignments
+    each side needs. ``audit_left`` / ``audit_right`` are the new audit
+    rows each side needs. ``ties`` lists seat IDs where the
+    ``last_updated`` matched but content diverged — these were resolved
+    via the ``primary`` tie-breaker, but the caller may want to log them.
+    """
+
+    write_left: list[Assignment] = field(default_factory=list)
+    write_right: list[Assignment] = field(default_factory=list)
+    audit_left: list[AuditEntry] = field(default_factory=list)
+    audit_right: list[AuditEntry] = field(default_factory=list)
+    ties: list[str] = field(default_factory=list)
+
+
+def reconcile(
+    left: Iterable[Assignment],
+    right: Iterable[Assignment],
+    *,
+    primary: str,
+    left_audit: Iterable[AuditEntry] = (),
+    right_audit: Iterable[AuditEntry] = (),
+) -> SyncPlan:
+    """Compute a :class:`SyncPlan` for two snapshots.
+
+    ``primary`` must be ``"left"`` or ``"right"`` and is the tie-breaker
+    when ``last_updated`` matches but content differs. The CLI maps
+    ``--primary sheets`` / ``--primary dynamo`` to left / right.
+    """
+    if primary not in ("left", "right"):
+        raise ValueError(f"primary must be 'left' or 'right'; got {primary!r}")
+
+    left_by_id = {a.seat_id: a for a in left}
+    right_by_id = {a.seat_id: a for a in right}
+    plan = SyncPlan()
+
+    for seat_id in left_by_id.keys() - right_by_id.keys():
+        plan.write_right.append(left_by_id[seat_id])
+    for seat_id in right_by_id.keys() - left_by_id.keys():
+        plan.write_left.append(right_by_id[seat_id])
+
+    for seat_id in left_by_id.keys() & right_by_id.keys():
+        la = left_by_id[seat_id]
+        ra = right_by_id[seat_id]
+        if _content_eq(la, ra):
+            continue  # already aligned
+        if la.last_updated > ra.last_updated:
+            plan.write_right.append(la)
+        elif ra.last_updated > la.last_updated:
+            plan.write_left.append(ra)
+        else:
+            # Same last_updated, diverged content. Pick the primary side.
+            plan.ties.append(seat_id)
+            if primary == "left":
+                plan.write_right.append(la)
+            else:
+                plan.write_left.append(ra)
+
+    plan.audit_left.extend(_audit_diff(right_audit, left_audit))
+    plan.audit_right.extend(_audit_diff(left_audit, right_audit))
+    return plan
+
+
+def _content_eq(a: Assignment, b: Assignment) -> bool:
+    """Equal on every persisted column.
+
+    ``redacted`` is a non-persisted view-time flag from Stage 7 — never
+    written, so we exclude it from the equality check (the service can
+    set it differently on snapshots fetched with different roles).
+    """
+    return (
+        a.seat_id == b.seat_id
+        and a.floor == b.floor
+        and a.employee_email == b.employee_email
+        and a.last_updated == b.last_updated
+        and a.hidden == b.hidden
+        and a.notes == b.notes
+        and a.effective_from == b.effective_from
+        and a.effective_until == b.effective_until
+    )
+
+
+def _audit_diff(src: Iterable[AuditEntry], existing: Iterable[AuditEntry]) -> list[AuditEntry]:
+    """Return entries from ``src`` whose dedup key isn't in ``existing``."""
+    seen = {_audit_key(e) for e in existing}
+    out: list[AuditEntry] = []
+    for entry in src:
+        if _audit_key(entry) not in seen:
+            out.append(entry)
+            seen.add(_audit_key(entry))
+    return out
+
+
+def _audit_key(e: AuditEntry) -> tuple[str, str, str, str]:
+    return (e.seat_id, e.timestamp, e.action, e.employee_email)

--- a/office_cli/seats/dynamo/__init__.py
+++ b/office_cli/seats/dynamo/__init__.py
@@ -1,0 +1,16 @@
+"""DynamoDB backends for :class:`AssignmentStore` and :class:`AuditLog`.
+
+Imports of this subpackage do not import ``boto3`` at module-load time;
+the ``Boto3DynamoClient`` adapter performs a lazy import only when
+constructed. That way, environments without the ``dynamo`` extra
+installed can still import :mod:`office_cli.seats` and use the default
+CSV path or the Sheets backend.
+"""
+
+from __future__ import annotations
+
+from office_cli.seats.dynamo._audit import DynamoAuditLog
+from office_cli.seats.dynamo._client import Boto3DynamoClient, DynamoClient
+from office_cli.seats.dynamo._store import DynamoStore
+
+__all__ = ["Boto3DynamoClient", "DynamoAuditLog", "DynamoClient", "DynamoStore"]

--- a/office_cli/seats/dynamo/_audit.py
+++ b/office_cli/seats/dynamo/_audit.py
@@ -3,12 +3,22 @@
 Schema:
 
 * PK = ``seat_id`` (string).
-* SK = ``timestamp`` (ISO-8601 string).
+* SK = ``event_id`` — composite key
+  ``f"{timestamp}#{action}#{employee_email}"`` so two events for the
+  same seat in the same wall-clock second don't collide.
 
-The PK + SK pair gives natural chronological ordering per seat and
-makes ``put_item`` idempotent — re-running a batch overwrites the same
-keys rather than duplicating rows. ``for_seat`` is a single
-``query_by_pk`` instead of a full scan.
+The naked ``timestamp`` is kept as a regular attribute for filtering
+and human reading; the SK is the composite ``event_id`` so DynamoDB
+sorts chronologically (the timestamp prefix dominates the lex sort)
+without losing concurrent events. PK + SK dedups identical writes,
+so ``put_item`` is still idempotent for re-runs of ``migrate`` /
+``sync`` against the same source.
+
+Why composite-SK rather than nanosecond timestamps: ``SeatService``
+generates timestamps at second precision (matches CSV / Sheets
+behavior), and bumping precision would split this rule across all
+backends. The composite SK keeps the wire shape identical across
+stores while making the Dynamo SK collision-free in normal usage.
 """
 
 from __future__ import annotations
@@ -36,31 +46,45 @@ class DynamoAuditLog:
     def all(self) -> list[AuditEntry]:
         items = self._client.scan_all(self._table)
         out = [_item_to_entry(it) for it in items if it.get("seat_id")]
-        out.sort(key=lambda e: (e.timestamp, e.seat_id))
+        out.sort(key=lambda e: (e.timestamp, e.seat_id, e.action))
         return out
 
     def for_seat(self, seat_id: str) -> list[AuditEntry]:
         items = self._client.query_by_pk(self._table, "seat_id", seat_id)
         out = [_item_to_entry(it) for it in items]
-        out.sort(key=lambda e: e.timestamp)
+        out.sort(key=lambda e: (e.timestamp, e.action))
         return out
+
+
+def _string(item: dict, key: str) -> str:
+    """Coerce a Dynamo attribute to ``str``, mapping ``None`` to empty.
+
+    DynamoDB can return ``None`` for NULL-typed values or partially-
+    migrated items. Without this normalization, ``str(None)`` would
+    produce the literal string ``"None"`` and leak into CLI output.
+    """
+    value = item.get(key, "")
+    if value is None:
+        return ""
+    return str(value)
 
 
 def _item_to_entry(item: dict) -> AuditEntry:
     return AuditEntry(
-        timestamp=str(item.get("timestamp", "")),
-        actor=str(item.get("actor", "")),
-        action=str(item.get("action", "")),
-        seat_id=str(item.get("seat_id", "")),
-        employee_email=str(item.get("employee_email", "")),
-        old_employee_email=str(item.get("old_employee_email", "")),
-        note=str(item.get("note", "")),
+        timestamp=_string(item, "timestamp"),
+        actor=_string(item, "actor"),
+        action=_string(item, "action"),
+        seat_id=_string(item, "seat_id"),
+        employee_email=_string(item, "employee_email"),
+        old_employee_email=_string(item, "old_employee_email"),
+        note=_string(item, "note"),
     )
 
 
 def _entry_to_item(e: AuditEntry) -> dict:
     return {
         "seat_id": e.seat_id,
+        "event_id": _event_id(e),
         "timestamp": e.timestamp,
         "actor": e.actor,
         "action": e.action,
@@ -68,3 +92,14 @@ def _entry_to_item(e: AuditEntry) -> dict:
         "old_employee_email": e.old_employee_email,
         "note": e.note,
     }
+
+
+def _event_id(e: AuditEntry) -> str:
+    """Compose the unique SK so collisions on second-precision timestamps
+    don't overwrite earlier audit rows.
+
+    Uses ``#`` as the separator since it sorts before any alphanumeric
+    character — the timestamp prefix still dominates the lex order, so
+    chronological queries return events in wall-clock order.
+    """
+    return f"{e.timestamp}#{e.action}#{e.employee_email}"

--- a/office_cli/seats/dynamo/_audit.py
+++ b/office_cli/seats/dynamo/_audit.py
@@ -1,0 +1,70 @@
+"""DynamoDB-backed append-only audit log.
+
+Schema:
+
+* PK = ``seat_id`` (string).
+* SK = ``timestamp`` (ISO-8601 string).
+
+The PK + SK pair gives natural chronological ordering per seat and
+makes ``put_item`` idempotent — re-running a batch overwrites the same
+keys rather than duplicating rows. ``for_seat`` is a single
+``query_by_pk`` instead of a full scan.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from office_cli.seats._models import AuditEntry
+from office_cli.seats.dynamo._client import DynamoClient
+
+
+class DynamoAuditLog:
+    def __init__(self, client: DynamoClient, *, table: str) -> None:
+        self._client = client
+        self._table = table
+
+    def append(self, entry: AuditEntry) -> None:
+        self.append_many([entry])
+
+    def append_many(self, entries: Iterable[AuditEntry]) -> None:
+        items = [_entry_to_item(e) for e in entries]
+        if not items:
+            return
+        self._client.batch_put(self._table, items)
+
+    def all(self) -> list[AuditEntry]:
+        items = self._client.scan_all(self._table)
+        out = [_item_to_entry(it) for it in items if it.get("seat_id")]
+        out.sort(key=lambda e: (e.timestamp, e.seat_id))
+        return out
+
+    def for_seat(self, seat_id: str) -> list[AuditEntry]:
+        items = self._client.query_by_pk(self._table, "seat_id", seat_id)
+        out = [_item_to_entry(it) for it in items]
+        out.sort(key=lambda e: e.timestamp)
+        return out
+
+
+def _item_to_entry(item: dict) -> AuditEntry:
+    return AuditEntry(
+        timestamp=str(item.get("timestamp", "")),
+        actor=str(item.get("actor", "")),
+        action=str(item.get("action", "")),
+        seat_id=str(item.get("seat_id", "")),
+        employee_email=str(item.get("employee_email", "")),
+        old_employee_email=str(item.get("old_employee_email", "")),
+        note=str(item.get("note", "")),
+    )
+
+
+def _entry_to_item(e: AuditEntry) -> dict:
+    return {
+        "seat_id": e.seat_id,
+        "timestamp": e.timestamp,
+        "actor": e.actor,
+        "action": e.action,
+        "employee_email": e.employee_email,
+        "old_employee_email": e.old_employee_email,
+        "note": e.note,
+    }

--- a/office_cli/seats/dynamo/_client.py
+++ b/office_cli/seats/dynamo/_client.py
@@ -1,0 +1,92 @@
+"""Thin shim over the AWS DynamoDB API.
+
+The :class:`DynamoClient` Protocol exposes only the four operations the
+store and audit log need (``scan_all`` / ``put_item`` / ``batch_put`` /
+``query_by_pk``). The store is unit-tested against a ``FakeDynamoClient``
+so the test suite never needs real AWS credentials.
+:class:`Boto3DynamoClient` is the production implementation — import is
+deferred to construction so the parent package can be imported without
+the ``[dynamo]`` extra installed.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
+
+
+class DynamoClient(Protocol):
+    def scan_all(self, table: str) -> list[dict]:
+        """Return every item in ``table`` as a list of attribute dicts."""
+
+    def put_item(self, table: str, item: dict) -> None:
+        """Insert or replace a single ``item`` keyed by its PK (+ SK)."""
+
+    def batch_put(self, table: str, items: list[dict]) -> None:
+        """Best-effort batched put for ``items``. Idempotent by primary key."""
+
+    def query_by_pk(self, table: str, pk_name: str, pk_value: str) -> list[dict]:
+        """Return items matching a partition-key equality, ordered by sort key."""
+
+
+class Boto3DynamoClient:
+    """Production :class:`DynamoClient` backed by ``boto3.resource("dynamodb")``."""
+
+    def __init__(self, region: str) -> None:
+        try:
+            import boto3  # noqa: F401 — runtime check
+        except ImportError as err:
+            raise OfficeError(
+                code=EXIT_ENV_ERROR,
+                message="boto3 is not installed",
+                remediation="install the dynamo extra: pip install office-cli[dynamo]",
+            ) from err
+        self._region = region
+        self._resource = None
+
+    def _ddb(self):
+        if self._resource is None:
+            import boto3
+
+            self._resource = boto3.resource("dynamodb", region_name=self._region)
+        return self._resource
+
+    def scan_all(self, table: str) -> list[dict]:
+        tbl = self._ddb().Table(table)
+        items: list[dict] = []
+        kwargs: dict = {}
+        while True:
+            resp = tbl.scan(**kwargs)
+            items.extend(resp.get("Items", []))
+            last = resp.get("LastEvaluatedKey")
+            if not last:
+                break
+            kwargs["ExclusiveStartKey"] = last
+        return items
+
+    def put_item(self, table: str, item: dict) -> None:
+        self._ddb().Table(table).put_item(Item=item)
+
+    def batch_put(self, table: str, items: list[dict]) -> None:
+        if not items:
+            return
+        tbl = self._ddb().Table(table)
+        with tbl.batch_writer() as bw:
+            for item in items:
+                bw.put_item(Item=item)
+
+    def query_by_pk(self, table: str, pk_name: str, pk_value: str) -> list[dict]:
+        from boto3.dynamodb.conditions import Key
+
+        tbl = self._ddb().Table(table)
+        items: list[dict] = []
+        kwargs: dict = {"KeyConditionExpression": Key(pk_name).eq(pk_value)}
+        while True:
+            resp = tbl.query(**kwargs)
+            items.extend(resp.get("Items", []))
+            last = resp.get("LastEvaluatedKey")
+            if not last:
+                break
+            kwargs["ExclusiveStartKey"] = last
+        return items

--- a/office_cli/seats/dynamo/_store.py
+++ b/office_cli/seats/dynamo/_store.py
@@ -1,0 +1,110 @@
+"""DynamoDB-backed :class:`AssignmentStore`.
+
+Item shape mirrors :mod:`office_cli.seats._csv_store` columns:
+
+* PK ``seat_id`` (string).
+* String attrs: ``floor``, ``employee_email``, ``last_updated``,
+  ``notes``, ``effective_from``, ``effective_until``.
+* Boolean attr: ``hidden``.
+
+The 5-minute TTL cache mirrors :class:`SheetsStore` so the read path
+behavior is identical: one ``scan`` populates the cache, ``by_email``
+filters in memory. A GSI on ``employee_email`` is documented as a
+Stage-9 hardening; for v1's hundreds-of-seats scale the cache + scan
+is fine and keeps the Protocol behavior aligned across backends.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Iterable
+
+from office_cli.seats._models import Assignment
+from office_cli.seats.dynamo._client import DynamoClient
+
+_DEFAULT_TTL_SECONDS = 300
+
+
+class DynamoStore:
+    def __init__(
+        self,
+        client: DynamoClient,
+        *,
+        table: str,
+        cache_ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+        clock: "callable[[], float] | None" = None,  # type: ignore[name-defined]
+    ) -> None:
+        self._client = client
+        self._table = table
+        self._ttl = cache_ttl_seconds
+        self._clock = clock or time.monotonic
+        self._cache: list[Assignment] | None = None
+        self._cache_at: float = 0.0
+
+    # -- AssignmentStore -------------------------------------------------
+
+    def list(self) -> list[Assignment]:
+        if self._cache is not None and (self._clock() - self._cache_at) < self._ttl:
+            return list(self._cache)
+        items = self._client.scan_all(self._table)
+        self._cache = [_item_to_assignment(it) for it in items if it.get("seat_id")]
+        self._cache.sort(key=lambda a: (a.floor, a.seat_id))
+        self._cache_at = self._clock()
+        return list(self._cache)
+
+    def get(self, seat_id: str) -> Assignment | None:
+        for a in self.list():
+            if a.seat_id == seat_id:
+                return a
+        return None
+
+    def by_email(self, email: str) -> Assignment | None:
+        if not email:
+            return None
+        for a in self.list():
+            if a.employee_email == email:
+                return a
+        return None
+
+    def upsert(self, assignment: Assignment) -> None:
+        self._client.put_item(self._table, _assignment_to_item(assignment))
+        self.invalidate()
+
+    def upsert_many(self, assignments: Iterable[Assignment]) -> None:
+        items = [_assignment_to_item(a) for a in assignments]
+        if not items:
+            return
+        self._client.batch_put(self._table, items)
+        self.invalidate()
+
+    # -- Helpers ---------------------------------------------------------
+
+    def invalidate(self) -> None:
+        self._cache = None
+        self._cache_at = 0.0
+
+
+def _item_to_assignment(item: dict) -> Assignment:
+    return Assignment(
+        seat_id=str(item.get("seat_id", "")),
+        floor=str(item.get("floor", "")),
+        employee_email=str(item.get("employee_email", "")),
+        last_updated=str(item.get("last_updated", "")),
+        hidden=bool(item.get("hidden", False)),
+        notes=str(item.get("notes", "")),
+        effective_from=str(item.get("effective_from", "")),
+        effective_until=str(item.get("effective_until", "")),
+    )
+
+
+def _assignment_to_item(a: Assignment) -> dict:
+    return {
+        "seat_id": a.seat_id,
+        "floor": a.floor,
+        "employee_email": a.employee_email,
+        "last_updated": a.last_updated,
+        "hidden": bool(a.hidden),
+        "notes": a.notes,
+        "effective_from": a.effective_from,
+        "effective_until": a.effective_until,
+    }

--- a/office_cli/seats/dynamo/_store.py
+++ b/office_cli/seats/dynamo/_store.py
@@ -84,16 +84,29 @@ class DynamoStore:
         self._cache_at = 0.0
 
 
+def _string(item: dict, key: str) -> str:
+    """Coerce a Dynamo attribute to ``str``, mapping ``None`` to empty.
+
+    DynamoDB can return ``None`` for NULL-typed values or partially-
+    migrated items. Without this normalization, ``str(None)`` would
+    produce the literal ``"None"`` and leak into CLI output.
+    """
+    value = item.get(key, "")
+    if value is None:
+        return ""
+    return str(value)
+
+
 def _item_to_assignment(item: dict) -> Assignment:
     return Assignment(
-        seat_id=str(item.get("seat_id", "")),
-        floor=str(item.get("floor", "")),
-        employee_email=str(item.get("employee_email", "")),
-        last_updated=str(item.get("last_updated", "")),
-        hidden=bool(item.get("hidden", False)),
-        notes=str(item.get("notes", "")),
-        effective_from=str(item.get("effective_from", "")),
-        effective_until=str(item.get("effective_until", "")),
+        seat_id=_string(item, "seat_id"),
+        floor=_string(item, "floor"),
+        employee_email=_string(item, "employee_email"),
+        last_updated=_string(item, "last_updated"),
+        hidden=bool(item.get("hidden") or False),
+        notes=_string(item, "notes"),
+        effective_from=_string(item, "effective_from"),
+        effective_until=_string(item, "effective_until"),
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.7.0"
+version = "0.8.0"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"
@@ -30,6 +30,7 @@ sso = [
     "itsdangerous>=2.1",
     "httpx>=0.27",
 ]
+dynamo = ["boto3>=1.34"]
 
 [project.urls]
 Homepage = "https://github.com/agentculture/office-agent"
@@ -63,6 +64,10 @@ dev = [
     # against a stub OIDC config; we never hit a real IdP.
     "authlib>=1.3",
     "itsdangerous>=2.1",
+    # Stage 8 — DynamoDB. CI exercises the dynamo store via the
+    # in-memory FakeDynamoClient; we still pull boto3 so the
+    # production import path is sanity-checked at install time.
+    "boto3>=1.34",
 ]
 
 [tool.coverage.run]

--- a/tests/test_cli_migrate.py
+++ b/tests/test_cli_migrate.py
@@ -1,0 +1,126 @@
+"""End-to-end tests for ``office seats migrate``.
+
+Drives migrations between the CSV backend (the default) and the
+DynamoDB backend via :class:`FakeDynamoClient`. The fake client is
+swapped in by patching ``Boto3DynamoClient`` at the call site so no
+real AWS creds are needed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli import main
+from tests.test_dynamo_store import FakeDynamoClient
+
+
+@pytest.fixture
+def dynamo_data_dir(data_dir: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Configure a Dynamo target via env, swap in the in-memory fake client."""
+    monkeypatch.setenv("OFFICE_DYNAMO_ASSIGNMENTS", "office-assignments")
+    monkeypatch.setenv("OFFICE_DYNAMO_AUDIT", "office-audit-log")
+    monkeypatch.setenv("OFFICE_DYNAMO_REGION", "us-east-1")
+
+    fake = FakeDynamoClient()
+
+    def _fake_factory(*args, **kwargs):  # noqa: ANN001
+        return fake
+
+    # The migrate code does ``from office_cli.seats.dynamo import
+    # Boto3DynamoClient``; patch the re-export site so the lazy import
+    # picks up the fake.
+    monkeypatch.setattr(
+        "office_cli.seats.dynamo.Boto3DynamoClient",
+        _fake_factory,
+    )
+    return data_dir
+
+
+def _data(data_dir: Path) -> list[str]:
+    return ["--data-dir", str(data_dir)]
+
+
+def test_csv_to_dynamo_round_trip(
+    dynamo_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue #12 acceptance — CSV → Dynamo migration preserves rows + audit."""
+    # Seed the CSV side with two assignments.
+    main(["seats", "assign", "5-T-01", "alice@example.com", *_data(dynamo_data_dir)])
+    main(["seats", "assign", "5-T-02", "bob@example.com", *_data(dynamo_data_dir)])
+    capsys.readouterr()
+
+    rc = main(
+        ["seats", "migrate", "--from", "csv", "--to", "dynamo", "--json", *_data(dynamo_data_dir)]
+    )
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["assignments_written"] == 2
+
+    # Now read via dynamo and confirm parity.
+    import os
+
+    os.environ["OFFICE_STORE"] = "dynamo"
+    try:
+        rc = main(["seats", "list", "--json", "--occupied", *_data(dynamo_data_dir)])
+        assert rc == 0
+        body = json.loads(capsys.readouterr().out)
+        emails = sorted(s["employee_email"] for s in body["seats"])
+        assert emails == ["alice@example.com", "bob@example.com"]
+    finally:
+        os.environ.pop("OFFICE_STORE", None)
+
+
+def test_dry_run_writes_nothing(dynamo_data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    main(["seats", "assign", "5-T-01", "alice@example.com", *_data(dynamo_data_dir)])
+    capsys.readouterr()
+
+    rc = main(
+        [
+            "seats",
+            "migrate",
+            "--from",
+            "csv",
+            "--to",
+            "dynamo",
+            "--dry-run",
+            "--json",
+            *_data(dynamo_data_dir),
+        ]
+    )
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["dry_run"] is True
+    assert summary["assignments_new"] == 1
+
+
+def test_idempotent_rerun(dynamo_data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Re-running migrate is safe: assignments upsert, audit dedups (Dynamo PK+SK)."""
+    main(["seats", "assign", "5-T-01", "alice@example.com", *_data(dynamo_data_dir)])
+    capsys.readouterr()
+
+    main(["seats", "migrate", "--from", "csv", "--to", "dynamo", *_data(dynamo_data_dir)])
+    main(["seats", "migrate", "--from", "csv", "--to", "dynamo", *_data(dynamo_data_dir)])
+    capsys.readouterr()
+
+    import os
+
+    os.environ["OFFICE_STORE"] = "dynamo"
+    try:
+        rc = main(["seats", "history", "5-T-01", "--json", *_data(dynamo_data_dir)])
+        assert rc == 0
+        body = json.loads(capsys.readouterr().out)
+        # One assign action, deduped after the second migrate.
+        assert [e["action"] for e in body["history"]] == ["assign"]
+    finally:
+        os.environ.pop("OFFICE_STORE", None)
+
+
+def test_same_source_and_target_rejected(
+    dynamo_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    rc = main(["seats", "migrate", "--from", "csv", "--to", "csv", *_data(dynamo_data_dir)])
+    assert rc == 1
+    assert "both" in capsys.readouterr().err

--- a/tests/test_cli_migrate.py
+++ b/tests/test_cli_migrate.py
@@ -44,7 +44,9 @@ def _data(data_dir: Path) -> list[str]:
 
 
 def test_csv_to_dynamo_round_trip(
-    dynamo_data_dir: Path, capsys: pytest.CaptureFixture[str]
+    dynamo_data_dir: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Issue #12 acceptance — CSV → Dynamo migration preserves rows + audit."""
     # Seed the CSV side with two assignments.
@@ -59,18 +61,14 @@ def test_csv_to_dynamo_round_trip(
     summary = json.loads(capsys.readouterr().out)
     assert summary["assignments_written"] == 2
 
-    # Now read via dynamo and confirm parity.
-    import os
-
-    os.environ["OFFICE_STORE"] = "dynamo"
-    try:
-        rc = main(["seats", "list", "--json", "--occupied", *_data(dynamo_data_dir)])
-        assert rc == 0
-        body = json.loads(capsys.readouterr().out)
-        emails = sorted(s["employee_email"] for s in body["seats"])
-        assert emails == ["alice@example.com", "bob@example.com"]
-    finally:
-        os.environ.pop("OFFICE_STORE", None)
+    # Now read via dynamo and confirm parity. Use monkeypatch so a
+    # pre-existing OFFICE_STORE in the developer's shell is preserved.
+    monkeypatch.setenv("OFFICE_STORE", "dynamo")
+    rc = main(["seats", "list", "--json", "--occupied", *_data(dynamo_data_dir)])
+    assert rc == 0
+    body = json.loads(capsys.readouterr().out)
+    emails = sorted(s["employee_email"] for s in body["seats"])
+    assert emails == ["alice@example.com", "bob@example.com"]
 
 
 def test_dry_run_writes_nothing(dynamo_data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -96,7 +94,11 @@ def test_dry_run_writes_nothing(dynamo_data_dir: Path, capsys: pytest.CaptureFix
     assert summary["assignments_new"] == 1
 
 
-def test_idempotent_rerun(dynamo_data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_idempotent_rerun(
+    dynamo_data_dir: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Re-running migrate is safe: assignments upsert, audit dedups (Dynamo PK+SK)."""
     main(["seats", "assign", "5-T-01", "alice@example.com", *_data(dynamo_data_dir)])
     capsys.readouterr()
@@ -105,17 +107,12 @@ def test_idempotent_rerun(dynamo_data_dir: Path, capsys: pytest.CaptureFixture[s
     main(["seats", "migrate", "--from", "csv", "--to", "dynamo", *_data(dynamo_data_dir)])
     capsys.readouterr()
 
-    import os
-
-    os.environ["OFFICE_STORE"] = "dynamo"
-    try:
-        rc = main(["seats", "history", "5-T-01", "--json", *_data(dynamo_data_dir)])
-        assert rc == 0
-        body = json.loads(capsys.readouterr().out)
-        # One assign action, deduped after the second migrate.
-        assert [e["action"] for e in body["history"]] == ["assign"]
-    finally:
-        os.environ.pop("OFFICE_STORE", None)
+    monkeypatch.setenv("OFFICE_STORE", "dynamo")
+    rc = main(["seats", "history", "5-T-01", "--json", *_data(dynamo_data_dir)])
+    assert rc == 0
+    body = json.loads(capsys.readouterr().out)
+    # One assign action, deduped after the second migrate.
+    assert [e["action"] for e in body["history"]] == ["assign"]
 
 
 def test_same_source_and_target_rejected(

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -1,0 +1,148 @@
+"""End-to-end tests for ``office seats sync``.
+
+Drives the bi-directional reconciliation between Sheets and Dynamo
+via in-memory fakes (no real AWS / Google creds).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli import main
+from tests.test_dynamo_store import FakeDynamoClient
+from tests.test_sheets_store import FakeSheetsClient
+
+
+@pytest.fixture
+def sync_env(data_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    """Configure both backends to use in-memory fakes via env + monkeypatch.
+
+    Returns a tuple ``(data_dir, fake_dynamo, fake_sheets)`` so tests
+    can inspect or seed each side directly.
+    """
+    sa_path = data_dir / "fake-sa.json"
+    sa_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("OFFICE_SHEETS_ID", "fake-spreadsheet-id")
+    monkeypatch.setenv("OFFICE_SHEETS_SA", str(sa_path))
+
+    monkeypatch.setenv("OFFICE_DYNAMO_ASSIGNMENTS", "office-assignments")
+    monkeypatch.setenv("OFFICE_DYNAMO_AUDIT", "office-audit-log")
+    monkeypatch.setenv("OFFICE_DYNAMO_REGION", "us-east-1")
+
+    fake_dynamo = FakeDynamoClient()
+    fake_sheets = FakeSheetsClient()
+
+    monkeypatch.setattr(
+        "office_cli.seats.dynamo.Boto3DynamoClient",
+        lambda *a, **kw: fake_dynamo,
+    )
+    monkeypatch.setattr(
+        "office_cli.seats.sheets.GspreadClient",
+        lambda *a, **kw: fake_sheets,
+    )
+    return data_dir, fake_dynamo, fake_sheets
+
+
+def _data(data_dir: Path) -> list[str]:
+    return ["--data-dir", str(data_dir)]
+
+
+def _seed_sheets(data_dir: Path) -> None:
+    """Seed an assignment via the CLI pointing at the sheets backend."""
+    import os
+
+    prior = os.environ.get("OFFICE_STORE")
+    os.environ["OFFICE_STORE"] = "sheets"
+    try:
+        main(["seats", "assign", "5-T-01", "alice@example.com", *_data(data_dir)])
+    finally:
+        if prior is None:
+            os.environ.pop("OFFICE_STORE", None)
+        else:
+            os.environ["OFFICE_STORE"] = prior
+
+
+def test_sync_pulls_from_sheets_to_dynamo(sync_env, capsys: pytest.CaptureFixture[str]) -> None:
+    data_dir, _fake_dynamo, _fake_sheets = sync_env
+    _seed_sheets(data_dir)
+    capsys.readouterr()
+
+    rc = main(["seats", "sync", "--primary", "sheets", "--json", *_data(data_dir)])
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["dynamo_writes"] == 1
+    assert summary["sheets_writes"] == 0
+
+
+def test_sync_dry_run_writes_nothing(sync_env, capsys: pytest.CaptureFixture[str]) -> None:
+    data_dir, fake_dynamo, _fake_sheets = sync_env
+    _seed_sheets(data_dir)
+    capsys.readouterr()
+
+    rc = main(
+        [
+            "seats",
+            "sync",
+            "--primary",
+            "sheets",
+            "--dry-run",
+            "--json",
+            *_data(data_dir),
+        ]
+    )
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["dry_run"] is True
+    assert summary["dynamo_writes"] == 1
+    assert fake_dynamo.scan_all("office-assignments") == []
+
+
+def test_sync_is_idempotent(sync_env, capsys: pytest.CaptureFixture[str]) -> None:
+    data_dir, _fake_dynamo, _fake_sheets = sync_env
+    _seed_sheets(data_dir)
+    capsys.readouterr()
+
+    main(["seats", "sync", "--primary", "sheets", *_data(data_dir)])
+    capsys.readouterr()
+    rc = main(["seats", "sync", "--primary", "sheets", "--json", *_data(data_dir)])
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["dynamo_writes"] == 0
+    assert summary["sheets_writes"] == 0
+
+
+def test_sync_pushes_dynamo_to_sheets_via_primary(
+    sync_env, capsys: pytest.CaptureFixture[str]
+) -> None:
+    data_dir, fake_dynamo, _fake_sheets = sync_env
+    fake_dynamo.put_item(
+        "office-assignments",
+        {
+            "seat_id": "5-T-02",
+            "floor": "tlv-floor-5",
+            "employee_email": "bob@example.com",
+            "last_updated": "2026-05-01T00:00:01Z",
+            "hidden": False,
+            "notes": "",
+            "effective_from": "2026-05-01",
+            "effective_until": "",
+        },
+    )
+
+    rc = main(["seats", "sync", "--primary", "dynamo", "--json", *_data(data_dir)])
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["sheets_writes"] == 1
+
+
+def test_invalid_primary_rejected(sync_env, capsys: pytest.CaptureFixture[str]) -> None:
+    data_dir, *_ = sync_env
+    with pytest.raises(SystemExit) as exc:
+        main(["seats", "sync", "--primary", "csv", *_data(data_dir)])
+    # The CLI's _ArgumentParser override emits OfficeError + EXIT_USER_ERROR (1).
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "invalid choice" in err

--- a/tests/test_dynamo_audit.py
+++ b/tests/test_dynamo_audit.py
@@ -59,6 +59,38 @@ def test_for_seat_returns_chronological() -> None:
     assert all(r.seat_id == "5-T-01" for r in rows)
 
 
+def test_same_second_events_do_not_collide() -> None:
+    """Qodo Q2 / Copilot C1 — events at the same wall-clock second
+    must not overwrite each other.
+
+    SeatService writes timestamps at second precision; a rapid
+    assign → unassign within the same second must keep both rows.
+    The composite SK ``timestamp#action#employee_email`` ensures
+    DynamoDB's PK+SK dedup happens only on truly identical events.
+    """
+    _, log = _audit()
+    log.append_many(
+        [
+            AuditEntry(
+                timestamp="2026-05-01T00:00:01Z",
+                seat_id="5-T-01",
+                action="assign",
+                actor="cli",
+                employee_email="alice@example.com",
+            ),
+            AuditEntry(
+                timestamp="2026-05-01T00:00:01Z",
+                seat_id="5-T-01",
+                action="unassign",
+                actor="cli",
+                old_employee_email="alice@example.com",
+            ),
+        ]
+    )
+    rows = log.for_seat("5-T-01")
+    assert [r.action for r in rows] == ["assign", "unassign"]
+
+
 def test_idempotent_put_dedups() -> None:
     """Re-running the same batch doesn't duplicate rows — PK+SK key dedups."""
     _, log = _audit()

--- a/tests/test_dynamo_audit.py
+++ b/tests/test_dynamo_audit.py
@@ -1,0 +1,104 @@
+"""Tests for the DynamoDB-backed AuditLog."""
+
+from __future__ import annotations
+
+from office_cli.seats import AuditEntry
+from office_cli.seats.dynamo import DynamoAuditLog
+from tests.test_dynamo_store import FakeDynamoClient
+
+
+def _audit() -> tuple[FakeDynamoClient, DynamoAuditLog]:
+    client = FakeDynamoClient()
+    return client, DynamoAuditLog(client, table="office-audit-log")
+
+
+def test_append_and_all_round_trip() -> None:
+    _, log = _audit()
+    log.append(
+        AuditEntry(
+            timestamp="2026-05-01T00:00:01Z",
+            actor="cli",
+            action="assign",
+            seat_id="5-T-01",
+            employee_email="alice@example.com",
+        )
+    )
+    rows = log.all()
+    assert len(rows) == 1
+    assert rows[0].seat_id == "5-T-01"
+    assert rows[0].action == "assign"
+
+
+def test_for_seat_returns_chronological() -> None:
+    _, log = _audit()
+    log.append_many(
+        [
+            AuditEntry(
+                timestamp="2026-05-02T00:00:00Z",
+                actor="cli",
+                action="unassign",
+                seat_id="5-T-01",
+            ),
+            AuditEntry(
+                timestamp="2026-05-01T00:00:00Z",
+                actor="cli",
+                action="assign",
+                seat_id="5-T-01",
+            ),
+            AuditEntry(
+                timestamp="2026-05-01T00:00:00Z",
+                actor="cli",
+                action="assign",
+                seat_id="5-T-02",
+            ),
+        ]
+    )
+    rows = log.for_seat("5-T-01")
+    assert [r.action for r in rows] == ["assign", "unassign"]
+    # Other seat's entries are not returned.
+    assert all(r.seat_id == "5-T-01" for r in rows)
+
+
+def test_idempotent_put_dedups() -> None:
+    """Re-running the same batch doesn't duplicate rows — PK+SK key dedups."""
+    _, log = _audit()
+    entries = [
+        AuditEntry(
+            timestamp="2026-05-01T00:00:01Z",
+            actor="cli",
+            action="assign",
+            seat_id="5-T-01",
+        ),
+        AuditEntry(
+            timestamp="2026-05-01T00:00:02Z",
+            actor="cli",
+            action="unassign",
+            seat_id="5-T-01",
+        ),
+    ]
+    log.append_many(entries)
+    log.append_many(entries)  # re-run
+    rows = log.for_seat("5-T-01")
+    assert len(rows) == 2  # no duplicates
+
+
+def test_all_returns_all_seats_chronological() -> None:
+    _, log = _audit()
+    log.append_many(
+        [
+            AuditEntry(
+                timestamp="2026-05-02T00:00:00Z",
+                seat_id="5-T-02",
+                action="assign",
+                actor="cli",
+            ),
+            AuditEntry(
+                timestamp="2026-05-01T00:00:00Z",
+                seat_id="5-T-01",
+                action="assign",
+                actor="cli",
+            ),
+        ]
+    )
+    rows = log.all()
+    assert [r.seat_id for r in rows] == ["5-T-01", "5-T-02"]

--- a/tests/test_dynamo_storage_config.py
+++ b/tests/test_dynamo_storage_config.py
@@ -1,0 +1,108 @@
+"""Tests for the DynamoDB branch of ``resolve_storage``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from office_cli._config import resolve_storage
+from office_cli.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, OfficeError
+
+
+def _write(data_dir: Path, body: str) -> None:
+    (data_dir / "data").mkdir(parents=True, exist_ok=True)
+    (data_dir / "data" / "offices.yaml").write_text(body, encoding="utf-8")
+
+
+def test_resolve_dynamo_from_yaml(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        """
+storage:
+  type: dynamo
+  dynamo:
+    table_assignments: office-assignments
+    table_audit: office-audit-log
+    region: us-east-1
+""",
+    )
+    cfg = resolve_storage(tmp_path)
+    assert cfg.type == "dynamo"
+    assert cfg.table_assignments == "office-assignments"
+    assert cfg.table_audit == "office-audit-log"
+    assert cfg.region == "us-east-1"
+
+
+def test_resolve_dynamo_env_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write(
+        tmp_path,
+        """
+storage:
+  type: dynamo
+  dynamo:
+    table_assignments: office-assignments
+    table_audit: office-audit-log
+    region: us-east-1
+""",
+    )
+    monkeypatch.setenv("OFFICE_DYNAMO_REGION", "eu-west-1")
+    monkeypatch.setenv("OFFICE_DYNAMO_ASSIGNMENTS", "alt-assignments")
+    cfg = resolve_storage(tmp_path)
+    assert cfg.region == "eu-west-1"
+    assert cfg.table_assignments == "alt-assignments"
+    # Non-overridden fields keep YAML values.
+    assert cfg.table_audit == "office-audit-log"
+
+
+def test_dynamo_missing_table_assignments_errors(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        """
+storage:
+  type: dynamo
+  dynamo:
+    table_audit: office-audit-log
+    region: us-east-1
+""",
+    )
+    with pytest.raises(OfficeError) as exc:
+        resolve_storage(tmp_path)
+    assert exc.value.code == EXIT_ENV_ERROR
+    assert "table_assignments" in exc.value.message
+
+
+def test_dynamo_missing_region_errors(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        """
+storage:
+  type: dynamo
+  dynamo:
+    table_assignments: office-assignments
+    table_audit: office-audit-log
+""",
+    )
+    with pytest.raises(OfficeError) as exc:
+        resolve_storage(tmp_path)
+    assert exc.value.code == EXIT_ENV_ERROR
+    assert "region" in exc.value.message
+
+
+def test_dynamo_block_must_be_mapping(tmp_path: Path) -> None:
+    _write(tmp_path, "storage:\n  type: dynamo\n  dynamo: nope\n")
+    with pytest.raises(OfficeError) as exc:
+        resolve_storage(tmp_path)
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "mapping" in exc.value.message
+
+
+def test_dynamo_via_env_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No YAML — env-only configuration is sufficient."""
+    monkeypatch.setenv("OFFICE_STORE", "dynamo")
+    monkeypatch.setenv("OFFICE_DYNAMO_ASSIGNMENTS", "office-assignments")
+    monkeypatch.setenv("OFFICE_DYNAMO_AUDIT", "office-audit-log")
+    monkeypatch.setenv("OFFICE_DYNAMO_REGION", "us-east-1")
+    cfg = resolve_storage(tmp_path)
+    assert cfg.type == "dynamo"
+    assert cfg.region == "us-east-1"

--- a/tests/test_dynamo_store.py
+++ b/tests/test_dynamo_store.py
@@ -23,10 +23,12 @@ class FakeDynamoClient:
     def _key(self, table: str, item: dict) -> tuple[str, str]:
         # Always return a (pk, sk) pair. Assignments use SK="" since
         # they're keyed on seat_id alone; audit tables key on
-        # (seat_id, timestamp). Keeping the shape uniform avoids the
-        # variable-length tuple Sonar S8495 flags.
+        # (seat_id, event_id) where event_id is the composite SK that
+        # guarantees collision-free writes even for same-second events.
+        # Keeping the shape uniform avoids the variable-length tuple
+        # Sonar S8495 flags.
         is_audit = "audit" in table
-        sk = item.get("timestamp", "") if is_audit else ""
+        sk = item.get("event_id", "") if is_audit else ""
         return (item.get("seat_id", ""), sk)
 
     def scan_all(self, table: str) -> list[dict]:

--- a/tests/test_dynamo_store.py
+++ b/tests/test_dynamo_store.py
@@ -20,15 +20,14 @@ class FakeDynamoClient:
         self.tables: dict[str, dict[tuple, dict]] = {}
         self.scan_calls = 0
 
-    # Helper — figure out the primary key columns for a table.
-    def _key_cols(self, table: str) -> tuple[str, ...]:
-        # Assignments: PK seat_id only. Audit: PK seat_id + SK timestamp.
-        if table.endswith("-audit") or table.endswith("audit-log") or "audit" in table:
-            return ("seat_id", "timestamp")
-        return ("seat_id",)
-
-    def _key(self, table: str, item: dict) -> tuple:
-        return tuple(item.get(c, "") for c in self._key_cols(table))
+    def _key(self, table: str, item: dict) -> tuple[str, str]:
+        # Always return a (pk, sk) pair. Assignments use SK="" since
+        # they're keyed on seat_id alone; audit tables key on
+        # (seat_id, timestamp). Keeping the shape uniform avoids the
+        # variable-length tuple Sonar S8495 flags.
+        is_audit = "audit" in table
+        sk = item.get("timestamp", "") if is_audit else ""
+        return (item.get("seat_id", ""), sk)
 
     def scan_all(self, table: str) -> list[dict]:
         self.scan_calls += 1

--- a/tests/test_dynamo_store.py
+++ b/tests/test_dynamo_store.py
@@ -1,0 +1,148 @@
+"""Tests for the DynamoDB-backed AssignmentStore.
+
+A ``FakeDynamoClient`` plays the role of boto3; no real AWS creds are
+needed. Cache-TTL behavior is exercised with an injected clock,
+mirroring the Sheets test pattern.
+"""
+
+from __future__ import annotations
+
+from itertools import count
+
+from office_cli.seats import Assignment
+from office_cli.seats.dynamo import DynamoStore
+
+
+class FakeDynamoClient:
+    """Minimal in-memory DynamoDB shim for store / audit tests."""
+
+    def __init__(self) -> None:
+        self.tables: dict[str, dict[tuple, dict]] = {}
+        self.scan_calls = 0
+
+    # Helper — figure out the primary key columns for a table.
+    def _key_cols(self, table: str) -> tuple[str, ...]:
+        # Assignments: PK seat_id only. Audit: PK seat_id + SK timestamp.
+        if table.endswith("-audit") or table.endswith("audit-log") or "audit" in table:
+            return ("seat_id", "timestamp")
+        return ("seat_id",)
+
+    def _key(self, table: str, item: dict) -> tuple:
+        return tuple(item.get(c, "") for c in self._key_cols(table))
+
+    def scan_all(self, table: str) -> list[dict]:
+        self.scan_calls += 1
+        return [dict(v) for v in self.tables.get(table, {}).values()]
+
+    def put_item(self, table: str, item: dict) -> None:
+        self.tables.setdefault(table, {})[self._key(table, item)] = dict(item)
+
+    def batch_put(self, table: str, items: list[dict]) -> None:
+        for item in items:
+            self.put_item(table, item)
+
+    def query_by_pk(self, table: str, pk_name: str, pk_value: str) -> list[dict]:
+        return [dict(v) for v in self.tables.get(table, {}).values() if v.get(pk_name) == pk_value]
+
+
+def _store(client: FakeDynamoClient | None = None, ttl: int = 0) -> DynamoStore:
+    return DynamoStore(
+        client or FakeDynamoClient(), table="office-assignments", cache_ttl_seconds=ttl
+    )
+
+
+def test_round_trip() -> None:
+    client = FakeDynamoClient()
+    store = DynamoStore(client, table="office-assignments", cache_ttl_seconds=0)
+    a = Assignment(
+        seat_id="5-T-01",
+        floor="tlv-floor-5",
+        employee_email="alice@example.com",
+        last_updated="2026-05-01T00:00:01Z",
+        hidden=True,
+        notes="ergonomic",
+    )
+    store.upsert(a)
+    rows = store.list()
+    assert len(rows) == 1
+    assert rows[0].seat_id == "5-T-01"
+    assert rows[0].employee_email == "alice@example.com"
+    assert rows[0].hidden is True
+
+
+def test_upsert_replaces_existing() -> None:
+    client = FakeDynamoClient()
+    store = DynamoStore(client, table="office-assignments", cache_ttl_seconds=0)
+    store.upsert(Assignment(seat_id="5-T-01", floor="tlv-floor-5", employee_email="a@x"))
+    store.upsert(Assignment(seat_id="5-T-01", floor="tlv-floor-5", employee_email="b@x"))
+    rows = store.list()
+    assert len(rows) == 1
+    assert rows[0].employee_email == "b@x"
+
+
+def test_by_email_filter() -> None:
+    client = FakeDynamoClient()
+    store = DynamoStore(client, table="office-assignments", cache_ttl_seconds=0)
+    store.upsert_many(
+        [
+            Assignment(seat_id="5-T-01", floor="tlv-floor-5", employee_email="a@x"),
+            Assignment(seat_id="5-T-02", floor="tlv-floor-5", employee_email="b@x"),
+        ]
+    )
+    found = store.by_email("b@x")
+    assert found is not None
+    assert found.seat_id == "5-T-02"
+    assert store.by_email("ghost@x") is None
+    assert store.by_email("") is None
+
+
+def test_cache_ttl_honored() -> None:
+    counter = count(0, 1)
+
+    def clock() -> float:
+        return float(next(counter))
+
+    client = FakeDynamoClient()
+    store = DynamoStore(
+        client,
+        table="office-assignments",
+        cache_ttl_seconds=10,
+        clock=clock,
+    )
+    store.upsert(Assignment(seat_id="5-T-01", floor="tlv-floor-5", employee_email="a@x"))
+    base_calls = client.scan_calls
+    # First list — populates cache (write invalidated above).
+    store.list()
+    after_first = client.scan_calls
+    # Second list within the TTL — must not hit the underlying client again.
+    store.list()
+    assert client.scan_calls == after_first
+    # The first list went to the wire; subsequent reads stayed cached.
+    assert after_first == base_calls + 1
+
+
+def test_upsert_invalidates_cache() -> None:
+    client = FakeDynamoClient()
+    store = DynamoStore(client, table="office-assignments", cache_ttl_seconds=999)
+    store.upsert(Assignment(seat_id="5-T-01", floor="tlv-floor-5", employee_email="a@x"))
+    store.list()  # populate cache
+    cached_scans = client.scan_calls
+    store.upsert(Assignment(seat_id="5-T-02", floor="tlv-floor-5", employee_email="b@x"))
+    # Cache invalidated → next list goes back to the wire.
+    rows = store.list()
+    assert client.scan_calls == cached_scans + 1
+    assert {r.seat_id for r in rows} == {"5-T-01", "5-T-02"}
+
+
+def test_list_sorted_by_floor_then_seat() -> None:
+    client = FakeDynamoClient()
+    store = DynamoStore(client, table="office-assignments", cache_ttl_seconds=0)
+    store.upsert_many(
+        [
+            Assignment(seat_id="5-T-02", floor="tlv-floor-5"),
+            Assignment(seat_id="5-T-01", floor="tlv-floor-5"),
+            Assignment(seat_id="2-A-01", floor="ber-floor-2"),
+        ]
+    )
+    ids = [r.seat_id for r in store.list()]
+    assert ids == ["2-A-01", "5-T-01", "5-T-02"]

--- a/tests/test_seats_sync.py
+++ b/tests/test_seats_sync.py
@@ -1,0 +1,138 @@
+"""Pure tests for the last-write-wins reconciler in ``office_cli.seats._sync``."""
+
+from __future__ import annotations
+
+import pytest
+
+from office_cli.seats import Assignment, AuditEntry
+from office_cli.seats._sync import reconcile
+
+
+def _a(seat_id: str, *, ts: str = "2026-05-01", email: str = "alice@x") -> Assignment:
+    return Assignment(
+        seat_id=seat_id,
+        floor="tlv-floor-5",
+        employee_email=email,
+        last_updated=ts,
+    )
+
+
+def test_row_only_left_copies_to_right() -> None:
+    plan = reconcile([_a("5-T-01")], [], primary="left")
+    assert [a.seat_id for a in plan.write_right] == ["5-T-01"]
+    assert plan.write_left == []
+    assert plan.ties == []
+
+
+def test_row_only_right_copies_to_left() -> None:
+    plan = reconcile([], [_a("5-T-01")], primary="left")
+    assert [a.seat_id for a in plan.write_left] == ["5-T-01"]
+    assert plan.write_right == []
+
+
+def test_identical_content_is_noop() -> None:
+    a = _a("5-T-01")
+    plan = reconcile([a], [a], primary="left")
+    assert plan.write_left == []
+    assert plan.write_right == []
+    assert plan.ties == []
+
+
+def test_left_newer_writes_right() -> None:
+    left = _a("5-T-01", ts="2026-05-02", email="alice@x")
+    right = _a("5-T-01", ts="2026-05-01", email="bob@x")
+    plan = reconcile([left], [right], primary="left")
+    assert plan.write_right == [left]
+    assert plan.write_left == []
+
+
+def test_right_newer_writes_left() -> None:
+    left = _a("5-T-01", ts="2026-05-01", email="bob@x")
+    right = _a("5-T-01", ts="2026-05-02", email="alice@x")
+    plan = reconcile([left], [right], primary="left")
+    assert plan.write_left == [right]
+    assert plan.write_right == []
+
+
+def test_tie_breaker_left() -> None:
+    left = _a("5-T-01", ts="2026-05-01", email="alice@x")
+    right = _a("5-T-01", ts="2026-05-01", email="bob@x")
+    plan = reconcile([left], [right], primary="left")
+    assert plan.write_right == [left]
+    assert plan.ties == ["5-T-01"]
+
+
+def test_tie_breaker_right() -> None:
+    left = _a("5-T-01", ts="2026-05-01", email="alice@x")
+    right = _a("5-T-01", ts="2026-05-01", email="bob@x")
+    plan = reconcile([left], [right], primary="right")
+    assert plan.write_left == [right]
+    assert plan.ties == ["5-T-01"]
+
+
+def test_invalid_primary_rejected() -> None:
+    with pytest.raises(ValueError):
+        reconcile([], [], primary="middle")
+
+
+def test_audit_diff_unions_both_sides() -> None:
+    left = [
+        AuditEntry(timestamp="2026-05-01", seat_id="5-T-01", action="assign", actor="cli"),
+    ]
+    right = [
+        AuditEntry(timestamp="2026-05-02", seat_id="5-T-01", action="unassign", actor="cli"),
+    ]
+    plan = reconcile([], [], primary="left", left_audit=left, right_audit=right)
+    # Right needs the row only-on-left.
+    assert [e.action for e in plan.audit_right] == ["assign"]
+    # Left needs the row only-on-right.
+    assert [e.action for e in plan.audit_left] == ["unassign"]
+
+
+def test_audit_diff_dedups_by_key() -> None:
+    same = AuditEntry(
+        timestamp="2026-05-01",
+        seat_id="5-T-01",
+        action="assign",
+        actor="cli",
+        employee_email="alice@x",
+    )
+    plan = reconcile([], [], primary="left", left_audit=[same], right_audit=[same])
+    assert plan.audit_left == []
+    assert plan.audit_right == []
+
+
+def test_redacted_flag_does_not_drive_writes() -> None:
+    """Stage 7 redacted flag is view-time; never written, so identical
+    content with different redacted should still be a no-op."""
+    left = Assignment(
+        seat_id="5-T-01",
+        floor="tlv-floor-5",
+        employee_email="exec@x",
+        last_updated="2026-05-01",
+        hidden=True,
+        redacted=False,
+    )
+    right = Assignment(
+        seat_id="5-T-01",
+        floor="tlv-floor-5",
+        employee_email="exec@x",
+        last_updated="2026-05-01",
+        hidden=True,
+        redacted=True,  # different redacted, same persisted content
+    )
+    plan = reconcile([left], [right], primary="left")
+    assert plan.write_left == []
+    assert plan.write_right == []
+
+
+def test_idempotent_repeated_run() -> None:
+    """After applying the plan, a re-run yields an empty plan."""
+    left_only = _a("5-T-01")
+    right_only = _a("5-T-02")
+    # Apply a notional first reconcile by handing each side both rows.
+    new_left = [left_only, right_only]
+    new_right = [right_only, left_only]
+    plan2 = reconcile(new_left, new_right, primary="left")
+    assert plan2.write_left == []
+    assert plan2.write_right == []

--- a/tests/test_storage_config.py
+++ b/tests/test_storage_config.py
@@ -78,7 +78,7 @@ def test_sheets_requires_service_account(tmp_path: Path, monkeypatch: pytest.Mon
 
 
 def test_unknown_store_type_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OFFICE_STORE", "dynamo")
+    monkeypatch.setenv("OFFICE_STORE", "redis")
     with pytest.raises(OfficeError) as exc:
         resolve_storage(tmp_path)
     assert "unknown storage type" in exc.value.message

--- a/uv.lock
+++ b/uv.lock
@@ -94,6 +94,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/36/028c12ed6ed85009a21b5472eb76c27f9b0341c6986f06f83475b40aaf51/boto3-1.43.1.tar.gz", hash = "sha256:9e4f85a7884797ff0f52c257094730ed228aaa07fa8134775ff8f86909cf4f2a", size = 113175, upload-time = "2026-04-30T20:27:04.569Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/d1/b8b2d5420c51cd8f7ec044ceecbf24b060156680b26519e1d482e160c3c8/boto3-1.43.1-py3-none-any.whl", hash = "sha256:3840bf0345b9aefcc5915176a19d227f63cfba7778c65e6e52d61c6ea0a10fdc", size = 140498, upload-time = "2026-04-30T20:27:01.791Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/b7/416ae6f1461d6fec3b3aaffc4759371319c71a21f7ab4c3106ee574fda8d/botocore-1.43.1.tar.gz", hash = "sha256:270d6357d662550fdb84973ec247e02bece0b6283d90bf37319c7753515336e4", size = 15296915, upload-time = "2026-04-30T20:26:50.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/48/dc2290d2af8b1dc3a44d210555a90f0cb76ef913c52b0c4f31a43cce27b8/botocore-1.43.1-py3-none-any.whl", hash = "sha256:955edc6a398b9c4100cf0d5a31433fdba3835500bf38c1ef171e6e75f4b477d2", size = 14979119, upload-time = "2026-04-30T20:26:46.031Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -542,6 +570,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "joserfc"
 version = "1.6.4"
 source = { registry = "https://pypi.org/simple" }
@@ -603,7 +640,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
@@ -612,6 +649,9 @@ dependencies = [
 [package.optional-dependencies]
 bamboohr = [
     { name = "requests" },
+]
+dynamo = [
+    { name = "boto3" },
 ]
 sheets = [
     { name = "gspread" },
@@ -635,6 +675,7 @@ dev = [
     { name = "authlib" },
     { name = "bandit" },
     { name = "black" },
+    { name = "boto3" },
     { name = "fastapi" },
     { name = "flake8" },
     { name = "httpx" },
@@ -648,6 +689,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "authlib", marker = "extra == 'sso'", specifier = ">=1.3" },
+    { name = "boto3", marker = "extra == 'dynamo'", specifier = ">=1.34" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.110" },
     { name = "gspread", marker = "extra == 'sheets'", specifier = ">=6.0" },
     { name = "httpx", marker = "extra == 'sso'", specifier = ">=0.27" },
@@ -658,13 +700,14 @@ requires-dist = [
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.30" },
 ]
-provides-extras = ["sheets", "bamboohr", "slack", "web", "sso"]
+provides-extras = ["sheets", "bamboohr", "slack", "web", "sso", "dynamo"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "authlib", specifier = ">=1.3" },
     { name = "bandit", specifier = ">=1.7.5" },
     { name = "black", specifier = ">=23.7.0" },
+    { name = "boto3", specifier = ">=1.34" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "flake8", specifier = ">=6.1" },
     { name = "httpx", specifier = ">=0.28" },
@@ -902,6 +945,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "pytokens"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1015,6 +1070,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #12.

## Summary

Adds the third storage backend behind the existing `AssignmentStore`
+ `AuditLog` Protocols, plus two CLI verbs that make Sheets and
Dynamo interoperable.

### `office_cli/seats/dynamo/` subpackage

- `DynamoStore` + `DynamoAuditLog` mirror the `SheetsStore` /
  `SheetsAuditLog` shape; same 5-minute TTL cache + in-memory
  `by_email` filter. The Protocol stays the boundary — service-
  layer code is unchanged.
- `DynamoClient` Protocol + `Boto3DynamoClient` (lazy `boto3` import).
  Tests use an in-memory `FakeDynamoClient` — no `moto` dependency.
- Audit table keyed on `PK=seat_id`, `SK=timestamp` so `put_item` is
  idempotent and migrations can re-run safely.

### Storage selector

`StorageConfig` extends to `type: "dynamo"` with `table_assignments`,
`table_audit`, `region`. Configurable via `offices.yaml`
`storage.dynamo:` block or env (`OFFICE_DYNAMO_ASSIGNMENTS`,
`OFFICE_DYNAMO_AUDIT`, `OFFICE_DYNAMO_REGION`). AWS credentials via
the standard chain (`AWS_PROFILE`, IAM role, etc) — never in YAML.

### Two new CLI verbs under `office seats`

- `office seats migrate --from {csv,sheets,dynamo} --to {csv,sheets,dynamo}
  [--dry-run] [--audit-append] [--json]` — one-shot import/export,
  idempotent for assignments (upsert by `seat_id`).
- `office seats sync --primary {sheets,dynamo} [--dry-run] [--json]` —
  bi-directional reconciliation via last-write-wins on
  `last_updated`. The pure reconciler in
  `office_cli/seats/_sync.py` is store-agnostic. Idempotent —
  re-runs converge.

### Sheets stays a first-class runtime backend

Per the user's direction in this session: Stage 8 makes Dynamo an
alternative, not a replacement. Operators who prefer the spreadsheet
UI as the primary editor keep using `OFFICE_STORE=sheets`. The
migrate + sync verbs make the two backends interoperable.

### Extras + version

- `pip install office-cli[dynamo]` pulls `boto3>=1.34`. Package
  still imports cleanly without it.
- Bumped to **0.8.0**.

## Test plan

- [x] 280 tests pass (`uv run pytest -n auto -q`)
- [x] black / isort / flake8 / bandit / markdownlint all clean
- [x] CLI acceptance smoke (issue #12 checklist):
  - CSV → fake-Dynamo round-trip preserves assignments + audit
    (`test_csv_to_dynamo_round_trip`).
  - `office seats migrate --dry-run` writes nothing
    (`test_dry_run_writes_nothing`).
  - Re-run is idempotent (assignments upsert; Dynamo audit dedups
    via PK+SK — `test_idempotent_rerun`).
  - Source / target type validation
    (`test_same_source_and_target_rejected`).
- [x] Sync verb (this session's expansion):
  - Sheets → Dynamo writes only Dynamo
    (`test_sync_pulls_from_sheets_to_dynamo`).
  - `--dry-run` writes nothing (`test_sync_dry_run_writes_nothing`).
  - Repeated runs converge (`test_sync_is_idempotent`).
  - Dynamo → Sheets via `--primary dynamo`
    (`test_sync_pushes_dynamo_to_sheets_via_primary`).
  - Pure reconciler covers all 7 row-state combinations + audit
    diff dedup + `redacted` flag exclusion
    (`test_seats_sync.py`, 11 tests).
- [x] CSV + Sheets paths still work without `boto3` — existing
      tests keep passing.

## Out of scope (deferred)

- **GSI on `employee_email`** — Stage 9 hardening; v1 read path is
  cache-backed scan + in-memory filter (matches Sheets behavior).
- **`moto`-based smoke test** — could land later; the hand-rolled
  fake is sufficient for v1.
- **Continuous (always-on) sync daemon** — `office seats sync` is
  a one-shot reconciler; operators run it via cron / GitHub Action.
- **Three-way merge for content collisions** — `--primary` is the
  tie-breaker when `last_updated` matches but content diverges.
- **Cross-region replication / point-in-time recovery** — operator
  concern, not code (per issue #12).

- Claude