### PR TITLE
docs: CONTRIBUTING guide + per-feature deep-dive pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,5 +223,9 @@ __marimo__/
 # operator state.
 seats/assignments.csv
 seats/audit-log.csv
+
+# Google Sheets service-account key — never commit credentials.
+data/sheets-service-account.json
+data/*-service-account.json
 .claude/scheduled_tasks.lock
 .claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-05-01
+
+### Added
+
+- `CONTRIBUTING.md` — contributor guide (fork, dev loop, conventions, OSS scope).
+- `docs/features/` — per-feature deep-dive index plus pages for CLI, BambooHR,
+  Slack, web map, effective dates, roles, Sheets, DynamoDB, and bi-directional
+  sync.
+
 ## [Unreleased]
 
 ## [0.8.0] - 2026-05-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.8.1] - 2026-05-01
 
 ### Added
@@ -13,8 +15,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `docs/features/` — per-feature deep-dive index plus pages for CLI, BambooHR,
   Slack, web map, effective dates, roles, Sheets, DynamoDB, and bi-directional
   sync.
-
-## [Unreleased]
 
 ## [0.8.0] - 2026-05-01
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,185 @@
+# Contributing to office-agent
+
+Thanks for your interest. This is a small, focused project — the
+contribution flow is light but the conventions matter because the
+CLI's public surface ships to PyPI on every merge to `main`.
+
+For the system overview, start with [README.md](./README.md). For
+feature deep-dives, see [docs/features/](./docs/features/). For the
+stage-by-stage implementation history, see
+[docs/architecture.md](./docs/architecture.md).
+
+## Quickstart for contributors
+
+```bash
+git clone https://github.com/agentculture/office-agent
+cd office-agent
+uv sync                                       # install deps
+uv run pytest -n auto -q                      # full suite, parallel
+uv run office --version
+```
+
+For a clean dev environment with every optional extra:
+
+```bash
+uv pip install -e '.[sheets,bamboohr,slack,web,sso,dynamo]'
+```
+
+## Branch + commit naming
+
+| Prefix            | Use for                                            |
+| ----------------- | -------------------------------------------------- |
+| `feat/<desc>`     | New user-visible feature.                          |
+| `fix/<desc>`      | Bug fix.                                           |
+| `docs/<desc>`     | Docs-only changes.                                 |
+| `chore/<desc>`    | Tooling, CI, dependency bumps, no behavior change. |
+| `refactor/<desc>` | Internal restructure, no behavior change.          |
+
+Commit messages aren't strictly Conventional Commits, but landing
+PR commit messages tend to follow `feat:` / `fix:` / `docs:` /
+`chore:` / `refactor:` prefixes for searchability in
+[CHANGELOG.md](./CHANGELOG.md).
+
+Sign every commit body and PR body with a trailing `- Claude` (or
+your name) so the agent-driven PR-review flow can attribute
+replies.
+
+## PR contract
+
+Every PR must:
+
+1. **Bump the version** in `pyproject.toml`. The `version-check`
+   CI job rejects PRs that don't.
+
+   ```bash
+   python3 .claude/skills/version-bump/scripts/bump.py patch     # docs / fixes
+   python3 .claude/skills/version-bump/scripts/bump.py minor     # new feature
+   python3 .claude/skills/version-bump/scripts/bump.py major     # breaking
+   ```
+
+   The script also prepends a `[<version>]` section to
+   `CHANGELOG.md` for you.
+
+2. **Pass the lint chain** (CI runs all of these):
+
+   ```bash
+   uv run black --check office_cli tests
+   uv run isort --check-only office_cli tests
+   uv run flake8 office_cli tests
+   uv run bandit -c pyproject.toml -r office_cli
+   markdownlint-cli2 "**/*.md" "#node_modules" "#.venv"
+   ```
+
+3. **Pass the test suite**:
+
+   ```bash
+   uv run pytest -n auto -q
+   ```
+
+   Coverage threshold is 60% (`fail_under` in `pyproject.toml`).
+
+4. **Update the relevant doc**. If you touch a feature, update the
+   matching `docs/features/<feature>.md`. If you touch the CLI
+   contract, update `docs/features/cli.md`. If you ship a new
+   stage, add a section to `docs/architecture.md`.
+
+5. **Link the issue** the PR addresses. PR descriptions follow the
+   template in `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## Optional-extras matrix
+
+When you add a new feature that depends on a third-party library,
+follow the lazy-import + optional-extra pattern (see
+[Stages 2–8](./docs/architecture.md) for prior art):
+
+1. Add the extra to `pyproject.toml` `[project.optional-dependencies]`:
+
+   ```toml
+   [project.optional-dependencies]
+   myfeat = ["mylib>=1.0"]
+   ```
+
+2. **Lazy-import** the dep inside the runtime module so the
+   package loads cleanly without the extra installed:
+
+   ```python
+   def use_myfeat():
+       try:
+           import mylib
+       except ImportError as err:
+           raise OfficeError(
+               code=EXIT_ENV_ERROR,
+               message="mylib is not installed",
+               remediation="install the myfeat extra: pip install office-cli[myfeat]",
+           ) from err
+       ...
+   ```
+
+3. **Mirror the extra in the dev dep group** so CI exercises the
+   path:
+
+   ```toml
+   [dependency-groups]
+   dev = [
+       ...,
+       "mylib>=1.0",
+   ]
+   ```
+
+4. **Test with a hand-rolled fake**, not a real-API mock library.
+   We don't take heavy test deps (no `moto`, no `responses`); the
+   `FakeSheetsClient` / `FakeBambooHRClient` / `FakeDynamoClient`
+   pattern is the convention.
+
+## Code review
+
+PRs go through three reviewers:
+
+1. **Qodo** (free Code Review bot) — produces a walkthrough +
+   inline correctness/rule comments.
+2. **Copilot** (GitHub Copilot Code Review) — inline comments.
+3. **SonarCloud** — quality gate + new-issue list. Must pass.
+
+Use the in-repo `pr-review` skill to drive the loop:
+
+```bash
+.claude/skills/pr-review/scripts/workflow.sh poll <PR>
+.claude/skills/pr-review/scripts/workflow.sh reply <PR> --resolve < replies.jsonl
+```
+
+Sonar findings that the rule's premise doesn't fit can be accepted
+with rationale via `.claude/skills/sonarclaude/scripts/sonar.sh
+accept`. Don't dismiss silently — the rationale lives forever in
+the SonarCloud history and helps future maintainers.
+
+## Skills convention
+
+Vendored skills live under `.claude/skills/<name>/` and ship with:
+
+1. `SKILL.md` (frontmatter `name` matches the directory name).
+2. A sibling `scripts/` directory.
+3. **No path dependencies** on external checkouts — skills must
+   work on a fresh `git clone`.
+
+`steward doctor . --scope self` enforces all three rules. If you
+add a new skill, run it.
+
+## Reporting issues
+
+- **Bug**: open an issue using
+  [`bug_report.md`](./.github/ISSUE_TEMPLATE/bug_report.md).
+- **Feature**: open an issue using
+  [`feature_request.md`](./.github/ISSUE_TEMPLATE/feature_request.md).
+- **Security**: see [SECURITY.md](./SECURITY.md). Don't open a
+  public issue.
+
+## Code of Conduct
+
+Participation is governed by the
+[Contributor Covenant](./CODE_OF_CONDUCT.md). Reports of
+unacceptable behavior go to <ori@agentculture.org>.
+
+## License
+
+By contributing, you agree your contribution is licensed under
+the [MIT License](./LICENSE).

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,38 @@
+# Feature deep-dives
+
+Each page below documents one feature surface — what it is, why it
+exists, how to install / configure it, how to use it, and how it
+works under the hood.
+
+For the **stage-by-stage implementation history** (how each feature
+got added across PRs), see [`docs/architecture.md`](../architecture.md).
+For the **product-level overview**, see the
+[top-level README](../../README.md).
+
+## Index
+
+| Feature                                        | Status  | One-liner                                                                                  |
+| ---------------------------------------------- | ------- | ------------------------------------------------------------------------------------------ |
+| [Agent-first CLI](./cli.md)                    | Shipped | `office` is the public surface — `learn` / `explain` make it self-documenting for agents.  |
+| [Google Sheets backend](./sheets.md)           | Shipped | Spreadsheet-backed `AssignmentStore` with append-only audit log and a 5-minute read cache. |
+| [BambooHR + auto-vacate](./bamboohr.md)        | Shipped | Live people directory; offboarding in BambooHR auto-vacates seats with **no Sheet edit**.  |
+| [Slack `/whereis`](./slack.md)                 | Shipped | Socket-mode slash command that resolves `@user` / email / self-lookup to a seat ID.        |
+| [DynamoDB backend](./dynamodb.md)              | Shipped | The third runtime store; same `AssignmentStore` Protocol as CSV / Sheets.                  |
+| [Sheets ↔ Dynamo sync](./sync.md)              | Shipped | `office seats migrate` (one-shot) and `office seats sync` (last-write-wins, idempotent).   |
+| [Search-first web map](./web-map.md)           | Shipped | Vanilla-JS SPA with deep-linkable URLs over a FastAPI seat-map server.                     |
+| [Effective-date windows](./effective-dates.md) | Shipped | `--from` / `--until` / `--as-of` everywhere; date-only storage, lex-sort comparison.       |
+| [SSO + roles](./roles.md)                      | Shipped | OIDC on the web; viewer / editor / planning gating; CLI stays unrestricted.                |
+
+## Doc skeleton
+
+Every feature page follows the same structure so you can skim
+directly to what you need:
+
+1. **What it is** — one paragraph.
+2. **Why** — design rationale, what problem it solves.
+3. **Install / configure** — pip extra, env vars, YAML keys.
+4. **Use** — copy-pasteable commands.
+5. **How it works** — internals at the level useful to operators
+   and contributors.
+6. **Limits + roadmap** — known constraints, deferred features.
+7. **Related** — cross-links.

