### PR TITLE
chore: gate BambooHR backend behind OFFICE_BAMBOOHR_ENABLED (default off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-05-03
+
+### Changed
+
+- Gate BambooHR directory backend behind `OFFICE_BAMBOOHR_ENABLED` env
+  flag (default off). Existing `directory.type: bamboohr` configuration
+  silently falls back to the stub directory with a stderr warning until
+  the flag is set. All BambooHR code, tests, and the `[bamboohr]` extra
+  remain in place — opt in with `OFFICE_BAMBOOHR_ENABLED=1`.
+
 ## [Unreleased]
 
 ## [0.8.1] - 2026-05-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,7 +314,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   preserving the SVG ID contract and architectural guardrails for the v1
   seating system (issue #1).
 
-[Unreleased]: https://github.com/agentculture/office-agent/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/agentculture/office-agent/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/agentculture/office-agent/compare/v0.8.1...v0.9.0
+[0.8.1]: https://github.com/agentculture/office-agent/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/agentculture/office-agent/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/agentculture/office-agent/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/agentculture/office-agent/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -87,10 +87,16 @@ Reads honor a 5-minute TTL cache; writes invalidate it. See
 
 `office` defaults to a no-op `StubDirectory` that trusts whatever email
 it receives. Switch to BambooHR for the auto-vacate killer feature
-(seats render as vacant automatically when an employee is offboarded):
+(seats render as vacant automatically when an employee is offboarded).
+
+> **Note:** the BambooHR backend is gated off by default. Set
+> `OFFICE_BAMBOOHR_ENABLED=1` in addition to the config below; without
+> it, even valid BambooHR settings silently fall back to the stub
+> directory (with a one-line warning to stderr).
 
 ```bash
 pip install office-cli[bamboohr]
+export OFFICE_BAMBOOHR_ENABLED=1   # required: opt in to the gated feature
 export OFFICE_DIRECTORY=bamboohr
 export BAMBOOHR_SUBDOMAIN=tipalti
 export BAMBOOHR_API_TOKEN=...   # env-only — do not commit

--- a/docs/features/bamboohr.md
+++ b/docs/features/bamboohr.md
@@ -1,5 +1,13 @@
 # BambooHR + auto-vacate
 
+> **Status: gated off by default.** The BambooHR backend is wired
+> end-to-end but disabled at runtime. Even when `directory.type: bamboohr`
+> is set in `offices.yaml` or `OFFICE_DIRECTORY=bamboohr` is exported,
+> the seat service falls back to the `stub` directory and prints a
+> one-line warning to stderr unless `OFFICE_BAMBOOHR_ENABLED=1` is set.
+> All code, configuration plumbing, and tests below remain functional —
+> opt in with the env flag to re-enable.
+
 ## What it is
 
 A BambooHR-backed `EmployeeDirectory` that powers the system's
@@ -47,14 +55,19 @@ directory:
 ```
 
 …and set the API token as an env var (it's a secret — **never**
-in YAML):
+in YAML). You also need to flip the runtime gate:
 
 ```bash
+export OFFICE_BAMBOOHR_ENABLED=1   # required: opt in to the gated feature
 export BAMBOOHR_API_TOKEN=...
 # Optional env overrides:
 export OFFICE_DIRECTORY=bamboohr
 export BAMBOOHR_SUBDOMAIN=tipalti
 ```
+
+Without `OFFICE_BAMBOOHR_ENABLED=1`, the service silently uses the stub
+directory and emits a single `warning: BambooHR backend is gated off …`
+line to stderr.
 
 `cache_ttl_seconds` is capped at 300 (5 minutes) so an offboard
 event can't sit stale for more than that. The cap is enforced in

--- a/office_cli/_config.py
+++ b/office_cli/_config.py
@@ -28,13 +28,13 @@ from __future__ import annotations
 
 import argparse
 import os
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
 
 from office_cli.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, OfficeError
+from office_cli.cli._output import emit_diagnostic
 
 _SHAPE_HINT = "see docs/architecture.md for the expected shape"
 _BAMBOOHR_TTL_MAX_SECONDS = 300
@@ -42,11 +42,24 @@ _PREFIX_SHEETS = "storage.sheets"
 _PREFIX_DYNAMO = "storage.dynamo"
 _PREFIX_BAMBOOHR = "directory.bamboohr"
 _BAMBOOHR_GATE_ENV = "OFFICE_BAMBOOHR_ENABLED"
-_TRUTHY = {"1", "true", "yes", "on"}
+_GATE_TRUTHY = {"1", "true", "yes", "on"}
+_GATE_FALSY = {"", "0", "false", "no", "off"}
 
 
 def _bamboohr_gate_enabled() -> bool:
-    return os.environ.get(_BAMBOOHR_GATE_ENV, "").strip().lower() in _TRUTHY
+    raw = os.environ.get(_BAMBOOHR_GATE_ENV, "").strip().lower()
+    if raw in _GATE_TRUTHY:
+        return True
+    if raw in _GATE_FALSY:
+        return False
+    raise OfficeError(
+        code=EXIT_USER_ERROR,
+        message=f"unrecognized value for {_BAMBOOHR_GATE_ENV}: {raw!r}",
+        remediation=(
+            f"set {_BAMBOOHR_GATE_ENV} to one of 1/true/yes/on (enable) "
+            "or 0/false/no/off (disable), or unset it"
+        ),
+    )
 
 
 def resolve_data_dir(args: argparse.Namespace | None = None) -> Path:
@@ -349,11 +362,10 @@ def resolve_directory(data_dir: Path) -> DirectoryConfig:
         )
 
     if not _bamboohr_gate_enabled():
