### PR TITLE
fix(sheets): migrate writes one row per SVG seat (Sheets-as-CMS UX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- `office seats migrate` now writes one row per SVG seat — vacant rows
-  for never-assigned seats — so the target backend mirrors the full
-  seat universe declared in `data/offices.yaml` + `floors/*.svg`. The
-  previous behavior wrote only "touched" rows, leaving the Google Sheet
-  sparse (3 of 9 seats in the smoke-test fixture) and undercutting the
-  Sheets-as-CMS architectural promise in `CLAUDE.md`. Rows in the source
-  store that don't correspond to any SVG seat (orphans) survive the
-  migration but are now surfaced separately on stderr and in the JSON
-  summary's `assignments_orphans` field.
+- `office seats migrate` now writes one row per assignable seat-or-room
+  declared by the office topology — vacant rows for never-assigned
+  ids — so the target backend mirrors the full universe (union of SVG
+  `seat_ids`, SVG `room_ids`, and YAML-declared rooms; matches
+  `SeatService._build_seat_index`). The previous behavior wrote only
+  "touched" rows, leaving the Google Sheet sparse and undercutting the
+  Sheets-as-CMS architectural promise in `CLAUDE.md`. Two flavors of
+  orphan are surfaced separately: **source orphans** (rows in source
+  not in any SVG/YAML — kept, never deleted) and **target orphans**
+  (rows in target neither in source nor in the universe — kept, never
+  deleted, but now flagged so dry-run no longer reports a falsely
+  "all unchanged" status while the target diverges from the universe).
+  Both surface on stderr and in the JSON summary as
+  `assignments_orphans` / `assignments_target_orphans`.
   ([#33](https://github.com/agentculture/office-agent/issues/33))
 
 ## [0.9.2] - 2026-05-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - 2026-05-05
+
+### Fixed
+
+- `office seats migrate` now writes one row per SVG seat — vacant rows
+  for never-assigned seats — so the target backend mirrors the full
+  seat universe declared in `data/offices.yaml` + `floors/*.svg`. The
+  previous behavior wrote only "touched" rows, leaving the Google Sheet
+  sparse (3 of 9 seats in the smoke-test fixture) and undercutting the
+  Sheets-as-CMS architectural promise in `CLAUDE.md`. Rows in the source
+  store that don't correspond to any SVG seat (orphans) survive the
+  migration but are now surfaced separately on stderr and in the JSON
+  summary's `assignments_orphans` field.
+  ([#33](https://github.com/agentculture/office-agent/issues/33))
+
 ## [0.9.2] - 2026-05-05
 
 ### Added

--- a/office_cli/cli/_commands/migrate.py
+++ b/office_cli/cli/_commands/migrate.py
@@ -19,15 +19,26 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from typing import Iterator
 
 from office_cli._config import add_data_dir_arg, resolve_data_dir
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 from office_cli.cli._output import emit_diagnostic, emit_result
 from office_cli.floors import parse_svg
-from office_cli.offices import load_offices
+from office_cli.offices import Floor, load_offices
 from office_cli.seats import Assignment, build_backends_for_type
 
 _VALID_TYPES = ("csv", "sheets", "dynamo")
+
+
+def _floor_assignable_ids(floor: Floor) -> Iterator[str]:
+    """Every assignable id declared by a single floor: SVG ``seat_ids``,
+    SVG ``room_ids``, and YAML-declared rooms (in that order)."""
+    if floor.svg.is_file():
+        svg = parse_svg(floor.svg)
+        yield from svg.seat_ids
+        yield from svg.room_ids
+    yield from floor.rooms
 
 
 def _load_all_assignable_ids(data_dir: Path) -> list[tuple[str, str]]:
@@ -40,18 +51,10 @@ def _load_all_assignable_ids(data_dir: Path) -> list[tuple[str, str]]:
     seen: set[str] = set()
     for office in load_offices(data_dir).values():
         for floor_id, floor in office.floors.items():
-            if floor.svg.is_file():
-                svg = parse_svg(floor.svg)
-                for sid in (*svg.seat_ids, *svg.room_ids):
-                    if sid not in seen:
-                        seen.add(sid)
-                        out.append((sid, floor_id))
-            # Rooms declared in YAML even without an SVG entry are still
-            # assignable.
-            for rid in floor.rooms:
-                if rid not in seen:
-                    seen.add(rid)
-                    out.append((rid, floor_id))
+            for sid in _floor_assignable_ids(floor):
+                if sid not in seen:
+                    seen.add(sid)
+                    out.append((sid, floor_id))
     return out
 
 

--- a/office_cli/cli/_commands/migrate.py
+++ b/office_cli/cli/_commands/migrate.py
@@ -18,13 +18,30 @@ Idempotency:
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 from office_cli._config import add_data_dir_arg, resolve_data_dir
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 from office_cli.cli._output import emit_diagnostic, emit_result
-from office_cli.seats import build_backends_for_type
+from office_cli.floors import parse_svg
+from office_cli.offices import load_offices
+from office_cli.seats import Assignment, build_backends_for_type
 
 _VALID_TYPES = ("csv", "sheets", "dynamo")
+
+
+def _load_all_svg_seats(data_dir: Path) -> list[tuple[str, str]]:
+    """Return ``[(seat_id, floor_id), ...]`` across every floor declared in
+    ``data/offices.yaml``. Mirrors the iteration in
+    :func:`office_cli.seats.build_service` so migrate can pad its output
+    with vacant rows for SVG seats the source store doesn't know about."""
+    out: list[tuple[str, str]] = []
+    for office in load_offices(data_dir).values():
+        for floor_id, floor in office.floors.items():
+            if floor.svg.is_file():
+                for seat_id in parse_svg(floor.svg).seat_ids:
+                    out.append((seat_id, floor_id))
+    return out
 
 
 def cmd_migrate(args: argparse.Namespace) -> int:
@@ -44,12 +61,26 @@ def cmd_migrate(args: argparse.Namespace) -> int:
     src_assignments = src_store.list()
     src_audit_entries = src_audit.all()
 
-    tgt_existing = {a.seat_id: a for a in tgt_store.list()}
-    new = [a for a in src_assignments if a.seat_id not in tgt_existing]
-    overwritten = [
-        a for a in src_assignments if a.seat_id in tgt_existing and tgt_existing[a.seat_id] != a
+    # Pad the source list with vacant rows for every SVG seat the source
+    # store doesn't already know about. This makes the target backend a
+    # complete view of the seat universe — important for Sheets-as-CMS,
+    # where HR/facilities need to see vacant seats to assign people. Rows
+    # in the source that aren't in any SVG (orphans — someone removed a
+    # seat from the SVG without cleaning the store) survive the migration
+    # but get reported separately so an operator can act.
+    svg_seats = _load_all_svg_seats(data_dir)
+    svg_seat_ids = {sid for sid, _ in svg_seats}
+    src_seat_ids = {a.seat_id for a in src_assignments}
+    padding = [
+        Assignment(seat_id=sid, floor=fid) for sid, fid in svg_seats if sid not in src_seat_ids
     ]
-    unchanged = len(src_assignments) - len(new) - len(overwritten)
+    orphans = [a for a in src_assignments if a.seat_id not in svg_seat_ids]
+    padded = list(src_assignments) + padding
+
+    tgt_existing = {a.seat_id: a for a in tgt_store.list()}
+    new = [a for a in padded if a.seat_id not in tgt_existing]
+    overwritten = [a for a in padded if a.seat_id in tgt_existing and tgt_existing[a.seat_id] != a]
+    unchanged = len(padded) - len(new) - len(overwritten)
 
     audit_target_size = len(tgt_audit.all())
     if (
@@ -70,11 +101,18 @@ def cmd_migrate(args: argparse.Namespace) -> int:
             ),
         )
 
+    if orphans:
+        emit_diagnostic(
+            f"orphans: {len(orphans)} row(s) in source not present in any SVG: "
+            f"{', '.join(sorted(o.seat_id for o in orphans))}"
+        )
+
     if args.dry_run:
         emit_diagnostic(
             f"DRY RUN: {args.from_type} → {args.to_type}: "
             f"{len(new)} new, {len(overwritten)} overwritten, "
-            f"{unchanged} unchanged; {len(src_audit_entries)} audit rows"
+            f"{unchanged} unchanged; {len(orphans)} orphans; "
+            f"{len(src_audit_entries)} audit rows"
         )
         if args.json:
             emit_result(
@@ -85,27 +123,29 @@ def cmd_migrate(args: argparse.Namespace) -> int:
                     "assignments_new": len(new),
                     "assignments_overwritten": len(overwritten),
                     "assignments_unchanged": unchanged,
+                    "assignments_orphans": len(orphans),
                     "audit_rows": len(src_audit_entries),
                 },
                 json_mode=True,
             )
         return 0
 
-    tgt_store.upsert_many(src_assignments)
+    tgt_store.upsert_many(padded)
     tgt_audit.append_many(src_audit_entries)
 
     summary = {
         "from": args.from_type,
         "to": args.to_type,
         "dry_run": False,
-        "assignments_written": len(src_assignments),
+        "assignments_written": len(padded),
+        "assignments_orphans": len(orphans),
         "audit_rows_written": len(src_audit_entries),
     }
     if args.json:
         emit_result(summary, json_mode=True)
     else:
         emit_result(
-            f"migrated {len(src_assignments)} assignments and "
+            f"migrated {len(padded)} assignments and "
             f"{len(src_audit_entries)} audit rows from "
             f"{args.from_type} to {args.to_type}",
             json_mode=False,

--- a/office_cli/cli/_commands/migrate.py
+++ b/office_cli/cli/_commands/migrate.py
@@ -30,17 +30,28 @@ from office_cli.seats import Assignment, build_backends_for_type
 _VALID_TYPES = ("csv", "sheets", "dynamo")
 
 
-def _load_all_svg_seats(data_dir: Path) -> list[tuple[str, str]]:
-    """Return ``[(seat_id, floor_id), ...]`` across every floor declared in
-    ``data/offices.yaml``. Mirrors the iteration in
-    :func:`office_cli.seats.build_service` so migrate can pad its output
-    with vacant rows for SVG seats the source store doesn't know about."""
+def _load_all_assignable_ids(data_dir: Path) -> list[tuple[str, str]]:
+    """Return ``[(id, floor_id), ...]`` for every assignable seat-or-room
+    declared by the office topology. The universe is the union of SVG
+    ``seat_ids``, SVG ``room_ids``, and YAML-declared rooms — matching
+    :func:`office_cli.seats._service._build_seat_index` exactly. First
+    occurrence per id wins (mirrors that function's ``setdefault``)."""
     out: list[tuple[str, str]] = []
+    seen: set[str] = set()
     for office in load_offices(data_dir).values():
         for floor_id, floor in office.floors.items():
             if floor.svg.is_file():
-                for seat_id in parse_svg(floor.svg).seat_ids:
-                    out.append((seat_id, floor_id))
+                svg = parse_svg(floor.svg)
+                for sid in (*svg.seat_ids, *svg.room_ids):
+                    if sid not in seen:
+                        seen.add(sid)
+                        out.append((sid, floor_id))
+            # Rooms declared in YAML even without an SVG entry are still
+            # assignable.
+            for rid in floor.rooms:
+                if rid not in seen:
+                    seen.add(rid)
+                    out.append((rid, floor_id))
     return out
 
 
@@ -61,23 +72,33 @@ def cmd_migrate(args: argparse.Namespace) -> int:
     src_assignments = src_store.list()
     src_audit_entries = src_audit.all()
 
-    # Pad the source list with vacant rows for every SVG seat the source
-    # store doesn't already know about. This makes the target backend a
+    # Pad the source list with vacant rows for every assignable seat-or-room
+    # the source store doesn't already know about. This makes the target a
     # complete view of the seat universe — important for Sheets-as-CMS,
-    # where HR/facilities need to see vacant seats to assign people. Rows
-    # in the source that aren't in any SVG (orphans — someone removed a
-    # seat from the SVG without cleaning the store) survive the migration
-    # but get reported separately so an operator can act.
-    svg_seats = _load_all_svg_seats(data_dir)
-    svg_seat_ids = {sid for sid, _ in svg_seats}
+    # where HR/facilities need to see vacant rows to assign people. The
+    # universe is the union of SVG ``seat_ids``, SVG ``room_ids``, and
+    # YAML-declared rooms (matches ``SeatService._build_seat_index``).
+    #
+    # Two flavors of "orphan" surface separately:
+    #   * **source orphans** — rows in source for ids not in any SVG/YAML.
+    #     Survive the migration so operators don't lose data; reported.
+    #   * **target orphans** — rows already in the target whose ids aren't
+    #     in source AND not in the universe. Left in place (migrate doesn't
+    #     delete data) but reported so the operator knows the target isn't
+    #     converging to the universe.
+    universe_pairs = _load_all_assignable_ids(data_dir)
+    universe_ids = {sid for sid, _ in universe_pairs}
     src_seat_ids = {a.seat_id for a in src_assignments}
     padding = [
-        Assignment(seat_id=sid, floor=fid) for sid, fid in svg_seats if sid not in src_seat_ids
+        Assignment(seat_id=sid, floor=fid) for sid, fid in universe_pairs if sid not in src_seat_ids
     ]
-    orphans = [a for a in src_assignments if a.seat_id not in svg_seat_ids]
+    orphans = [a for a in src_assignments if a.seat_id not in universe_ids]
     padded = list(src_assignments) + padding
 
     tgt_existing = {a.seat_id: a for a in tgt_store.list()}
+    target_orphans = sorted(
+        sid for sid in tgt_existing if sid not in src_seat_ids and sid not in universe_ids
+    )
     new = [a for a in padded if a.seat_id not in tgt_existing]
     overwritten = [a for a in padded if a.seat_id in tgt_existing and tgt_existing[a.seat_id] != a]
     unchanged = len(padded) - len(new) - len(overwritten)
@@ -103,15 +124,22 @@ def cmd_migrate(args: argparse.Namespace) -> int:
 
     if orphans:
         emit_diagnostic(
-            f"orphans: {len(orphans)} row(s) in source not present in any SVG: "
-            f"{', '.join(sorted(o.seat_id for o in orphans))}"
+            f"source orphans: {len(orphans)} row(s) in source not in any "
+            f"SVG/YAML: {', '.join(sorted(o.seat_id for o in orphans))}"
+        )
+    if target_orphans:
+        emit_diagnostic(
+            f"target orphans: {len(target_orphans)} row(s) already in "
+            f"target neither in source nor SVG/YAML (kept, not deleted): "
+            f"{', '.join(target_orphans)}"
         )
 
     if args.dry_run:
         emit_diagnostic(
             f"DRY RUN: {args.from_type} → {args.to_type}: "
             f"{len(new)} new, {len(overwritten)} overwritten, "
-            f"{unchanged} unchanged; {len(orphans)} orphans; "
+            f"{unchanged} unchanged; {len(orphans)} orphans, "
+            f"{len(target_orphans)} target_orphans; "
             f"{len(src_audit_entries)} audit rows"
         )
         if args.json:
@@ -124,6 +152,7 @@ def cmd_migrate(args: argparse.Namespace) -> int:
                     "assignments_overwritten": len(overwritten),
                     "assignments_unchanged": unchanged,
                     "assignments_orphans": len(orphans),
+                    "assignments_target_orphans": len(target_orphans),
                     "audit_rows": len(src_audit_entries),
                 },
                 json_mode=True,
@@ -139,6 +168,7 @@ def cmd_migrate(args: argparse.Namespace) -> int:
         "dry_run": False,
         "assignments_written": len(padded),
         "assignments_orphans": len(orphans),
+        "assignments_target_orphans": len(target_orphans),
         "audit_rows_written": len(src_audit_entries),
     }
     if args.json:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.9.2"
+version = "0.9.3"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_migrate.py
+++ b/tests/test_cli_migrate.py
@@ -59,7 +59,9 @@ def test_csv_to_dynamo_round_trip(
     )
     assert rc == 0
     summary = json.loads(capsys.readouterr().out)
-    assert summary["assignments_written"] == 2
+    # Issue #33: migrate pads with vacant rows for every SVG seat, so the
+    # written count is the full SVG seat universe (2 touched + 6 padded).
+    assert summary["assignments_written"] == _FIXTURE_SEAT_COUNT
 
     # Now read via dynamo and confirm parity. Use monkeypatch so a
     # pre-existing OFFICE_STORE in the developer's shell is preserved.
@@ -91,7 +93,8 @@ def test_dry_run_writes_nothing(dynamo_data_dir: Path, capsys: pytest.CaptureFix
     assert rc == 0
     summary = json.loads(capsys.readouterr().out)
     assert summary["dry_run"] is True
-    assert summary["assignments_new"] == 1
+    # Issue #33: dry-run reports the padded count (1 touched + 7 vacant).
+    assert summary["assignments_new"] == _FIXTURE_SEAT_COUNT
 
 
 def test_idempotent_rerun(
@@ -121,3 +124,228 @@ def test_same_source_and_target_rejected(
     rc = main(["seats", "migrate", "--from", "csv", "--to", "csv", *_data(dynamo_data_dir)])
     assert rc == 1
     assert "both" in capsys.readouterr().err
+
+
+# --- Issue #33: migrate pads target with vacant rows for every SVG seat ----
+
+
+_FIXTURE_SEAT_COUNT = 8  # tlv-floor-5.svg: 6 in T cluster + 2 in Z cluster
+
+
+def test_migrate_pads_vacant_rows_for_every_svg_seat(
+    dynamo_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Empty source + non-empty SVG → target ends with one row per SVG seat,
+    all vacant. Sheets-as-CMS contract from CLAUDE.md."""
+    rc = main(
+        [
+            "seats",
+            "migrate",
+            "--from",
+            "csv",
+            "--to",
+            "dynamo",
+            "--json",
+            *_data(dynamo_data_dir),
+        ]
+    )
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["assignments_written"] == _FIXTURE_SEAT_COUNT
+    assert summary["assignments_orphans"] == 0
+
+
+def test_migrate_idempotent_with_padding(
+    dynamo_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Re-running migrate against an already-padded target reports
+    ``0 new / 0 overwritten / N unchanged``."""
+    main(["seats", "migrate", "--from", "csv", "--to", "dynamo", *_data(dynamo_data_dir)])
+    capsys.readouterr()
+
+    rc = main(
+        [
+            "seats",
+            "migrate",
+            "--from",
+            "csv",
+            "--to",
+            "dynamo",
+            "--dry-run",
+            "--json",
+            *_data(dynamo_data_dir),
+        ]
+    )
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["assignments_new"] == 0
+    assert summary["assignments_overwritten"] == 0
+    assert summary["assignments_unchanged"] == _FIXTURE_SEAT_COUNT
+
+
+def test_migrate_dry_run_with_padding_writes_nothing(
+    dynamo_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--dry-run --json`` reports the full padded count without writing
+    to the target."""
+    rc = main(
+        [
+            "seats",
+            "migrate",
+            "--from",
+            "csv",
+            "--to",
+            "dynamo",
+            "--dry-run",
+            "--json",
+            *_data(dynamo_data_dir),
+        ]
+    )
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["dry_run"] is True
+    assert summary["assignments_new"] == _FIXTURE_SEAT_COUNT
+
+    # Target must remain empty.
+    rc = main(["seats", "list", "--json", "--occupied", *_data(dynamo_data_dir)])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["seats"] == []
+
+
+def test_migrate_keeps_orphan_rows_and_reports_them(
+    dynamo_data_dir: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row in the source for a seat ID that's not in any SVG (orphan)
+    survives the migration but is surfaced in stderr + JSON."""
+    # Seed an orphan directly into the CSV — the assign verb would reject
+    # an unknown seat ID, so we bypass it.
+    csv_path = dynamo_data_dir / "seats" / "assignments.csv"
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    csv_path.write_text(
+        "seat_id,floor,employee_email,last_updated,hidden,notes,"
+        "effective_from,effective_until\n"
+        "99-X-99,phantom-floor,ghost@example.com,2026-01-01T00:00:00Z,FALSE,,,\n",
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "seats",
+            "migrate",
+            "--from",
+            "csv",
+            "--to",
+            "dynamo",
+            "--json",
+            *_data(dynamo_data_dir),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "orphans: 1" in captured.err
+    assert "99-X-99" in captured.err
+
+    summary = json.loads(captured.out)
+    # 1 orphan + 8 padded vacant SVG rows = 9 written.
+    assert summary["assignments_orphans"] == 1
+    assert summary["assignments_written"] == 1 + _FIXTURE_SEAT_COUNT
+
+
+def test_migrate_mixed_touched_orphan_and_padding(
+    dynamo_data_dir: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """3 touched + 1 orphan + 8 SVG seats with one already touched →
+    target has 8 padded + 1 orphan = 9 rows;
+    ``new=8-3+1=6, overwritten=0, unchanged=2``."""
+    # Three legitimate assigns (hit 5-T-01 / 5-T-02 / 5-T-03) plus a
+    # hand-injected orphan row.
+    main(["seats", "assign", "5-T-01", "a@example.com", *_data(dynamo_data_dir)])
+    main(["seats", "assign", "5-T-02", "b@example.com", *_data(dynamo_data_dir)])
+    main(["seats", "assign", "5-T-03", "c@example.com", *_data(dynamo_data_dir)])
+    capsys.readouterr()
+
+    csv_path = dynamo_data_dir / "seats" / "assignments.csv"
+    existing = csv_path.read_text(encoding="utf-8")
+    csv_path.write_text(
+        existing + "99-X-99,phantom-floor,ghost@example.com,2026-01-01T00:00:00Z,FALSE,,,\n",
+        encoding="utf-8",
+    )
+
+    # First migrate to seed the target with the 3 touched + 1 orphan + 5 padded.
+    main(["seats", "migrate", "--from", "csv", "--to", "dynamo", *_data(dynamo_data_dir)])
+    capsys.readouterr()
+
+    # Re-run --dry-run: padded rows already exist → all unchanged.
+    rc = main(
+        [
+            "seats",
+            "migrate",
+            "--from",
+            "csv",
+            "--to",
+            "dynamo",
+            "--dry-run",
+            "--json",
+            *_data(dynamo_data_dir),
+        ]
+    )
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    # 3 touched + 1 orphan + 5 padded = 9 unchanged.
+    assert summary["assignments_unchanged"] == 1 + _FIXTURE_SEAT_COUNT
+    assert summary["assignments_new"] == 0
+    assert summary["assignments_overwritten"] == 0
+    assert summary["assignments_orphans"] == 1
+
+
+def test_migrate_padded_rows_carry_correct_floor_field(
+    data_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Multi-floor regression guard: each padded vacant row carries the
+    floor of the SVG it came from, not a single floor reused for the lot."""
+    # Add a synthetic second floor with two seats on a different floor id.
+    second_floor_svg = data_dir / "floors" / "tlv-floor-9.svg"
+    second_floor_svg.write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">\n'
+        '  <rect id="9-A-01" class="seat" x="0" y="0" width="10" height="10"/>\n'
+        '  <rect id="9-A-02" class="seat" x="20" y="0" width="10" height="10"/>\n'
+        "</svg>\n",
+        encoding="utf-8",
+    )
+    offices_yaml = data_dir / "data" / "offices.yaml"
+    offices_yaml.write_text(
+        offices_yaml.read_text(encoding="utf-8")
+        + "      - id: tlv-floor-9\n"
+        + "        svg: floors/tlv-floor-9.svg\n"
+        + "        clusters:\n"
+        + "          A: { capacity: 2, type: open-space }\n",
+        encoding="utf-8",
+    )
+
+    # Run migrate against the existing CSV (empty) into Dynamo. Seed a
+    # Dynamo target through the existing fixture pattern.
+    monkeypatch.setenv("OFFICE_DYNAMO_ASSIGNMENTS", "office-assignments")
+    monkeypatch.setenv("OFFICE_DYNAMO_AUDIT", "office-audit-log")
+    monkeypatch.setenv("OFFICE_DYNAMO_REGION", "us-east-1")
+    fake = FakeDynamoClient()
+    monkeypatch.setattr("office_cli.seats.dynamo.Boto3DynamoClient", lambda *a, **k: fake)
+
+    main(["seats", "migrate", "--from", "csv", "--to", "dynamo", *_data(data_dir)])
+    capsys.readouterr()
+
+    # Read the target via dynamo and assert the floor field on each row.
+    monkeypatch.setenv("OFFICE_STORE", "dynamo")
+    rc = main(["seats", "list", "--json", *_data(data_dir)])
+    assert rc == 0
+    body = json.loads(capsys.readouterr().out)
+    seats_by_id = {s["seat_id"]: s["floor"] for s in body["seats"]}
+    # Floor-5 seats keep their floor; floor-9 seats keep theirs. The bug
+    # this guards against is "all rows get the same floor id".
+    assert seats_by_id["5-T-01"] == "tlv-floor-5"
+    assert seats_by_id["9-A-01"] == "tlv-floor-9"
+    assert seats_by_id["9-A-02"] == "tlv-floor-9"

--- a/tests/test_cli_migrate.py
+++ b/tests/test_cli_migrate.py
@@ -471,9 +471,26 @@ def test_migrate_reports_target_orphans_without_deleting_them(
     assert summary["assignments_unchanged"] == _FIXTURE_SEAT_COUNT
     assert summary["assignments_new"] == 0
 
-    # Stale row must still be in the target (not deleted by dry-run).
-    monkeypatch.setenv("OFFICE_STORE", "dynamo")
-    rc = main(["seats", "history", "stale-X-99", "--json", *_data(dynamo_data_dir)])
-    # The history call may return empty; the important check is that the
-    # row exists in the assignments store.
-    capsys.readouterr()
+    # Re-run dry-run; orphan count still 1 → row was not deleted by the
+    # first dry-run. (``seats list`` would filter the orphan out at the
+    # SVG-join layer, so we can't use it as the witness here — the
+    # dry-run's own ``assignments_target_orphans`` is the load-bearing
+    # signal that the row remains in the store.)
+    rc = main(
+        [
+            "seats",
+            "migrate",
+            "--from",
+            "csv",
+            "--to",
+            "dynamo",
+            "--dry-run",
+            "--json",
+            *_data(dynamo_data_dir),
+        ]
+    )
+    assert rc == 0
+    summary2 = json.loads(capsys.readouterr().out)
+    assert (
+        summary2["assignments_target_orphans"] == 1
+    ), "target orphan disappeared between dry-runs; migrate must never delete rows"

--- a/tests/test_cli_migrate.py
+++ b/tests/test_cli_migrate.py
@@ -59,8 +59,8 @@ def test_csv_to_dynamo_round_trip(
     )
     assert rc == 0
     summary = json.loads(capsys.readouterr().out)
-    # Issue #33: migrate pads with vacant rows for every SVG seat, so the
-    # written count is the full SVG seat universe (2 touched + 6 padded).
+    # Issue #33: migrate pads with vacant rows for every assignable id, so
+    # the written count is the full universe (2 touched + 7 padded).
     assert summary["assignments_written"] == _FIXTURE_SEAT_COUNT
 
     # Now read via dynamo and confirm parity. Use monkeypatch so a
@@ -129,7 +129,7 @@ def test_same_source_and_target_rejected(
 # --- Issue #33: migrate pads target with vacant rows for every SVG seat ----
 
 
-_FIXTURE_SEAT_COUNT = 8  # tlv-floor-5.svg: 6 in T cluster + 2 in Z cluster
+_FIXTURE_SEAT_COUNT = 9  # tlv-floor-5: 6 T-cluster + 2 Z-cluster + 1 room (5.18)
 
 
 def test_migrate_pads_vacant_rows_for_every_svg_seat(
@@ -184,7 +184,9 @@ def test_migrate_idempotent_with_padding(
 
 
 def test_migrate_dry_run_with_padding_writes_nothing(
-    dynamo_data_dir: Path, capsys: pytest.CaptureFixture[str]
+    dynamo_data_dir: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``--dry-run --json`` reports the full padded count without writing
     to the target."""
@@ -206,7 +208,10 @@ def test_migrate_dry_run_with_padding_writes_nothing(
     assert summary["dry_run"] is True
     assert summary["assignments_new"] == _FIXTURE_SEAT_COUNT
 
-    # Target must remain empty.
+    # The dry-run guarantee is about the *Dynamo target*, not the CSV
+    # source. Switch the read backend to dynamo so the assertion actually
+    # exercises the target store.
+    monkeypatch.setenv("OFFICE_STORE", "dynamo")
     rc = main(["seats", "list", "--json", "--occupied", *_data(dynamo_data_dir)])
     assert rc == 0
     assert json.loads(capsys.readouterr().out)["seats"] == []
@@ -349,3 +354,126 @@ def test_migrate_padded_rows_carry_correct_floor_field(
     assert seats_by_id["5-T-01"] == "tlv-floor-5"
     assert seats_by_id["9-A-01"] == "tlv-floor-9"
     assert seats_by_id["9-A-02"] == "tlv-floor-9"
+
+
+def test_migrate_pads_rooms_not_just_seats(
+    dynamo_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The fixture has a YAML-declared room ``5.18`` that's also class=room
+    in the SVG. After migrate against an empty source, the target must
+    include a vacant row for ``5.18``; it must not be reported as an
+    orphan. (Per ``_build_seat_index``, rooms are valid assignment
+    targets — pad them.)"""
+    rc = main(
+        [
+            "seats",
+            "migrate",
+            "--from",
+            "csv",
+            "--to",
+            "dynamo",
+            "--json",
+            *_data(dynamo_data_dir),
+        ]
+    )
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["assignments_orphans"] == 0
+    # 6 T-seats + 2 Z-seats + 1 room (5.18) = 9 assignable ids.
+    assert summary["assignments_written"] == _FIXTURE_SEAT_COUNT
+
+
+def test_migrate_room_assignment_is_not_an_orphan(
+    dynamo_data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A row in the source store for the room ``5.18`` is a legitimate
+    assignment, not an orphan — even though the room has a different
+    naming pattern from open-space seats."""
+    main(["seats", "assign", "5.18", "team-room@example.com", *_data(dynamo_data_dir)])
+    capsys.readouterr()
+
+    rc = main(
+        [
+            "seats",
+            "migrate",
+            "--from",
+            "csv",
+            "--to",
+            "dynamo",
+            "--json",
+            *_data(dynamo_data_dir),
+        ]
+    )
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["assignments_orphans"] == 0
+
+
+def test_migrate_reports_target_orphans_without_deleting_them(
+    dynamo_data_dir: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rows already in the target whose ids are neither in source nor in
+    any SVG/YAML are surfaced as ``assignments_target_orphans`` in stderr
+    + JSON, but the migration does not delete them — migrate is purely
+    additive, never destructive. Without this, dry-run misleadingly
+    reports 'all unchanged' while the target diverges from the universe."""
+    # Plant a stale row directly into the dynamo fake.
+    main(["seats", "migrate", "--from", "csv", "--to", "dynamo", *_data(dynamo_data_dir)])
+    capsys.readouterr()
+    # Inject a row for an id that's neither in source nor SVG/YAML.
+    csv_path = dynamo_data_dir / "seats" / "assignments.csv"
+    csv_path.write_text(
+        "seat_id,floor,employee_email,last_updated,hidden,notes,"
+        "effective_from,effective_until\n"
+        "stale-X-99,phantom-floor,old@example.com,2026-01-01T00:00:00Z,FALSE,,,\n",
+        encoding="utf-8",
+    )
+    main(
+        [
+            "seats",
+            "migrate",
+            "--from",
+            "csv",
+            "--to",
+            "dynamo",
+            "--audit-append",
+            *_data(dynamo_data_dir),
+        ]
+    )
+    capsys.readouterr()
+    # Now reset the source CSV (no rows). target still has stale-X-99.
+    csv_path.unlink()
+
+    rc = main(
+        [
+            "seats",
+            "migrate",
+            "--from",
+            "csv",
+            "--to",
+            "dynamo",
+            "--dry-run",
+            "--json",
+            *_data(dynamo_data_dir),
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "target orphans: 1" in captured.err
+    assert "stale-X-99" in captured.err
+
+    summary = json.loads(captured.out)
+    assert summary["assignments_target_orphans"] == 1
+    # Source has nothing; padding is the full universe; target already
+    # has all of those + stale-X-99 as the orphan. So all unchanged.
+    assert summary["assignments_unchanged"] == _FIXTURE_SEAT_COUNT
+    assert summary["assignments_new"] == 0
+
+    # Stale row must still be in the target (not deleted by dry-run).
+    monkeypatch.setenv("OFFICE_STORE", "dynamo")
+    rc = main(["seats", "history", "stale-X-99", "--json", *_data(dynamo_data_dir)])
+    # The history call may return empty; the important check is that the
+    # row exists in the assignments store.
+    capsys.readouterr()

--- a/uv.lock
+++ b/uv.lock
@@ -640,7 +640,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- `office seats migrate` now pads its output with vacant `Assignment` rows for every SVG seat the source store doesn't know about, so the target backend mirrors the full seat universe — the contract `CLAUDE.md` promises with *"The Google Sheet is the CMS."*
- Rows in the source for seat IDs not in any SVG (orphans — someone removed a seat from the SVG without cleaning the store) survive the migration but are surfaced separately on stderr and in the JSON summary's new `assignments_orphans` field, so an operator can act.
- Idempotent: re-running migrate against an already-padded target reports `0 new / 0 overwritten / N unchanged`. Multi-floor floor-attribution regression guard included.

Closes #33.

## Discovered while

Smoke-testing the Sheets backend during initial install (see #31). Fresh test against `tlv-floor-5.svg` (8 seats) ended up with 3 rows in the Sheet; 6 seats were absent. The CLI's `seats list` papers over this at read time by joining SVG seats × store, but the spreadsheet UI doesn't — so HR/facilities couldn't see the seats they needed to assign people to. With this fix, the same migrate produces all 8 rows and operators have the full grid in front of them.

## Test plan

- [x] `uv run pytest -n auto -v` — 309 passed (was 303, +6 for the new padding/orphan/floor-attribution coverage).
- [x] `uv run black --check` / `flake8` / `isort --check-only` — clean.
- [x] `markdownlint-cli2 CHANGELOG.md` — clean.
- [x] **Live verification** against the test sheet `101mHi6MKicwwKNG-7OSTYRD1X7VCT1Y6AG7a3RwxybE`:
  - Cleared the assignments tab via gspread.
  - `migrate --dry-run` reports `8 new` (was `3` under the old behavior).
  - `migrate` writes 8 rows in the sheet.
  - `migrate --dry-run` immediately after reports `0 new / 0 overwritten / 8 unchanged` — idempotency proven.

## Out of scope (file as follow-ups)

- Same padding semantics for `office seats sync`. Sync is bi-directional and the orphan/padding behavior needs separate thought.
- Issue #32 — audit-log header missing on first migrate. Sister bug found in the same smoke test; separate fix path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)