--- a/docs/features/bamboohr.md
+++ b/docs/features/bamboohr.md
@@ -1,0 +1,164 @@
+# BambooHR + auto-vacate
+
+## What it is
+
+A BambooHR-backed `EmployeeDirectory` that powers the system's
+single most valuable feature: **a seat assigned to an offboarded
+employee renders as vacant automatically — no Sheet edit, no
+manual cleanup**. The directory is consulted at view time on
+every `seats list` / `whereis` call.
+
+## Why
+
+Offboarding is one of the few HR events that absolutely must
+propagate quickly. The historical pattern (Sheet-as-source-of-truth)
+relied on a human remembering to delete a row when a person left;
+in practice that step lagged or was skipped. The auto-vacate
+contract removes the human entirely:
+
+> When BambooHR no longer returns an employee in its
+> `/v1/employees/directory` response, every seat assigned to them
+> renders as vacant.
+
+The assignment row in the store is **not** mutated. The filter is
+applied at view time. If the employee is re-activated in BambooHR
+(or BambooHR is unreachable — fail-open), their seat reappears. No
+data is lost.
+
+## Install
+
+```bash
+pip install office-cli[bamboohr]
+```
+
+The package imports without `requests`; only the `bamboohr`
+runtime path lazy-imports it.
+
+## Configure
+
+YAML:
+
+```yaml
+directory:
+  type: bamboohr
+  bamboohr:
+    subdomain: tipalti
+    cache_ttl_seconds: 300
+```
+
+…and set the API token as an env var (it's a secret — **never**
+in YAML):
+
+```bash
+export BAMBOOHR_API_TOKEN=...
+# Optional env overrides:
+export OFFICE_DIRECTORY=bamboohr
+export BAMBOOHR_SUBDOMAIN=tipalti
+```
+
+`cache_ttl_seconds` is capped at 300 (5 minutes) so an offboard
+event can't sit stale for more than that. The cap is enforced in
+`office_cli/_config.py` — operators who try to set 1 hour get a
+clear `OfficeError(EXIT_USER_ERROR)`.
+
+## Use
+
+The directory is read transparently — no new verb. Just run the
+existing seat-lookup commands:
+
+```bash
+office seats list                      # rows for offboarded employees render vacant
+office whereis bob@example.com         # returns None if Bob isn't in BambooHR
+office whereis bob@example.com --json  # → {"email": "bob@example.com", "assignment": null}
+```
+
+Slack `/whereis` and the web map honor the same filter (they share
+the `SeatService`).
+
+## How it works
+
+### Module layout
+
+| File                                       | Role                                                 |
+| ------------------------------------------ | ---------------------------------------------------- |
+| `office_cli/people/__init__.py`            | `Employee` dataclass + `EmployeeDirectory` Protocol. |
+| `office_cli/people/_stub.py`               | `StubDirectory` — default; trusts every email.       |
+| `office_cli/people/bamboohr/_client.py`    | `RequestsBambooHRClient` (lazy `requests` shim).     |
+| `office_cli/people/bamboohr/_directory.py` | `BambooHRDirectory` — TTL cache, fail-open.          |
+
+### View-time filter
+
+`SeatService._apply_autovacate(a)` runs in both `list_seats` and
+`whereis`:
+
+```python
+def _apply_autovacate(self, a):
+    if not a.employee_email:
+        return a
+    if self.directory.is_active(a.employee_email):
+        return a
+    # cleared email + hidden=False so the row renders as plain vacant
+    return dataclasses.replace(a, employee_email="", hidden=False)
+```
+
+The store row stays unchanged. Only the in-memory `Assignment`
+returned to the surface is mutated.
+
+### TTL cache + fail-open semantics
+
+`BambooHRDirectory` keeps a snapshot of active employees in memory
+with a 5-minute TTL. The behavior on a refresh:
+
+| Scenario                               | Action                                                                            |
+| -------------------------------------- | --------------------------------------------------------------------------------- |
+| Cache fresh (within TTL)               | Use cache; no API call.                                                           |
+| Cache stale + API succeeds             | Replace cache; reset TTL.                                                         |
+| Cache stale + API fails (network, 5xx) | **Fail-open**: keep the stale cache, emit a stderr warning with the cache age.    |
+| Cache stale + API returns empty        | Replace with empty cache → all seats render vacant (this is the offboard signal). |
+
+A separate `_last_attempt_at` tracks failed-refresh attempts so we
+don't hammer BambooHR on every CLI call when the API is down.
+
+Fail-open is intentional: a temporary BambooHR outage shouldn't
+cause the whole seat map to look offboarded.
+
+### Why we never store names locally
+
+`Employee` carries `email` and a display `name` field. The
+directory layer is the **only** place names live; we **never**
+write them to the assignment store. Reasons:
+
+- GDPR / data-minimization: the audit log only needs the email
+  (which is already a join key); the human-readable name belongs
+  to the source of truth.
+- Stale-name avoidance: if Sarah Smith becomes Sarah Jones, the
+  Sheet doesn't end up with two different names for the same seat
+  — the rendering layer always asks the directory.
+
+## Limits + roadmap
+
+- **Token in env only** — by design. If your shell history is
+  shared, use `direnv` or an OS keychain to scope the variable.
+- **No webhook integration** — the auto-vacate latency is bounded
+  by the cache TTL (default 5 min). A future Stage-9+ work item
+  could subscribe to BambooHR's webhook for instant invalidation;
+  not on the v1 roadmap because 5 minutes is fine for our use case.
+- **No name redaction in audit log** — the audit log carries the
+  email, never the name, but operators with access to the audit
+  log can still join against BambooHR. Audit-log redaction is
+  explicitly out of scope per [issue #11](https://github.com/agentculture/office-agent/issues/11).
+- **`StubDirectory` is the default** — installations that don't
+  set `OFFICE_DIRECTORY=bamboohr` get pass-through behavior (every
+  email is "active"). This is right for local dev; production
+  should set the env var.
+
+## Related
+
+- [Architecture stages — Stage 3](../architecture.md) — PR-by-PR
+  record.
+- [SSO + roles](./roles.md) — Slack `/whereis` resolves caller
+  email via `users.info`, then looks up the role in the same
+  directory pipeline.
+- [Effective-date windows](./effective-dates.md) — auto-vacate
+  runs **after** the date filter, so a future-dated assignment to
+  an offboarded employee surfaces as vacant in both timeframes.

--- a/docs/features/bamboohr.md
+++ b/docs/features/bamboohr.md
@@ -156,9 +156,11 @@ write them to the assignment store. Reasons:
 
 - [Architecture stages — Stage 3](../architecture.md) — PR-by-PR
   record.
-- [SSO + roles](./roles.md) — Slack `/whereis` resolves caller
-  email via `users.info`, then looks up the role in the same
-  directory pipeline.
+- [SSO + roles](./roles.md) — Slack `/whereis` resolves the
+  caller's email via `users.info` and then looks up their role in
+  the `RolesConfig` map (loaded from `data/offices.yaml`); BambooHR
+  is consulted only for the queried subject's identity, not for the
+  caller's role.
 - [Effective-date windows](./effective-dates.md) — auto-vacate
   runs **after** the date filter, so a future-dated assignment to
   an offboarded employee surfaces as vacant in both timeframes.

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -1,0 +1,188 @@
+# Agent-first CLI
+
+## What it is
+
+`office` is the command-line entry point and the canonical public
+surface of the system. Every other surface — Slack, the web map,
+the migration / sync verbs — sits on top of the same
+`SeatService`. A human operator can drive the whole product through
+the CLI; an agent (Claude, etc.) can drive it just as well because
+the CLI is **self-documenting** and **JSON-emitting**.
+
+## Why
+
+The product was designed agent-first. That meant two contracts the
+CLI must honor:
+
+- **Self-teaching**: `office learn` returns a comprehensive prompt
+  describing every verb, exit-code policy, and JSON shape — agents
+  read it once and don't need a separate manual.
+- **Structured I/O**: every command accepts `--json` and emits a
+  predictable shape. Errors are structured `{code, message,
+  remediation}` objects, never bare tracebacks.
+
+You can drop the operator entirely and let an agent do seating ops.
+That's the design — "you can just work with Claude without any
+interface."
+
+## Install
+
+```bash
+uv tool install office-cli
+office --version       # 0.8.x
+```
+
+Optional extras pull in surface-specific dependencies:
+
+| Extra                  | Adds                               | Used by                                 |
+| ---------------------- | ---------------------------------- | --------------------------------------- |
+| `office-cli[sheets]`   | `gspread`                          | [Sheets backend](./sheets.md)           |
+| `office-cli[bamboohr]` | `requests`                         | [BambooHR + auto-vacate](./bamboohr.md) |
+| `office-cli[slack]`    | `slack-bolt`, `slack-sdk`          | [Slack `/whereis`](./slack.md)          |
+| `office-cli[web]`      | `fastapi`, `uvicorn`               | [Web map](./web-map.md)                 |
+| `office-cli[sso]`      | `authlib`, `itsdangerous`, `httpx` | [SSO + roles](./roles.md)               |
+| `office-cli[dynamo]`   | `boto3`                            | [DynamoDB backend](./dynamodb.md)       |
+
+The package imports cleanly without any of the extras — features
+that need a missing dep raise `OfficeError(EXIT_ENV_ERROR)` with a
+clear `pip install office-cli[<extra>]` remediation.
+
+## Use
+
+### Self-teaching surface
+
+```bash
+office learn                          # the full prompt every agent should read
+office explain seats                  # markdown docs for any verb path
+office explain seats assign
+office whoami --json                  # auth probe
+```
+
+### Floor + seat operations
+
+```bash
+office floors list --json
+office floors validate floors/tlv-floor-5.svg
+
+office seats list                     # operator default — unrestricted
+office seats list --vacant
+office seats list --as-of 2026-07-15  # Stage 6 — see effective-dates.md
+office seats list --json --occupied
+
+office seats assign 5-T-01 alice@example.com
+office seats assign 5-T-01 alice@example.com --hidden --note "ergonomic"
+office seats assign 5-T-01 alice@example.com --from 2026-07-01 --until 2026-12-31
+
+office seats unassign 5-T-01
+office seats move alice@example.com 5-T-02
+office seats history 5-T-01 --json
+```
+
+### Look-ups
+
+```bash
+office whereis alice@example.com
+office whereis alice@example.com --as-of 2026-07-15 --json
+```
+
+### Long-running services
+
+```bash
+office serve --port 8000 --data-dir tests/fixtures      # web map
+office slack-serve                                       # Slack /whereis listener
+```
+
+### Cross-store ops
+
+```bash
+office seats migrate --from sheets --to dynamo --dry-run
+office seats migrate --from sheets --to dynamo
+office seats sync --primary sheets                       # bi-directional
+```
+
+## How it works
+
+### Module shape
+
+| Module                       | Role                                                                         |
+| ---------------------------- | ---------------------------------------------------------------------------- |
+| `office_cli/cli/__init__.py` | `main()` — argparse top-level; dispatch to verb handlers; structured exit.   |
+| `office_cli/cli/_errors.py`  | `OfficeError` + `EXIT_SUCCESS`/`_USER_ERROR`/`_ENV_ERROR`/`_INTERNAL_ERROR`. |
+| `office_cli/cli/_output.py`  | `emit_result` / `emit_error` / `emit_diagnostic` — `--json` aware.           |
+| `office_cli/cli/_commands/`  | One module per verb. Each exports `register(sub)` + `cmd_<name>(args)`.      |
+
+### Exit-code policy
+
+| Code | Meaning                                                            |
+| ---- | ------------------------------------------------------------------ |
+| 0    | Success.                                                           |
+| 1    | User-input error (bad flag, bad path, missing required arg).       |
+| 2    | Environment / setup error (missing pip extra, missing env var, …). |
+| 3    | Internal error (unexpected exception, classified separately).      |
+| 4+   | Reserved.                                                          |
+
+Every failure path raises `OfficeError(code=…, message=…, remediation=…)`.
+The CLI dispatcher catches it and:
+
+- Prints `error: <message>\nhint: <remediation>` to stderr.
+- In `--json` mode, prints `{"code": …, "message": …, "remediation": …}`.
+- Exits with `code`.
+
+No traceback ever leaks. Agents can branch on code; operators read
+the hint.
+
+### JSON shape
+
+Every verb that produces output supports `--json`. Examples:
+
+```jsonc
+// office seats list --json
+{
+  "seats": [
+    { "seat_id": "5-T-01", "floor": "tlv-floor-5",
+      "employee_email": "alice@example.com", "hidden": false,
+      "redacted": false, "effective_from": "2026-05-01",
+      "effective_until": null, ...}
+  ]
+}
+
+// office whereis alice@x --json
+{ "email": "alice@x", "assignment": { "seat_id": "5-T-01", ... } }
+
+// Error
+{ "code": 1, "message": "unknown seat: 9-Q-99",
+  "remediation": "run: office seats list to see the known seat IDs" }
+```
+
+### Data resolution
+
+`office` looks for `data/offices.yaml`, `floors/`, and `seats/`
+in this order:
+
+1. `--data-dir DIR` flag.
+2. `OFFICE_DATA_DIR` env var.
+3. Current working directory.
+
+The chosen directory is used by the storage / directory / role
+resolvers. See [Sheets](./sheets.md), [BambooHR](./bamboohr.md), and
+[Roles](./roles.md) for the per-feature config.
+
+## Limits + roadmap
+
+- **No remote-shell mode** — the CLI runs locally; an agent that
+  drives it must SSH or run it as a subprocess. A future `office
+  serve --rpc` could expose verbs over HTTP, but isn't on the v1
+  roadmap.
+- **No tab-completion file shipped** — argparse generates `--help`
+  for everything, but `bash`/`zsh` completion would be a nice add.
+- **No per-verb auth gate** — operators who can run the CLI have
+  full access. SSO + roles only gate the **web** + **Slack**
+  surfaces. The CLI is operator-only by design.
+
+## Related
+
+- [Architecture stages history](../architecture.md)
+- [SSO + roles](./roles.md) — how viewer / editor / planning gating
+  works on the web + Slack surfaces (CLI stays unrestricted).
+- [Effective-date windows](./effective-dates.md) — `--from` /
+  `--until` / `--as-of` semantics shared with web + Slack.

--- a/docs/features/dynamodb.md
+++ b/docs/features/dynamodb.md
@@ -1,0 +1,198 @@
+# DynamoDB backend
+
+## What it is
+
+A DynamoDB-backed `AssignmentStore` + `AuditLog` behind the same
+Protocol the CSV and Sheets backends implement. It's the v2
+production-shaped store: managed, multi-region-ready, and designed
+to run alongside Sheets — not replace it. See
+[Sheets ↔ Dynamo sync](./sync.md) for the bi-directional
+reconciliation pattern.
+
+## Why
+
+The Sheets backend is great for human editing but limits production
+ergonomics: latency tied to gspread's HTTP path, no per-row IAM,
+no streaming change feed. DynamoDB gives:
+
+- Predictable single-digit-ms read latency.
+- Per-table IAM; service-to-service AWS auth.
+- DynamoDB Streams (future hookup for webhooks / search indexing).
+- Schema flexibility — adding a new attribute is a no-op write.
+
+Issue [#1](https://github.com/agentculture/office-agent/issues/1)
+named Dynamo as the v2 source of truth from the start, with the
+schema explicitly **flat enough that a Sheets→Dynamo migration is
+a copy operation**. That constraint shaped the choice of keys.
+
+## Install
+
+```bash
+pip install office-cli[dynamo]
+```
+
+The package imports without `boto3`; only the `dynamo` runtime
+path lazy-imports it.
+
+## Configure
+
+YAML:
+
+```yaml
+storage:
+  type: dynamo
+  dynamo:
+    table_assignments: office-assignments
+    table_audit: office-audit-log
+    region: us-east-1
+    cache_ttl_seconds: 300
+```
+
+…or env (overrides YAML):
+
+```bash
+export OFFICE_STORE=dynamo
+export OFFICE_DYNAMO_ASSIGNMENTS=office-assignments
+export OFFICE_DYNAMO_AUDIT=office-audit-log
+export OFFICE_DYNAMO_REGION=us-east-1
+```
+
+AWS credentials follow the standard chain (`AWS_PROFILE`, IAM
+role, env vars). **Never** in YAML.
+
+### Tables to provision
+
+| Table                | Partition key (PK) | Sort key (SK)                                     | Notes                                             |
+| -------------------- | ------------------ | ------------------------------------------------- | ------------------------------------------------- |
+| `office-assignments` | `seat_id` (S)      | _none_                                            | One row per seat. Flat schema mirrors CSV cols.   |
+| `office-audit-log`   | `seat_id` (S)      | `event_id` (S) — `"{timestamp}#{action}#{email}"` | Composite SK so same-second events don't collide. |
+
+Use on-demand billing for both. Provisioned mode is fine too — at
+v1 scale (hundreds of seats) the throughput is dominated by the
+audit-log writes during sync runs.
+
+### IAM
+
+Minimum policy for the office-cli identity:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan",
+        "dynamodb:PutItem", "dynamodb:BatchWriteItem"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:us-east-1:*:table/office-assignments",
+        "arn:aws:dynamodb:us-east-1:*:table/office-audit-log"
+      ]
+    }
+  ]
+}
+```
+
+## Use
+
+```bash
+office seats list                             # reads from Dynamo
+office seats assign 5-T-01 alice@example.com  # writes via batch_writer
+office seats history 5-T-01 --json            # query_by_pk on audit table
+
+office seats migrate --from sheets --to dynamo  # bootstrap
+office seats sync --primary sheets              # ongoing reconcile
+```
+
+## How it works
+
+### Module layout
+
+| File                                  | Role                                                 |
+| ------------------------------------- | ---------------------------------------------------- |
+| `office_cli/seats/dynamo/__init__.py` | Re-exports + lazy guards.                            |
+| `office_cli/seats/dynamo/_client.py`  | `DynamoClient` Protocol + `Boto3DynamoClient` shim.  |
+| `office_cli/seats/dynamo/_store.py`   | `DynamoStore` with TTL cache + in-memory `by_email`. |
+| `office_cli/seats/dynamo/_audit.py`   | `DynamoAuditLog` with composite event_id SK.         |
+
+### Read path
+
+`DynamoStore.list()` mirrors the Sheets pattern:
+
+1. Cache check (5-min TTL by default).
+2. On miss: `scan` the table (paginated under the hood —
+   `Boto3DynamoClient.scan_all` follows `LastEvaluatedKey`).
+3. Build `Assignment` objects; cache; return a copy.
+
+`by_email` is an in-memory linear scan over the cached list. At
+v1 scale this is sub-millisecond; a future Stage-9 work item could
+add a GSI on `employee_email` for direct query.
+
+### Write path
+
+`DynamoStore.upsert_many` uses `batch_put` (boto3's
+`Table.batch_writer`) and invalidates the cache afterwards. PK
+dedup means re-running the same upsert is a no-op for unchanged
+rows.
+
+### Audit-table SK rationale
+
+The audit log keys on `(seat_id, event_id)` where:
+
+```python
+event_id = f"{timestamp}#{action}#{employee_email}"
+```
+
+Three reasons for this composite shape:
+
+1. **Same-second collisions don't lose history.** `SeatService`
+   produces second-precision timestamps. A rapid `assign →
+   unassign` within the same wall-clock second would otherwise
+   write to the same `(seat_id, timestamp)` key and the second
+   `put_item` would overwrite the first, breaking the
+   append-only contract.
+2. **Lex order matches chronological order.** `#` sorts before any
+   alphanumeric, so the timestamp prefix dominates the SK lex
+   sort. `for_seat` queries return events in wall-clock order.
+3. **Idempotent migrations.** Two re-runs of `migrate sheets
+   dynamo` write the same SK, so `put_item` just overwrites the
+   same row. No duplicate-row drift.
+
+### Pagination
+
+Both `scan_all` and `query_by_pk` walk `LastEvaluatedKey` until
+DynamoDB returns no continuation. At v1 scale this is one round
+trip; the loop is there so pagination doesn't surprise anyone if
+the data set grows.
+
+### Test harness
+
+Tests use a hand-rolled `FakeDynamoClient` (in
+`tests/test_dynamo_store.py`) — an in-memory dict keyed by `(pk,
+sk)`. No `moto` dependency. The Protocol is the boundary, so the
+fake matches the production shim's contract bit-for-bit.
+
+## Limits + roadmap
+
+- **No GSI on `employee_email`** — Stage-9 hardening. The 5-min
+  cache + linear scan is fine for v1 scale; revisit when a
+  deployment hits >5k seats.
+- **No conditional writes** — `upsert_many` is unconditional.
+  The migrate/sync verbs do explicit read-merge-write, so
+  conflicts are visible at that layer; per-row CAS would be
+  Stage-9+.
+- **No DynamoDB Streams hookup** — a future webhook out to
+  BambooHR / search index could subscribe to the stream; not on
+  the roadmap.
+- **One region per deployment** — multi-region replication is an
+  AWS-level concern, not application.
+- **Sheets stays first-class.** Dynamo doesn't replace Sheets;
+  see [sync.md](./sync.md) for the bi-directional pattern.
+
+## Related
+
+- [Sheets backend](./sheets.md) — the v1 store, still supported.
+- [Sheets ↔ Dynamo sync](./sync.md) — `migrate` and `sync` verbs.
+- [Architecture stages — Stage 8](../architecture.md) — PR-by-PR
+  record.