-        print(
+        emit_diagnostic(
             "warning: BambooHR backend is gated off "
             f"(set {_BAMBOOHR_GATE_ENV}=1 to enable); "
-            "falling back to stub directory",
-            file=sys.stderr,
+            "falling back to stub directory"
         )
         return DirectoryConfig(type="stub")
 

--- a/office_cli/_config.py
+++ b/office_cli/_config.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -40,6 +41,12 @@ _BAMBOOHR_TTL_MAX_SECONDS = 300
 _PREFIX_SHEETS = "storage.sheets"
 _PREFIX_DYNAMO = "storage.dynamo"
 _PREFIX_BAMBOOHR = "directory.bamboohr"
+_BAMBOOHR_GATE_ENV = "OFFICE_BAMBOOHR_ENABLED"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _bamboohr_gate_enabled() -> bool:
+    return os.environ.get(_BAMBOOHR_GATE_ENV, "").strip().lower() in _TRUTHY
 
 
 def resolve_data_dir(args: argparse.Namespace | None = None) -> Path:
@@ -340,6 +347,15 @@ def resolve_directory(data_dir: Path) -> DirectoryConfig:
                 "set directory.type to 'stub' or 'bamboohr' in offices.yaml or OFFICE_DIRECTORY"
             ),
         )
+
+    if not _bamboohr_gate_enabled():
+        print(
+            "warning: BambooHR backend is gated off "
+            f"(set {_BAMBOOHR_GATE_ENV}=1 to enable); "
+            "falling back to stub directory",
+            file=sys.stderr,
+        )
+        return DirectoryConfig(type="stub")
 
     bamboo_cfg = yaml_cfg.get("bamboohr")
     if bamboo_cfg is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.8.1"
