### PR TITLE
fix(sheets): seed audit-log header on auto-created tab (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.5] - 2026-05-05
+
+### Fixed
+
+- `SheetsAuditLog.append_many` now seeds the `audit-log` schema header
+  even when the tab was just auto-created by gspread. Auto-created tabs
+  (`add_worksheet(rows=1, cols=10)`) read back as a single phantom row
+  of empty strings, which the previous existence check treated as
+  "already populated" — the header was skipped, `audit.all()` parsed
+  row 1 as schema, and `office seats history <seat>` then returned no
+  rows even though `migrate` had written them. The check now ignores
+  rows that are entirely whitespace, so the first `append_many` against
+  a freshly created tab seeds the header and the data rows together.
+  ([#32](https://github.com/agentculture/office-agent/issues/32))
+
 ## [0.9.4] - 2026-05-05
 
 ### Fixed

--- a/office_cli/seats/sheets/_audit.py
+++ b/office_cli/seats/sheets/_audit.py
@@ -24,7 +24,12 @@ class SheetsAuditLog:
         if not rows:
             return
         existing = self._client.read_rows(self._worksheet)
-        if not existing:
+        # gspread auto-creates the tab via ``add_worksheet(rows=1, cols=10)``
+        # the first time we touch it, and ``get_all_values()`` then returns a
+        # phantom row of empty strings — truthy, but content-free. Treat that
+        # the same as an empty sheet so the header gets seeded.
+        has_real_content = any(any(cell.strip() for cell in row) for row in existing)
+        if not has_real_content:
             self._client.replace_rows(self._worksheet, [list(FIELDNAMES), *rows])
         else:
             self._client.append_rows(self._worksheet, rows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.9.4"
+version = "0.9.5"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_sheets_store.py
+++ b/tests/test_sheets_store.py
@@ -11,6 +11,7 @@ from itertools import count
 import pytest
 
 from office_cli.seats import Assignment, AuditEntry
+from office_cli.seats._audit import FIELDNAMES
 from office_cli.seats.sheets import SheetsAuditLog, SheetsStore
 
 
@@ -146,6 +147,31 @@ def test_audit_append_seeds_header_then_appends() -> None:
     )
     rows = audit.all()
     assert [r.action for r in rows] == ["assign", "unassign"]
+
+
+def test_audit_append_seeds_header_when_tab_is_phantom_empty() -> None:
+    """Regression for #32: gspread auto-creates a tab via
+    ``add_worksheet(rows=1, cols=10)`` on first touch; the read returns a
+    single row of empty strings, not ``[]``. The previous guard treated
+    that as "already populated" and skipped writing the header, so
+    ``audit.all()`` couldn't parse subsequent rows."""
+    client = FakeSheetsClient()
+    client.tabs["audit-log"] = [["", "", "", "", "", "", "", "", "", ""]]
+    audit = SheetsAuditLog(client)
+    audit.append(
+        AuditEntry(
+            timestamp="2026-05-05T00:00:01Z",
+            actor="t",
+            action="assign",
+            seat_id="5-T-01",
+            employee_email="alice@x",
+        )
+    )
+    assert client.tabs["audit-log"][0] == list(FIELDNAMES)
+    rows = audit.all()
+    assert len(rows) == 1
+    assert rows[0].seat_id == "5-T-01"
+    assert audit.for_seat("5-T-01")[0].employee_email == "alice@x"
 
 
 def test_audit_for_seat_filters() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -640,7 +640,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.9.4"
+version = "0.9.5"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- `SheetsAuditLog.append_many` now writes the schema header even when the `audit-log` tab was just auto-created by gspread.
- Auto-created tabs (`add_worksheet(rows=1, cols=10)`) read back as a single phantom row of empty strings — truthy, so the previous `if not existing` guard skipped header-seeding and `audit.all()` couldn't parse any rows.
- The check now ignores rows that are entirely whitespace, so the first append against a freshly created tab seeds the header and the data rows together. Already-populated tabs keep using the append path unchanged.

Closes #32.

## Test plan

- [x] `uv run pytest -n auto -q` (315 passed)
- [x] `uv run black/isort/flake8` clean
- [x] `markdownlint-cli2 CHANGELOG.md` clean
- [x] New regression test `test_audit_append_seeds_header_when_tab_is_phantom_empty` simulates gspread's auto-created phantom-row state and asserts the header lands at row 1, `audit.all()` round-trips the entry, and `audit.for_seat()` finds it.
- [ ] Live verification: clear `audit-log` tab, run `office seats migrate --from csv --to sheets`, confirm header is row 1 and `office seats history` returns rows.

- Claude