--- a/docs/features/effective-dates.md
+++ b/docs/features/effective-dates.md
@@ -1,0 +1,166 @@
+# Effective-date windows
+
+## What it is
+
+Every assignment carries an `effective_from` and `effective_until`
+date pair. The seat-listing surfaces (CLI, web, Slack) accept an
+`as-of` parameter and render the seat map **as of that date**.
+Future-dated assignments don't show until their window opens; past
+assignments stop showing when their window closes.
+
+## Why
+
+HR and facilities teams plan ahead. Knowing "Alice moves to
+5-T-04 on July 1" is real information; flipping the spreadsheet
+on July 1 at 9 AM isn't. With effective dates, the operator
+records the move now, and the system surfaces it automatically.
+The web map's `?asOf=2026-07-15` query lets a planner ask "what
+will the floor look like on the 15th?" without changing any data.
+
+The contract intentionally avoids time-precision: dates only.
+Day-granularity matches the UX, lex-sort comparison is correct on
+ISO `YYYY-MM-DD`, and the storage shape stays plain text — no
+per-backend timestamp gymnastics.
+
+## Install
+
+Built-in. No extra needed.
+
+## Configure
+
+No configuration. The feature is always on. CLI defaults to
+**today** (the operator's wall-clock date) when `--as-of` is
+omitted; web defaults to today (via the service's clock); Slack
+defaults to today.
+
+## Use
+
+### CLI
+
+```bash
+office seats list --as-of 2026-07-15
+office whereis alice@example.com --as-of 2026-07-15
+
+# Schedule a future assignment:
+office seats assign 5-T-01 alice@example.com --from 2026-07-01 --until 2026-12-31
+
+# Defaults (no flags):
+office whereis alice@example.com   # default = today
+```
+
+### Web
+
+```text
+http://localhost:8000/offices/tlv/floors/tlv-floor-5?asOf=2026-07-15
+```
+
+The frontend reads `asOf` from the URL, validates it
+(`/^\d{4}-\d{2}-\d{2}$/` regex), and forwards it as
+`/api/floors/<id>?as_of=2026-07-15`. The API accepts both
+`as_of` (Python convention) and `asOf` (camelCase) for direct-API
+callers.
+
+### Slack
+
+A trailing `YYYY-MM-DD` token on `/whereis`:
+
+```text
+/whereis alice@example.com 2026-07-15
+/whereis @alice 2026-07-15
+/whereis 2026-07-15                # self-lookup as-of a date
+```
+
+## How it works
+
+### Storage shape
+
+Both `effective_from` and `effective_until` are stored as
+**date-only `YYYY-MM-DD` strings**. `last_updated` and audit-log
+timestamps stay full ISO-8601 wall-clock — those record the *write
+time*, not the *effective period*.
+
+Date-only choice is intentional: the comparison is lex on ISO
+strings (`"2026-07-15" < "2026-08-01"` is true), and an empty
+string means open-ended (`""` < any real date, so it acts as
+"begins always" for `from` and "never ends" for `until`).
+
+### View-time filter
+
+`SeatService.list_seats(as_of=...)` and
+`SeatService.whereis(email, as_of=...)` apply
+`is_effective(a, as_of_date)` to each row before returning:
+
+```python
+def is_effective(a, as_of_date):
+    eff_from = _date_prefix(a.effective_from)   # strips T... if legacy
+    eff_until = _date_prefix(a.effective_until)
+    if eff_from and as_of_date < eff_from:
+        return False
+    if eff_until and as_of_date > eff_until:
+        return False
+    return True
+```
+
+Both bounds are **inclusive**. Pre-Stage-6 rows that wrote a full
+ISO timestamp into `effective_from` keep working — the
+`_date_prefix` helper strips `T...` before comparison.
+
+### Order of view-time filters
+
+Surfaces apply filters in this order:
+
+1. **Date filter** (Stage 6) — out-of-window rows render vacant.
+2. **Auto-vacate filter** (Stage 3) — inactive employees render
+   vacant.
+3. **Role redaction** (Stage 7) — viewer callers see hidden seats
+   as `"(private)"`.
+
+The order matters: a future-dated assignment to an offboarded
+employee surfaces as vacant in both timeframes; the date filter
+wins first.
+
+### Validation
+
+Every malformed date — CLI flag, URL param, Slack token —
+surfaces as `OfficeError(EXIT_USER_ERROR)` with a contextual
+remediation:
+
+| Surface       | `parse_iso_date` `field=` / `example=`            |
+| ------------- | ------------------------------------------------- |
+| `--as-of`     | `field="--as-of"`, `example="--as-of 2026-07-01"` |
+| `--from`      | `field="--from"`, `example="--from 2026-07-01"`   |
+| `--until`     | `field="--until"`, `example="--until 2026-12-31"` |
+| API `?as_of=` | `field="as_of"`, `example="?as_of=2026-07-01"`    |
+| Slack token   | `field="as-of date"`, `example="2026-07-01"`      |
+
+Calendar validation (`datetime.strptime`) rejects shapes the regex
+accepts but the calendar doesn't (e.g. `2026-02-30`).
+
+### Window validation
+
+`validate_window(from_date, until_date)` runs in `SeatService.assign`
+and rejects an inverted window with a clear message before any
+write hits the store.
+
+## Limits + roadmap
+
+- **Date precision only.** No hour-granularity scheduling. Could
+  land later, but the storage shape would have to change across
+  all backends.
+- **No multi-row scheduling per seat.** A future-dated assignment
+  on a currently-occupied seat is rejected. Stage-9+ work could
+  unlock multi-row scheduling (with `effective_until` driving the
+  handoff), but isn't on the v1 roadmap.
+- **No "what-if" mode.** Web shows the map at one date at a time;
+  comparing two dates side-by-side is operator territory (open two
+  tabs).
+- **Audit-log timestamp stays wall-clock.** We never compare audit
+  timestamps with `as_of`; that's the right contract.
+
+## Related
+
+- [CLI](./cli.md) — `--from` / `--until` / `--as-of` flags.
+- [Web map](./web-map.md) — `?asOf=` URL semantics.
+- [Slack `/whereis`](./slack.md) — trailing date token.
+- [Architecture stages — Stage 6](../architecture.md) — PR-by-PR
+  record.

--- a/docs/features/roles.md
+++ b/docs/features/roles.md
@@ -1,0 +1,207 @@
+# SSO + roles (viewer / editor / planning)
+
+## What it is
+
+Three roles drive **what callers see** on the web and Slack
+surfaces:
+
+- **viewer** (default, everyone) — `hidden=TRUE` seats render as
+  `"occupied (private)"`. No email, no notes.
+- **editor** (HR / IT) — full details on hidden seats.
+- **planning** (facilities) — same as editor in v1; the
+  draft-SVG and future-dated visibility carve-outs from issue #1
+  are deferred.
+
+The web layer adds OIDC authentication on top — unauthenticated
+browsers are redirected through the IdP and back. The CLI is
+**operator-only and unrestricted** (no role flag, full data).
+
+## Why
+
+`hidden=TRUE` exists for a reason — exec seats, sensitive HR
+moves, etc. Stages 4 + 5 redacted hidden seats for everyone;
+Stage 7 lifted the redaction for the small subset of users who
+need it (HR / facilities), without complicating the model. The
+role check is the **only** gate; the data model carries the same
+`hidden` flag everywhere, and the per-role view is computed at
+surface time.
+
+OIDC instead of role-passing-by-header because the web is
+operator-facing — anyone with a browser tab is a potential
+caller. Without auth, `X-Test-Role: editor` would let any visitor
+see exec emails. With OIDC, the session is the sole source of
+identity in production.
+
+## Install
+
+```bash
+pip install office-cli[web,sso]
+```
+
+Pulls `authlib`, `itsdangerous`, `httpx` (alongside the `[web]`
+extras `fastapi` + `uvicorn`).
+
+## Configure
+
+### IdP (you, in the IdP console)
+
+Set up an OIDC client in your IdP:
+
+- **Authorized redirect URI**:
+  `https://<your-host>/auth/callback`
+- **Scopes**: `openid email profile`.
+
+Capture the client ID, client secret, and the issuer URL (the IdP
+publishes `<issuer>/.well-known/openid-configuration`).
+
+### App-side env
+
+```bash
+export OIDC_ISSUER=https://your-idp.example.com
+export OIDC_CLIENT_ID=office-agent
+export OIDC_CLIENT_SECRET=...
+export OIDC_REDIRECT_URL=https://office.example.com/auth/callback
+export SESSION_SECRET=$(openssl rand -hex 32)
+office serve --port 8000
+```
+
+All five env vars must be set together. Setting some-but-not-all
+raises `OfficeError(EXIT_ENV_ERROR)` so a partial misconfig fails
+fast.
+
+`SESSION_SECRET` should be 32+ bytes. Rotate it per deployment
+generation; rotation invalidates all live sessions.
+
+### Optional: HTTP staging behind a TLS proxy
+
+```bash
+export OIDC_COOKIE_SECURE=false
+```
+
+Defaults to `true` (production-secure). Set to `false` when the
+edge is HTTPS but the office-cli process speaks HTTP behind the
+proxy — otherwise the browser drops the `Secure` cookie and you
+get a login loop.
+
+### Roles map
+
+`data/offices.yaml`:
+
+```yaml
+roles:
+  editor:
+    - "hr-it@tipalti.com"
+    - "alice@tipalti.com"
+  planning:
+    - "facilities@tipalti.com"
+```
+
+Anything not listed is `viewer` (the default). Email matching is
+case-insensitive; the parser normalizes to lowercase at load time.
+
+## Use
+
+### Web
+
+Visit any URL under `/offices/<id>/floors/<id>` while
+unauthenticated → 302 to `/auth/login?next=<original URL>`. The
+IdP authenticates → callback at `/auth/callback` → session cookie
+set → redirect to original URL. The SPA shell renders, calls
+`/api/floors/<id>`, and the response carries the user identity and
+a logout button:
+
+```jsonc
+{
+  "floor": { ... },
+  "seats": [ ... ],
+  "user": { "email": "alice@tipalti.com", "role": "editor" }
+}
+```
+
+Logout: POST `/auth/logout` clears the session and redirects to
+`/`.
+
+### Slack
+
+The slash-command listener resolves the caller's email via
+`users.info` and looks the role up in the same `RolesConfig`.
+Hidden seats render as `"occupied (private)"` for viewers; full
+details for editors / planning. See [Slack](./slack.md).
+
+### CLI
+
+The CLI is operator-only and unrestricted. No role flag. The
+`SeatService` accepts `role=None` (CLI default) which means **no
+filter** — full data passes through.
+
+## How it works
+
+### Auth-disabled mode
+
+When the OIDC env vars are unset, the server runs without
+`SessionMiddleware` and without `/auth/*` routes. This is the
+default for local dev. An optional `X-Test-Role: viewer|editor|planning`
+header drives role-aware behavior; **only honored when OIDC is
+disabled**. Once `OIDC_ISSUER` etc. are set, the header is
+silently ignored — production is session-only.
+
+### Service-layer redaction
+
+`SeatService.list_seats(role="viewer")` returns `Assignment` rows
+with `employee_email=""`, `notes=""`, and a non-persisted
+`redacted=True` flag set on `hidden=TRUE` rows. The web's
+`_redact()` helper maps that to `"(private)"` in the JSON; Slack's
+`_blocks` consults the same flag to choose the private-vs-occupied
+template.
+
+### Module layout
+
+| File                           | Role                                                                                               |
+| ------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `office_cli/_roles.py`         | `RolesConfig`, `resolve_roles`, `role_for_email`, `is_full_access`.                                |
+| `office_cli/server/_auth.py`   | `OIDCConfig`, `resolve_oidc`, `register_auth_routes`, `current_user`, `role_from_user`.            |
+| `office_cli/server/_routes.py` | `_spa_shell_response` issues the SSO redirect; `_build_floor_response` resolves role from session. |
+| `office_cli/server/_app.py`    | Auto-resolves OIDC + roles when not passed explicitly.                                             |
+
+### Session shape
+
+`SessionMiddleware` (Starlette) signs a cookie containing
+`{"user": {"email": "...", "role": "..."}}` after the OIDC
+callback. The session cookie is `Secure`, `SameSite=Lax`, scoped
+to the cookie domain by default.
+
+`current_user(request)` reads the session in production; falls
+back to the `X-Test-Role` header in auth-disabled mode.
+
+### Open-redirect protection
+
+`/auth/login?next=<path>` URL-encodes the `next` value end-to-end
+so a URL like `/offices/tlv/floors/tlv-floor-5?seat=X&asOf=Y`
+round-trips through the IdP intact. The handler whitelist-
+validates `next`: must start with `/`, no `//` or `/\\` prefixes
+(those would re-host the redirect).
+
+## Limits + roadmap
+
+- **No per-office role scoping.** One global role-map. Multi-office
+  deployments where editor of office A shouldn't see office B
+  data would need a richer config.
+- **Planning role's draft-SVG view + future-dated visibility
+  carve-outs** are deferred (issue #1 stretch). Lifting them is a
+  one-line change in `is_full_access` plus a date-window pass in
+  the service.
+- **No API-token auth.** Non-browser callers go through the CLI.
+  An `Authorization: Bearer` header with a service token could
+  land Stage-9+ if needed.
+- **Audit-log redaction is out of scope.** The audit log is
+  operator-internal and append-only — full data is OK there.
+
+## Related
+
+- [Web map](./web-map.md) — the surface the redirect gates.
+- [Slack `/whereis`](./slack.md) — caller-email → role pipeline.
+- [BambooHR + auto-vacate](./bamboohr.md) — auto-vacate runs on
+  the same data model that role gating filters; both apply at
+  view time.
+- [Architecture stages — Stage 7](../architecture.md) — PR-by-PR
+  record.

--- a/docs/features/sheets.md
+++ b/docs/features/sheets.md
@@ -1,0 +1,195 @@
+# Google Sheets backend
+
+## What it is
+
+A Google Sheets-backed `AssignmentStore` + `AuditLog` behind the
+same Protocol the CSV and DynamoDB backends implement. Operators
+who prefer the spreadsheet UI as their CMS can read and write
+directly to a Sheet; the seat service reads through `gspread` and
+caches results for 5 minutes.
+
+## Why
+
+Issue [#1](https://github.com/agentculture/office-agent/issues/1)
+named Sheets the v1 source of truth. Two reasons:
+
+- HR / facilities teams already use spreadsheets daily — no new UI
+  to learn for the human editor.
+- An audit trail in a separate tab is easy to read by a non-engineer.
+
+When Stage 8 added DynamoDB, **Sheets stayed first-class**: the two
+backends are interchangeable, and `office seats sync` keeps them in
+agreement bi-directionally. See [Sheets ↔ Dynamo sync](./sync.md).
+
+## Install
+
+```bash
+pip install office-cli[sheets]
+```
+
+The package imports without `gspread`; only the `sheets` runtime
+path lazy-imports it. CSV-only deployments don't pay for the
+dependency tree.
+
+## Configure
+
+Three knobs: spreadsheet ID, service-account JSON, optional
+cache-TTL seconds. YAML:
+
+```yaml
+storage:
+  type: sheets
+  sheets:
+    spreadsheet_id: "1abc..."
+    service_account: "data/sheets-service-account.json"
+    cache_ttl_seconds: 300
+```
+
+…or env (overrides YAML, last-wins):
+
+```bash
+export OFFICE_STORE=sheets
+export OFFICE_SHEETS_ID=1abc...
+export OFFICE_SHEETS_SA=/path/to/service-account.json
+```
+
+The service-account JSON is **never** placed in YAML. The repo's
+top-level `.gitignore` already protects `data/sheets-service-account.json`.
+
+### Operator setup checklist
+
+1. Create or pick a GCP project.
+2. Enable the **Google Sheets API** for that project.
+3. Create a service account; grant it no project-level IAM (only
+   per-spreadsheet ACL is needed).
+4. Generate a JSON key; save it as
+   `data/sheets-service-account.json`.
+5. Create a fresh spreadsheet, copy its ID from the URL.
+6. **Share the spreadsheet** with the service-account email
+   (`<sa>@<project>.iam.gserviceaccount.com`), role **Editor**.
+7. Wire the YAML / env config above; run
+   `office seats list` to verify.
+
+## Use
+
+```bash
+office seats list                                      # reads from Sheets
+office seats assign 5-T-01 alice@example.com           # writes a row
+office seats history 5-T-01 --json                     # reads audit-log tab
+office seats migrate --from sheets --to dynamo         # one-shot copy
+office seats sync --primary sheets                     # bi-directional reconcile
+```
+
+## How it works
+
+### Worksheet schema
+
+The store expects two tabs: **`assignments`** and **`audit-log`**.
+Both have a header row that matches the CSV column order exactly
+(see `office_cli/seats/_csv_store.py:FIELDNAMES` and
+`office_cli/seats/_audit.py:FIELDNAMES`).
+
+`assignments` columns:
+
+| Column            | Type   | Notes                                             |
+| ----------------- | ------ | ------------------------------------------------- |
+| `seat_id`         | string | `<floor>-<cluster>-<NN>` per the SVG ID contract. |
+| `floor`           | string | Matches a floor id in `data/offices.yaml`.        |
+| `employee_email`  | string | Empty for vacant seats.                           |
+| `last_updated`    | string | ISO-8601 wall-clock timestamp.                    |
+| `hidden`          | string | `TRUE` / `FALSE`.                                 |
+| `notes`           | string | Free text.                                        |
+| `effective_from`  | string | Date-only `YYYY-MM-DD` (Stage 6).                 |
+| `effective_until` | string | Date-only `YYYY-MM-DD` or empty for open-ended.   |
+
+`audit-log` columns: `timestamp, actor, action, seat_id,
+employee_email, old_employee_email, note`. Rows are append-only.
+
+### Read path
+
+1. `SheetsStore.list()` checks the in-memory cache (default 5 min).
+2. If stale: `gspread.Worksheet.get_all_values()` returns the whole
+   tab as `list[list[str]]`.
+3. Rows parse via `_rows_to_assignments` — empty / header-less rows
+   skipped.
+4. `by_email` filters in memory (no GSI). At v1 scale (~hundreds
+   of seats) this is sub-millisecond.
+
+### Write path
+
+`SheetsStore.upsert_many` is a **whole-tab replace**:
+
+1. Force-invalidate the cache (so we don't merge against a stale
+   read window).
+2. Re-read the tab (live state).
+3. Merge incoming rows into the existing dict by `seat_id`.
+4. Sort by `(floor, seat_id)`.
+5. `clear()` + `update()` the whole worksheet in two requests.
+
+The two-request shape is **not atomic** — a transport failure
+between `clear` and `update` leaves the tab empty. The TTL cache
+still holds the merged state in-process, so the next read populates
+the tab from the cache via the same upsert path. Operators who
+need stricter durability should snapshot the spreadsheet
+periodically (Sheets has built-in version history).
+
+### Audit-log shape
+
+`SheetsAuditLog.append_many` is true append:
+
+- If the tab is empty, write the header + new rows.
+- If the tab has rows, `append_rows` to the bottom.
+
+Re-running `migrate` against a Sheets target without
+`--audit-append` is **rejected** because Sheets has no primary-key
+dedup. See [sync.md](./sync.md) for the policy.
+
+### Cache TTL
+
+The cache lives in `SheetsStore._cache` + `_cache_at`. Default 5
+minutes. Reads within the window return a copy of the cached list;
+reads after the window go back to gspread. Writes always
+invalidate the cache before re-reading.
+
+A second writer hitting the same spreadsheet from a different
+process is **invisible to the first process for up to TTL seconds**.
+This is acceptable for the v1 use case (one CLI operator, one
+daemon) but operators running the daemon + the spreadsheet UI in
+parallel should know about it.
+
+### Error mapping
+
+| `gspread` error                         | `OfficeError` code             | Remediation surfaced                                       |
+| --------------------------------------- | ------------------------------ | ---------------------------------------------------------- |
+| Missing service-account file            | `EXIT_ENV_ERROR`               | "point OFFICE_SHEETS_SA at a real file"                    |
+| `gspread` import not available          | `EXIT_ENV_ERROR`               | "install the sheets extra: pip install office-cli[sheets]" |
+| API permission denied (sa not shared)   | `EXIT_ENV_ERROR` (via gspread) | gspread message — the operator usually forgot to share.    |
+| Bad YAML shape (`storage.sheets: nope`) | `EXIT_USER_ERROR`              | "must be a mapping in offices.yaml"                        |
+
+Permission errors specifically should land cleanly as
+`OfficeError`; if you see a raw gspread traceback, file a bug.
+
+## Limits + roadmap
+
+- **Whole-tab replace on writes** — fine at v1 scale; if rows grow
+  past ~10k a row-level `update` would beat the clear+update
+  pattern.
+- **No GSI / index on email** — `by_email` is a linear scan over
+  the cached list. Sub-millisecond at v1 scale.
+- **No conflict detection** — two processes writing in the same
+  TTL window can clobber each other. Mitigated by the v1 deployment
+  model (one writer at a time); sync/migrate verbs do explicit
+  read-merge-write cycles.
+- **Spreadsheet name not in config** — only the ID. If the operator
+  renames the spreadsheet that's fine; if they swap the ID
+  pointing at a fresh sheet, the old data is lost. (Sheets version
+  history is the recovery story.)
+
+## Related
+
+- [Sheets ↔ Dynamo sync](./sync.md) — keep the spreadsheet UI in
+  agreement with the Dynamo runtime.
+- [DynamoDB backend](./dynamodb.md) — the v2 production store; same
+  Protocol, different operational characteristics.
+- [Architecture stages — Stage 2](../architecture.md) — the
+  PR-by-PR record of how Sheets landed.

--- a/docs/features/slack.md
+++ b/docs/features/slack.md
@@ -1,0 +1,185 @@
+# Slack `/whereis`
+
+## What it is
+
+A Slack slash command — `/whereis @user`, `/whereis email@domain`,
+or just `/whereis` (self-lookup) — that resolves to a seat ID and
+floor. Responses are **ephemeral** (only the caller sees them) and
+honor every redaction the rest of the system does (hidden seats,
+auto-vacate, role gating, effective-date windows).
+
+It runs in **Socket Mode** so you don't need a public HTTPS
+endpoint; just the bot + app tokens.
+
+## Why
+
+The Slack call-out is the primary user surface for the v1 product
+(per [issue #1](https://github.com/agentculture/office-agent/issues/1)).
+"Where is X sitting?" is the most common ask, and it's friction-free
+to type into the Slack search bar. Building it as a slash command
+instead of a chatbot keeps the surface narrow and the privacy
+posture conservative (ephemeral by default).
+
+## Install
+
+```bash
+pip install office-cli[slack]
+```
+
+The package imports without `slack-bolt`; only `office slack-serve`
+lazy-imports it.
+
+## Configure
+
+### Slack app side
+
+In your Slack app config (<https://api.slack.com/apps>):
+
+1. **Bot scopes** (OAuth & Permissions):
+   - `commands` — to register `/whereis`.
+   - `users:read.email` — for `users.info` to return `profile.email`.
+   - `chat:write` — to post the ephemeral response.
+2. **Slash command** (Slash Commands → Create New Command):
+   - Command: `/whereis`.
+   - Short description: `Find someone's seat`.
+   - Usage hint: `[@user | email@domain]`.
+3. **Socket Mode** (Socket Mode → Enable). Generate an
+   app-level token with `connections:write` scope.
+
+### Repo side
+
+Two env vars, both secret-grade (never in YAML):
+
+```bash
+export SLACK_BOT_TOKEN=xoxb-...   # OAuth → Install App
+export SLACK_APP_TOKEN=xapp-...   # Basic Information → App-Level Tokens
+```
+
+Optional: for the deep-link button on responses, point at your web
+deployment:
+
+```bash
+export OFFICE_WEB_BASE_URL=https://office.example.com
+```
+
+When set, the Slack response includes an "Open map" button linking
+to `${OFFICE_WEB_BASE_URL}/floors/<floor>?seat=<seat>`.
+
+## Use
+
+```bash
+office slack-serve                    # blocking listener (Socket Mode)
+office slack-serve --bot-token xoxb-... --app-token xapp-...   # explicit override
+```
+
+In Slack:
+
+```text
+/whereis                                   # self-lookup
+/whereis @alice                            # mention
+/whereis alice@example.com                 # email
+/whereis @alice 2026-07-15                 # as-of trailing date (Stage 6)
+/whereis alice@example.com 2026-07-15
+/whereis 2026-07-15                        # self-lookup as-of a date
+```
+
+## How it works
+
+### Module layout
+
+| File                                      | Role                                                                      |
+| ----------------------------------------- | ------------------------------------------------------------------------- |
+| `office_cli/cli/_commands/slack_serve.py` | `office slack-serve` verb; reads tokens; constructs the bolt App.         |
+| `office_cli/slack/__init__.py`            | Re-exports `build_app`, `run_socket_mode`.                                |
+| `office_cli/slack/_app.py`                | `build_app(service, *, app, roles, data_dir)` — registers the listener.   |
+| `office_cli/slack/_resolve.py`            | Pure parser for the slash-command argument.                               |
+| `office_cli/slack/_blocks.py`             | Block Kit response builders (`occupied`, `no_seat`, `hidden_private`, …). |
+| `office_cli/slack/_serve.py`              | `run_socket_mode(app, app_token)` — blocking entry point.                 |
+
+### Argument parsing
+
+`parse_target(text) -> ParsedTarget` (in `_resolve.py`) recognizes:
+
+- `<@U123|alice>` — Slack-encoded mention. Extract user ID; resolve
+  to email via `users.info`.
+- `alice@x.com` — plain text email; used directly.
+- empty / whitespace — `self_lookup=True`; resolve caller's user
+  ID via the slash-command body.
+- A trailing `YYYY-MM-DD` token on any of the three shapes peels off
+  as the as-of date.
+
+ReDoS safety: input over 256 chars short-circuits to a parse
+failure; the email regex is split into literal-dot-separated
+segments so backtracking stays linear.
+
+### Caller-role resolution
+
+When [SSO + roles](./roles.md) is configured (`data/offices.yaml`
+has a `roles:` block), the listener:
+
+1. Calls `users.info` on the caller's `user_id` to get their email.
+2. Looks the email up in the `RolesConfig` map → `viewer` /
+   `editor` / `planning`.
+3. Passes the role into `service.whereis(email, role=...)`.
+
+Hidden seats render as `"occupied (private)"` for viewers;
+editors / planning callers see the full block. Without
+`roles_cfg`, every caller is treated as `viewer` (matches Stage
+4–6 behavior).
+
+### Response shapes
+
+Responses are always ephemeral (`chat.postEphemeral`). The Block
+Kit output has four shapes:
+
+| Shape            | Used when                                               |
+| ---------------- | ------------------------------------------------------- |
+| `parse_failed`   | The text didn't match a mention / email / date.         |
+| `lookup_failed`  | `users.info` failed or returned no email.               |
+| `no_seat`        | The target has no current assignment (or auto-vacated). |
+| `occupied`       | Full details (caller has full-access role).             |
+| `hidden_private` | Hidden seat + viewer caller — "occupied (private)".     |
+
+The plain-text fallback (`text=`) uses the same `label` the blocks
+use, **never the resolved profile email**. This prevents
+older/screen-reader clients from leaking the email when a hidden
+block is rendered.
+
+### Deep-link button
+
+When `OFFICE_WEB_BASE_URL` is set, every `occupied` response gets
+an "Open map" button pointing at
+`${BASE}/floors/<floor>?seat=<seat>`. The web server (Stage 5)
+resolves that short URL to the canonical SPA path
+`/offices/<office>/floors/<floor>` so callers don't need to know
+the office id.
+
+### Acknowledgement contract
+
+`ack()` is called immediately on receipt — Slack requires a 3s
+ACK or it retries. The slow work (`users.info`, `service.whereis`)
+runs synchronously after `ack()`; for v1's call volume this is
+fine.
+
+## Limits + roadmap
+
+- **No threaded responses / canvases** — ephemeral block, plain
+  text fallback. Future ergonomics could land in a follow-up
+  issue.
+- **No bot-message rate limit handling** — relies on Slack's
+  ephemeral path which has generous limits; if you hit them,
+  open an issue.
+- **`OFFICE_WEB_BASE_URL` is global** — multi-office deployments
+  point at one web frontend. Per-office routing would need a
+  small lookup change.
+- **No `/seats` admin verb** — `/whereis` is the only slash
+  command; mutations stay on the CLI / Sheets / Dynamo path.
+
+## Related
+
+- [Architecture stages — Stage 4](../architecture.md) — PR-by-PR
+  record of the slash command landing.
+- [SSO + roles](./roles.md) — caller-email → role mapping.
+- [Effective-date windows](./effective-dates.md) — trailing
+  `YYYY-MM-DD` token semantics.
+- [Web map](./web-map.md) — destination of the deep-link button.

--- a/docs/features/sync.md
+++ b/docs/features/sync.md
@@ -1,0 +1,212 @@
+# Sheets ↔ Dynamo sync
+
+## What it is
+
+Two CLI verbs that make the [Sheets](./sheets.md) and
+[DynamoDB](./dynamodb.md) backends interoperable rather than
+exclusive:
+
+- **`office seats migrate`** — one-shot import/export between any
+  two backends (csv / sheets / dynamo).
+- **`office seats sync`** — bi-directional reconciliation between
+  Sheets and Dynamo with last-write-wins per row by `last_updated`.
+  Idempotent — re-running converges.
+
+## Why
+
+Per the design constraint (and confirmed in
+[CHANGELOG 0.8.0](../../CHANGELOG.md#080---2026-05-01)): **Sheets
+stays a first-class runtime backend even with Dynamo on**.
+Operators who prefer the spreadsheet UI as their human editor keep
+using it; Dynamo gets the production read load. The two are kept in
+agreement by `sync`. The `migrate` verb covers one-time moves
+(bootstrap from Sheets, snapshot for offline review, etc.).
+
+This is not a bidirectional replication daemon. It's a
+reconciler operators run periodically (cron / GitHub Actions) and
+that idempotently brings both sides into agreement.
+
+## Install
+
+Both backends:
+
+```bash
+pip install office-cli[sheets,dynamo]
+```
+
+## Configure
+
+You need both backends configured at once — the verbs read source +
+target in the same call. Either both via YAML, both via env, or one
+of each. See [Sheets config](./sheets.md#configure) and
+[Dynamo config](./dynamodb.md#configure).
+
+## Use
+
+### One-shot migrate
+
+```bash
+# Bootstrap Dynamo from Sheets:
+office seats migrate --from sheets --to dynamo --dry-run   # preview
+office seats migrate --from sheets --to dynamo
+
+# Snapshot Dynamo back to Sheets for offline review:
+office seats migrate --from dynamo --to sheets --audit-append
+
+# CSV → anywhere:
+office seats migrate --from csv --to dynamo
+```
+
+`--dry-run` prints a summary diff (rows new / overwritten /
+unchanged + audit rows) without writing.
+
+### Bi-directional sync
+
+```bash
+office seats sync --primary sheets --dry-run
+office seats sync --primary sheets
+```
+
+`--primary` picks the **tie-breaker** when both sides have an
+identical `last_updated` but the content diverged (rare; happens on
+creation collisions or clock skew). It is **not** the source of
+truth — the reconciler is symmetric. The flag only matters for the
+tie case.
+
+### Cron / GitHub Action cookbook
+
+```yaml
+# .github/workflows/seats-sync.yml
+name: seats-sync
+on:
+  schedule: [{ cron: "*/15 * * * *" }]   # every 15 min
+  workflow_dispatch: {}
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv pip install -e '.[sheets,dynamo]'
+      - run: office seats sync --primary sheets --json
+        env:
+          OFFICE_SHEETS_ID: ${{ secrets.OFFICE_SHEETS_ID }}
+          OFFICE_SHEETS_SA: data/sheets-service-account.json
+          OFFICE_DYNAMO_ASSIGNMENTS: office-assignments
+          OFFICE_DYNAMO_AUDIT: office-audit-log
+          OFFICE_DYNAMO_REGION: us-east-1
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+```
+
+`--json` makes the GitHub Action log machine-parseable so a
+follow-up step can fail the run if `ties` is non-empty.
+
+## How it works
+
+### Module layout
+
+| File                                  | Role                                   |
+| ------------------------------------- | -------------------------------------- |
+| `office_cli/cli/_commands/migrate.py` | `office seats migrate` verb.           |
+| `office_cli/cli/_commands/sync.py`    | `office seats sync` verb.              |
+| `office_cli/seats/_sync.py`           | Pure `reconcile()` reconciler. No I/O. |
+
+### Migrate verb
+
+Source and target are built from the same factory
+(`build_backends_for_type(data_dir, store_type)`), which threads
+the type override directly into `resolve_storage` — no environment
+mutation.
+
+The flow:
+
+1. Read all assignments + audit entries from source.
+2. Compute the diff against target (for the dry-run summary).
+3. If the target is csv/sheets and its audit log is non-empty,
+   bail out with a clear `OfficeError` unless the operator passed
+   `--audit-append`. Sheets has no PK dedup, so a re-run would
+   duplicate audit rows.
+4. `target.upsert_many(assignments)` — idempotent by `seat_id`.
+5. `target.audit.append_many(audit_entries)` — idempotent if
+   target is Dynamo (PK + composite SK dedups), append-only
+   otherwise.
+
+### Sync verb
+
+The reconciler in `_sync.py` is pure (no I/O). It takes left +
+right snapshots and returns a `SyncPlan`:
+
+```python
+@dataclass(frozen=True)
+class SyncPlan:
+    write_left: list[Assignment]   # rows to push to the left side
+    write_right: list[Assignment]  # rows to push to the right side
+    audit_left: list[AuditEntry]   # audit rows to append left
+    audit_right: list[AuditEntry]  # audit rows to append right
+    ties: list[str]                # seat IDs that hit the tie-breaker
+```
+
+Per-row policy:
+
+| Row state                                       | Action                                           |
+| ----------------------------------------------- | ------------------------------------------------ |
+| Only on left                                    | Copy to right.                                   |
+| Only on right                                   | Copy to left.                                    |
+| On both, identical content                      | No-op.                                           |
+| On both, `last_updated` differs                 | Keep the side with the newer `last_updated`.     |
+| On both, `last_updated` ties + content diverged | `ties.append(seat_id)`; tie-breaker = `primary`. |
+
+Audit entries union into both sides, deduped by
+`(seat_id, timestamp, action, employee_email)`. Dynamo's composite
+SK dedups naturally on its side; the Sheets side does the in-memory
+diff before append.
+
+The `redacted` flag on `Assignment` is **excluded** from the
+content equality check — it's a view-time flag from
+[Stage 7](./roles.md), never persisted, so identical rows fetched
+under different roles still compare equal.
+
+### Idempotency
+
+`reconcile()` is referentially transparent — same inputs, same
+plan. After applying the plan, both sides agree, and a re-run
+yields an empty plan. Test
+`tests/test_seats_sync.py::test_idempotent_repeated_run` locks
+this in.
+
+### Mapping primary to left/right
+
+The reconciler is named left/right (surface-neutral). The CLI
+maps:
+
+```python
+primary="left"  if args.primary == "sheets" else "right"
+```
+
+Sheets is the left side by convention. Tie-breaker comments and
+test fixtures use the same convention.
+
+## Limits + roadmap
+
+- **No always-on daemon** — `sync` is a one-shot reconciler.
+  Operators run it via cron / GitHub Action. An always-on daemon
+  could subscribe to DynamoDB Streams + Sheets webhook, but is
+  Stage-9+.
+- **No three-way merge** — content collisions on identical
+  `last_updated` resolve via `--primary`. A real CRDT-shaped
+  resolution would require an audit-log-driven causal history;
+  out of scope.
+- **No row-level dry-run diff** — `--dry-run` prints aggregated
+  counts. A `--verbose` mode that lists the actual seat IDs
+  would be a small ergonomic add.
+- **`migrate --to sheets` audit append not idempotent** — Sheets
+  has no PK dedup, so re-running on a non-empty audit tab would
+  duplicate. Documented; the verb refuses unless
+  `--audit-append` is passed.
+
+## Related
+
+- [Sheets backend](./sheets.md)
+- [DynamoDB backend](./dynamodb.md)
+- [Architecture stages — Stage 8](../architecture.md) — PR-by-PR
+  record.

--- a/docs/features/web-map.md
+++ b/docs/features/web-map.md
@@ -1,0 +1,169 @@
+# Search-first web map
+
+## What it is
+
+A FastAPI server (`office serve`) that hosts a vanilla-JS
+single-page app rendering the floor SVGs and the seat assignments
+on top. Search is the primary interaction — type a name / seat ID
+/ cluster letter and the matching seats highlight on the map. URLs
+are deep-linkable: `/offices/<office>/floors/<floor>?seat=5-T-01`
+takes you straight to the highlighted seat.
+
+The frontend is **no-build**. Plain HTML + ES module + CSS, served
+as-is by the FastAPI `StaticFiles` mount. Fuse.js (vendored) does
+the fuzzy search.
+
+## Why
+
+Slack `/whereis` covers the 95% case (one-off lookup), but humans
+also want to skim the map — "who sits in cluster T?", "is that
+window seat free?". The web map is a secondary surface tuned for
+that browsing flow. Search-first means it never replaces the Sheet
+or the Slack command — they each own their UX niche.
+
+The no-build choice is deliberate (Stage 5): it keeps the repo
+free of npm tooling and means the frontend is auditable as plain
+text. Trade-off: no TypeScript, no module bundler. At the size of
+this app (~500 LOC of JS) the trade-off pays off.
+
+## Install
+
+```bash
+pip install office-cli[web]
+```
+
+The package imports without `fastapi` / `uvicorn`; only `office
+serve` lazy-imports them. Optional `[sso]` extras layer on top —
+see [Roles](./roles.md).
+
+## Configure
+
+The web layer reads through the same `data/offices.yaml` as the
+CLI; no extra config required for the basic map. SSO is
+opt-in via env (see [Roles](./roles.md)).
+
+```bash
+office serve                                       # localhost:8000
+office serve --host 0.0.0.0 --port 8080 --data-dir data
+office serve --port 0                              # OS-picked port (handy for tests)
+```
+
+Behind a reverse proxy with TLS termination on the proxy side, set
+`OIDC_COOKIE_SECURE=false` so the session cookie isn't dropped on
+the HTTP backplane.
+
+## Use
+
+```bash
+office serve --port 8000 &
+open http://127.0.0.1:8000/                         # redirects to first floor
+open http://127.0.0.1:8000/offices/tlv/floors/tlv-floor-5
+open "http://127.0.0.1:8000/offices/tlv/floors/tlv-floor-5?seat=5-T-01"
+open "http://127.0.0.1:8000/offices/tlv/floors/tlv-floor-5?asOf=2026-07-15"
+```
+
+Search box accepts seat IDs, emails, cluster letters, floor IDs,
+or fragments. Click a result → the SVG highlights it + the URL
+updates. Keyboard: `Enter` / `Space` on a focused result selects
+it; `popstate` (browser back/forward) syncs.
+
+## How it works
+
+### Module layout
+
+| File                                      | Role                                                          |
+| ----------------------------------------- | ------------------------------------------------------------- |
+| `office_cli/cli/_commands/serve.py`       | `office serve` verb; lazy fastapi import; uvicorn.run.        |
+| `office_cli/server/__init__.py`           | Re-exports `build_app`, `run_server`.                         |
+| `office_cli/server/_app.py`               | `build_app(service, *, data_dir, oidc, roles)`.               |
+| `office_cli/server/_routes.py`            | API + SPA shell + redirect routes.                            |
+| `office_cli/server/_auth.py`              | OIDC + SessionMiddleware (Stage 7 — see [Roles](./roles.md)). |
+| `office_cli/server/_serve.py`             | `run_server(app, host, port)` — lazy uvicorn.run.             |
+| `office_cli/server/static/index.html`     | SPA shell (`<header>` / `<main>` / `<aside>`).                |
+| `office_cli/server/static/app.js`         | Vanilla ES module: fetch + render + search + URL state.       |
+| `office_cli/server/static/app.css`        | Map + sidebar + responsive layout.                            |
+| `office_cli/server/static/vendor/fuse.js` | Vendored Fuse.js for fuzzy search.                            |
+
+### Endpoints
+
+| Endpoint                            | Returns                                                                                                       |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `GET /api/offices`                  | All offices + floors with `id` + `status`.                                                                    |
+| `GET /api/floors/{id}?as_of=&asOf=` | Merged seat list (auto-vacated, redacted, date-filtered) + `svg_url` + `user`.                                |
+| `GET /svgs/{name}.svg`              | Static-mount of the operator-traced floor SVG.                                                                |
+| `GET /static/...`                   | Static-mount of `office_cli/server/static/`.                                                                  |
+| `GET /`                             | 302 to the first office's first floor.                                                                        |
+| `GET /floors/{id}?seat=...`         | 307 to `/offices/<office>/floors/<id>?seat=…` (Slack deep-link entry).                                        |
+| `GET /offices/{office}/floors/{id}` | SPA shell (HTML). Validates office+floor pair, redirects to `/auth/login` if SSO enabled and unauthenticated. |
+
+### Hidden-seat redaction
+
+Stage 7 moved the redaction policy into the **service layer** —
+when called with `role="viewer"`, `SeatService` clears
+`employee_email` and `notes` on `hidden=TRUE` rows and sets
+`redacted=True` on the `Assignment`. The web's `_redact()` helper
+maps the view-time state to the JSON shape:
+
+| Service state               | API JSON                                                      |
+| --------------------------- | ------------------------------------------------------------- |
+| `redacted=True`             | `employee_email: "(private)"`, `notes: ""`, `redacted: true`. |
+| `hidden=True`, not redacted | Pass-through (editor / planning view).                        |
+| `hidden=False`              | Pass-through.                                                 |
+
+The frontend uses the `redacted` flag (not `hidden`) to decide
+whether to render `"(private)"` vs `"(vacant)"`.
+
+### URL state
+
+The SPA reads `globalThis.location` on load and on `popstate`. The
+URL is **canonical state** — `app.js` syncs UI ↔ URL via
+`history.pushState`. Three URL params:
+
+- `?seat=<seat_id>` — highlight + scroll to seat. Round-trips
+  through the SSO redirect path (the redirect URL-encodes the
+  full `next`).
+- `?asOf=<YYYY-MM-DD>` — render the map as of that date. Also
+  accepted server-side as `?as_of=` for direct API callers.
+- (Path) `/offices/<id>/floors/<id>` — the active floor.
+
+### XSS posture
+
+API-derived strings land in the DOM via `createElement` +
+`textContent`. The SVG (operator-supplied) is parsed via
+`DOMParser` and **sanitized** before insertion: `<script>` and
+`<foreignObject>` elements are stripped, `on*` attributes
+removed, `href="javascript:…"` cleared. Path-tainted fetches use
+per-endpoint helpers with hardcoded URL prefixes + regex-validated
+tokens; URLs are never built from a generic `path` string.
+
+### Search
+
+Fuse.js indexes `seat_id`, `employee_email`, `cluster`, `floor`.
+Threshold 0.35, ignoreLocation. Debounced 150 ms. Query → top 50
+results in the sidebar.
+
+## Limits + roadmap
+
+- **No editor in the SPA.** Sheets / DynamoDB are the editors; the
+  web is read-only. Editor mode could land later but isn't a v1
+  goal.
+- **No native mobile app.** The CSS is responsive (sidebar
+  collapses below 800 px); a native app is out of scope.
+- **Hot-desk / desk booking UI is out of v1.**
+- **No multi-floor view.** One floor per page; switch via the
+  picker. The deep-link button on Slack lands you on the right
+  floor automatically.
+- **No real-time updates.** Reads are TTL-cached on the backend;
+  the SPA refetches on floor switch / asOf change. WebSocket-driven
+  live updates would land Stage-9+ if the use case shows up.
+
+## Related
+
+- [Architecture stages — Stage 5](../architecture.md) — PR-by-PR
+  record.
+- [SSO + roles](./roles.md) — how the SPA shell decides whether to
+  redirect anonymous browsers.
+- [Effective-date windows](./effective-dates.md) — `?asOf=` URL
+  semantics.
+- [Slack `/whereis`](./slack.md) — source of the deep-link
+  button that lands on this map.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.8.0"
+version = "0.8.1"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Adds top-level `CONTRIBUTING.md` — fork-first OSS workflow, dev loop, conventions, in/out of scope.
- Adds `docs/features/` index plus deep-dive pages for: CLI, BambooHR directory, Slack `/whereis`, search-first web map, effective dates, roles + SSO, Sheets backend, DynamoDB backend, and bi-directional sync.
- Bumps version to 0.8.1 and updates `CHANGELOG.md`.

No code changes — docs only.

## Test plan

- [x] `markdownlint-cli2` clean on all new/changed `.md` files.
- [x] Tables aligned via `align-md-tables.py`.
- [x] `version-check` CI job (per-PR version bump enforced).

Generated with Claude Code