+version = "0.9.0"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_seats.py
+++ b/tests/test_cli_seats.py
@@ -120,3 +120,23 @@ def test_list_rejects_malformed_as_of(data_dir: Path, capsys: pytest.CaptureFixt
     rc = main(["seats", "list", "--as-of", "tomorrow", *_data(data_dir)])
     assert rc == 1
     assert "--as-of" in capsys.readouterr().err
+
+
+def test_bamboohr_gate_off_keeps_stdout_clean(
+    data_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Selecting bamboohr without the gate flag must (a) emit the
+    'gated off' warning to stderr and (b) leave stdout JSON parseable
+    (Copilot review on PR #24)."""
+    monkeypatch.delenv("OFFICE_BAMBOOHR_ENABLED", raising=False)
+    monkeypatch.setenv("OFFICE_DIRECTORY", "bamboohr")
+    monkeypatch.setenv("BAMBOOHR_SUBDOMAIN", "tipalti")
+    monkeypatch.setenv("BAMBOOHR_API_TOKEN", "fake")
+    rc = main(["seats", "list", "--json", *_data(data_dir)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "BambooHR backend is gated off" in captured.err
+    payload = json.loads(captured.out)
+    assert "seats" in payload

--- a/tests/test_directory_config.py
+++ b/tests/test_directory_config.py
@@ -186,7 +186,7 @@ def test_bamboohr_gate_truthy_values(
     assert cfg.type == "bamboohr"
 
 
-@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off"])
 def test_bamboohr_gate_falsy_values(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, value: str
 ) -> None:
@@ -196,3 +196,19 @@ def test_bamboohr_gate_falsy_values(
     monkeypatch.setenv("BAMBOOHR_API_TOKEN", "tok")
     cfg = resolve_directory(tmp_path)
     assert cfg.type == "stub"
+
+
+@pytest.mark.parametrize("value", ["ture", "maybe", "enabled", "2"])
+def test_bamboohr_gate_unrecognized_value_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """Typos like 'ture' must fail loudly so operators don't silently
+    lose auto-vacate (Copilot review on PR #24)."""
+    monkeypatch.setenv("OFFICE_BAMBOOHR_ENABLED", value)
+    monkeypatch.setenv("OFFICE_DIRECTORY", "bamboohr")
+    monkeypatch.setenv("BAMBOOHR_SUBDOMAIN", "x")
+    monkeypatch.setenv("BAMBOOHR_API_TOKEN", "tok")
+    with pytest.raises(OfficeError) as exc:
+        resolve_directory(tmp_path)
+    assert "unrecognized value for OFFICE_BAMBOOHR_ENABLED" in exc.value.message
+    assert value in exc.value.message

--- a/tests/test_directory_config.py
+++ b/tests/test_directory_config.py
@@ -37,6 +37,7 @@ directory:
     cache_ttl_seconds: 60
 """.lstrip(),
     )
+    monkeypatch.setenv("OFFICE_BAMBOOHR_ENABLED", "1")
     monkeypatch.setenv("BAMBOOHR_API_TOKEN", "token-xyz")
     monkeypatch.delenv("BAMBOOHR_SUBDOMAIN", raising=False)
     cfg = resolve_directory(tmp_path)
@@ -48,6 +49,7 @@ directory:
 
 def test_env_overrides_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _write(tmp_path, "directory:\n  type: stub\n")
+    monkeypatch.setenv("OFFICE_BAMBOOHR_ENABLED", "1")
     monkeypatch.setenv("OFFICE_DIRECTORY", "bamboohr")
     monkeypatch.setenv("BAMBOOHR_SUBDOMAIN", "from-env")
     monkeypatch.setenv("BAMBOOHR_API_TOKEN", "tok")
@@ -57,6 +59,7 @@ def test_env_overrides_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_bamboohr_requires_subdomain(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_BAMBOOHR_ENABLED", "1")
     monkeypatch.setenv("OFFICE_DIRECTORY", "bamboohr")
     monkeypatch.setenv("BAMBOOHR_API_TOKEN", "tok")
     monkeypatch.delenv("BAMBOOHR_SUBDOMAIN", raising=False)
@@ -66,6 +69,7 @@ def test_bamboohr_requires_subdomain(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
 
 def test_bamboohr_requires_api_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_BAMBOOHR_ENABLED", "1")
     monkeypatch.setenv("OFFICE_DIRECTORY", "bamboohr")
     monkeypatch.setenv("BAMBOOHR_SUBDOMAIN", "x")
     monkeypatch.delenv("BAMBOOHR_API_TOKEN", raising=False)
@@ -94,6 +98,7 @@ directory:
     cache_ttl_seconds: 600
 """.lstrip(),
     )
+    monkeypatch.setenv("OFFICE_BAMBOOHR_ENABLED", "1")
     monkeypatch.setenv("BAMBOOHR_API_TOKEN", "tok")
     with pytest.raises(OfficeError) as exc:
         resolve_directory(tmp_path)
@@ -116,14 +121,78 @@ directory:
     cache_ttl_seconds: not-a-number
 """.lstrip(),
     )
+    monkeypatch.setenv("OFFICE_BAMBOOHR_ENABLED", "1")
     monkeypatch.setenv("BAMBOOHR_API_TOKEN", "tok")
     with pytest.raises(OfficeError) as exc:
         resolve_directory(tmp_path)
     assert "directory.bamboohr.cache_ttl_seconds" in exc.value.message
 
 
-def test_non_dict_bamboohr_block_rejected(tmp_path: Path) -> None:
+def test_non_dict_bamboohr_block_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_BAMBOOHR_ENABLED", "1")
     _write(tmp_path, "directory:\n  type: bamboohr\n  bamboohr: nope\n")
     with pytest.raises(OfficeError) as exc:
         resolve_directory(tmp_path)
     assert "must be a mapping" in exc.value.message
+
+
+def test_bamboohr_gated_off_falls_back_to_stub(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Without OFFICE_BAMBOOHR_ENABLED, bamboohr config silently falls
+    back to stub and emits a single warning to stderr."""
+    _write(
+        tmp_path,
+        """
+directory:
+  type: bamboohr
+  bamboohr:
+    subdomain: tipalti
+""".lstrip(),
+    )
+    monkeypatch.delenv("OFFICE_BAMBOOHR_ENABLED", raising=False)
+    monkeypatch.setenv("BAMBOOHR_API_TOKEN", "tok")
+    cfg = resolve_directory(tmp_path)
+    assert cfg.type == "stub"
+    captured = capsys.readouterr()
+    assert "BambooHR backend is gated off" in captured.err
+    assert "OFFICE_BAMBOOHR_ENABLED=1" in captured.err
+
+
+def test_bamboohr_gate_unset_no_creds_does_not_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Misconfigured BambooHR (selected but no creds) must not raise
+    when the gate is off — the whole branch is skipped."""
+    monkeypatch.delenv("OFFICE_BAMBOOHR_ENABLED", raising=False)
+    monkeypatch.setenv("OFFICE_DIRECTORY", "bamboohr")
+    monkeypatch.delenv("BAMBOOHR_SUBDOMAIN", raising=False)
+    monkeypatch.delenv("BAMBOOHR_API_TOKEN", raising=False)
+    cfg = resolve_directory(tmp_path)
+    assert cfg.type == "stub"
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "Yes", "on"])
+def test_bamboohr_gate_truthy_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("OFFICE_BAMBOOHR_ENABLED", value)
+    monkeypatch.setenv("OFFICE_DIRECTORY", "bamboohr")
+    monkeypatch.setenv("BAMBOOHR_SUBDOMAIN", "x")
+    monkeypatch.setenv("BAMBOOHR_API_TOKEN", "tok")
+    cfg = resolve_directory(tmp_path)
+    assert cfg.type == "bamboohr"
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+def test_bamboohr_gate_falsy_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("OFFICE_BAMBOOHR_ENABLED", value)
+    monkeypatch.setenv("OFFICE_DIRECTORY", "bamboohr")
+    monkeypatch.setenv("BAMBOOHR_SUBDOMAIN", "x")
+    monkeypatch.setenv("BAMBOOHR_API_TOKEN", "tok")
+    cfg = resolve_directory(tmp_path)
+    assert cfg.type == "stub"

--- a/uv.lock
+++ b/uv.lock
@@ -640,7 +640,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- Gate the BambooHR directory backend behind a new `OFFICE_BAMBOOHR_ENABLED`
  env flag (accepts `1`/`true`/`yes`/`on`). Default is **off** — even with
  `directory.type: bamboohr` in `offices.yaml` or `OFFICE_DIRECTORY=bamboohr`
  in the environment, `resolve_directory()` short-circuits to the stub
  directory and prints a one-line stderr warning.
- Strict subdomain/token/TTL validation now lives behind the gate, so
  misconfigured BambooHR settings stop raising when the feature is off.
- All BambooHR code, the `[bamboohr]` optional extra, and existing tests
  in `test_bamboohr_directory.py` / `test_seats_service_autovacate.py`
  stay in place. Opt back in with `OFFICE_BAMBOOHR_ENABLED=1`.

## Test plan

- [x] `uv run pytest -n auto` — 294 passed (added gate-off, gate-truthy,
      gate-falsy, no-creds-with-gate-off tests; existing bamboohr tests
      now set the flag)
- [x] `uv run black --check`, `isort --check-only`, `flake8`, `bandit -r office_cli`
      — clean
- [x] `markdownlint-cli2 docs/features/bamboohr.md README.md CHANGELOG.md` — clean
- [x] `steward doctor . --scope self` — clean
- [x] Manual CLI smoke (`office seats list --data-dir tests/fixtures`):
  - Gate off + `OFFICE_DIRECTORY=bamboohr` + token → emits warning to stderr,
    falls back to stub, listing succeeds.
  - Gate on + missing creds → expected `directory.type=bamboohr requires a subdomain` error.
  - Default (no flag, no env) → unchanged stub behavior.

Generated with Claude Code