### PR TITLE
fix(slack): "you sit at" instead of "you sits" for self-lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.4] - 2026-05-05
+
+### Fixed
+
+- Slack `/whereis` (or any `OFFICE_SLACK_COMMAND` override) invoked with
+  no arguments now renders *"you sit at &lt;seat&gt;"* — second-person
+  agreement — instead of the previous *"you sits at &lt;seat&gt;"*. The
+  third-person paths (`alice@example.com sits…`, `<@U123> sits…`)
+  are unchanged. `office_cli.slack._blocks.occupied()` gained a
+  `verb: str = "sits"` kwarg; the handler picks `"sit"` when
+  `target.self_lookup` is true.
+  ([#27](https://github.com/agentculture/office-agent/issues/27))
+
 ## [0.9.3] - 2026-05-05
 
 ### Fixed

--- a/office_cli/slack/_app.py
+++ b/office_cli/slack/_app.py
@@ -122,10 +122,12 @@ def _resolve_and_lookup(
     email, fail_reason = _email_from_user_id(client, user_id)
     if not email:
         return _blocks.lookup_failed(fail_reason), "lookup failed"
-    # When the caller asked about themselves, label as "you"; otherwise
-    # use the @-mention so Slack renders the name.
+    # When the caller asked about themselves, label as "you" and pick the
+    # second-person verb form ("you sit"); otherwise use the @-mention so
+    # Slack renders the name and stay third-person ("<@U…> sits").
     label = "you" if target.self_lookup else f"<@{user_id}>"
-    return _lookup(service, email, label, as_of=as_of, role=role)
+    verb = "sit" if target.self_lookup else "sits"
+    return _lookup(service, email, label, as_of=as_of, role=role, verb=verb)
 
 
 def _resolve_caller_role(client: Any, body: dict, command: dict, roles: RolesConfig | None) -> str:
@@ -175,6 +177,7 @@ def _lookup(
     *,
     as_of: str | None = None,
     role: str | None = None,
+    verb: str = "sits",
 ) -> tuple[list[dict[str, Any]], str]:
     # Both blocks and the `text` fallback use ``label`` so we never leak
     # the resolved profile email through the screen-reader / older-client
@@ -188,4 +191,7 @@ def _lookup(
     # planning callers see hidden seats with full details.
     if assignment.redacted:
         return _blocks.hidden_private(assignment, target_label=label), "occupied (private)"
-    return _blocks.occupied(assignment, target_label=label), f"{label} → {assignment.seat_id}"
+    return (
+        _blocks.occupied(assignment, target_label=label, verb=verb),
+        f"{label} → {assignment.seat_id}",
+    )

--- a/office_cli/slack/_blocks.py
+++ b/office_cli/slack/_blocks.py
@@ -32,14 +32,22 @@ def _deep_link_button(seat_id: str, floor: str) -> dict[str, Any] | None:
     }
 
 
-def occupied(assignment: Assignment, *, target_label: str) -> list[dict[str, Any]]:
+def occupied(
+    assignment: Assignment, *, target_label: str, verb: str = "sits"
+) -> list[dict[str, Any]]:
+    """Render the seat-found block. ``verb`` is ``"sits"`` for third-person
+    subjects (email or ``<@Uxxx>`` mention) and ``"sit"`` for second-person
+    self-lookup where the handler substitutes the literal ``"you"`` for
+    ``target_label``. The handler picks the verb form; the renderer just
+    interpolates."""
     blocks: list[dict[str, Any]] = [
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
                 "text": (
-                    f"*{target_label}* sits at *{assignment.seat_id}* on `{assignment.floor}`."
+                    f"*{target_label}* {verb} at *{assignment.seat_id}* "
+                    f"on `{assignment.floor}`."
                 ),
             },
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.9.3"
+version = "0.9.4"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_slack_app.py
+++ b/tests/test_slack_app.py
@@ -119,6 +119,8 @@ def test_plain_email_path(data_dir: Path) -> None:
 
 
 def test_no_arg_resolves_caller(data_dir: Path) -> None:
+    """No-arg ``/whereis`` resolves the caller and renders second-person.
+    Issue #27: must say ``"you sit"``, not ``"you sits"``."""
     service = _service_with_active(data_dir, "carol@example.com")
     service.assign("5-T-03", "carol@example.com")
     app = build_app(service, app=FakeSlackApp())
@@ -129,7 +131,46 @@ def test_no_arg_resolves_caller(data_dir: Path) -> None:
         command={"text": ""},
         client=client,
     )
-    assert "5-T-03" in _block_text(_last_blocks(client))
+    text = _block_text(_last_blocks(client))
+    assert "5-T-03" in text
+    # Subject is bolded by mrkdwn → ``*you* sit at`` is the rendered string.
+    assert "*you* sit at" in text
+    assert "*you* sits" not in text
+
+
+def test_email_path_renders_third_person_sits(data_dir: Path) -> None:
+    """Default branch (explicit email) keeps third-person ``"sits"``.
+    Guards against the #27 fix accidentally swapping the default verb."""
+    service = _service_with_active(data_dir, "carol@example.com")
+    service.assign("5-T-03", "carol@example.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "carol@example.com"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "carol@example.com* sits at" in text
+    assert "carol@example.com* sit at" not in text
+
+
+def test_at_mention_path_renders_third_person_sits(data_dir: Path) -> None:
+    """At-mention path also stays third-person (``<@U123> sits at ...``)."""
+    service = _service_with_active(data_dir, "alice@example.com")
+    service.assign("5-T-01", "alice@example.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient(users={"U123": {"profile": {"email": "alice@example.com"}}})
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "<@U123|alice>"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "<@U123>* sits at" in text
+    assert "you sit" not in text
 
 
 def test_no_seat_renders_helpful_message(data_dir: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -640,7 +640,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- Slack `/whereis` (or any `OFFICE_SLACK_COMMAND` override) invoked with no arguments now renders *"you sit at <seat>"* — second-person agreement — instead of the previous *"you sits at <seat>"*.
- `office_cli.slack._blocks.occupied()` gained a `verb: str = "sits"` kwarg; the handler picks `"sit"` only when `target.self_lookup` is true. Third-person paths (`alice@example.com sits…`, `<@U123> sits…`) are unchanged.
- 2 sister tests added beyond the verb fix to lock in the third-person default and prevent future regression on the email + at-mention paths.

Closes #27.

## Discovered while

Smoke-testing PR #28 (`OFFICE_SLACK_COMMAND` override) live against the Tipalti workspace; happy-path output rendered as *"you sits at 5-T-01"*.

## Test plan

- [x] `uv run pytest -n auto -v` — 314 passed (was 312, +2 sister tests + 1 strengthened existing test).
- [x] `uv run black --check` / `flake8` / `isort --check-only` — clean.
- [x] `markdownlint-cli2 CHANGELOG.md` — clean.
- [x] Live-verifiable against the running `slack-serve` daemon once merged: `/beta-whereis` (no args) → *"you sit at..."*; `/beta-whereis ori.nachum@tipalti.com` → *"ori.nachum@tipalti.com sits at..."*.

## Out of scope

The `text` fallback on the slash-command response (just the bare `label`) still shows `"you"` alone in notification previews for the self-lookup case. Separate cosmetic concern, not the verb bug #27 is about. Will file as follow-up if it becomes a real complaint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)