### PR TITLE
fix(cli): standardize 'seats move' on seat-first order (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.6] - 2026-05-05
+
+### Changed
+
+- **Breaking:** `office seats move` now takes positional arguments in
+  the order `<seat_id> <email>`, matching `office seats assign`. The
+  previous order was `<email> <new_seat_id>`, which gave operators no
+  consistent mental model when alternating between the two verbs.
+  Update any scripts or muscle memory that called
+  `office seats move alice@example.com 5-T-02` to
+  `office seats move 5-T-02 alice@example.com`.
+  ([#30](https://github.com/agentculture/office-agent/issues/30))
+
+### Fixed
+
+- `office seats move` now detects the wrong-order case (`@` in the
+  first arg, none in the second) and emits a remediation hint
+  pointing at the correct invocation, instead of the previous
+  misleading `error: unknown seat: alice@example.com`.
+  ([#30](https://github.com/agentculture/office-agent/issues/30))
+
 ## [0.9.5] - 2026-05-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ office floors list --json
 office floors validate floors/tlv-floor-5.svg
 office seats list --vacant
 office seats assign 5-T-01 alice@example.com
-office seats move alice@example.com 5-T-02
+office seats move 5-T-02 alice@example.com
 office seats history 5-T-01 --json
 office whereis alice@example.com
 ```

--- a/docs/features/cli.md
+++ b/docs/features/cli.md
@@ -74,7 +74,7 @@ office seats assign 5-T-01 alice@example.com --hidden --note "ergonomic"
 office seats assign 5-T-01 alice@example.com --from 2026-07-01 --until 2026-12-31
 
 office seats unassign 5-T-01
-office seats move alice@example.com 5-T-02
+office seats move 5-T-02 alice@example.com
 office seats history 5-T-01 --json
 ```
 

--- a/office_cli/cli/_commands/seats.py
+++ b/office_cli/cli/_commands/seats.py
@@ -85,9 +85,25 @@ def cmd_unassign(args: argparse.Namespace) -> int:
 
 
 def cmd_move(args: argparse.Namespace) -> int:
+    # Args mirror ``assign``'s ``seat_id email``. If someone passes them
+    # the other way round (a leftover from the pre-0.9.6 signature, or
+    # the issue-#30 muscle memory), catch the swap and remediate before
+    # we hit the service.
+    if "@" in args.seat_id and "@" not in args.email:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"first argument {args.seat_id!r} looks like an email; "
+                f"second argument {args.email!r} looks like a seat id"
+            ),
+            remediation=(
+                f"office seats move expects: <seat_id> <email>; try: "
+                f"office seats move {args.email} {args.seat_id}"
+            ),
+        )
     data_dir = resolve_data_dir(args)
     service = build_service(data_dir)
-    a = service.move(args.email, args.new_seat_id, note=args.note or "")
+    a = service.move(args.email, args.seat_id, note=args.note or "")
     _emit_assignment(a, args.json, "moved")
     return 0
 
@@ -175,8 +191,8 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_unassign.set_defaults(func=cmd_unassign)
 
     p_move = inner.add_parser("move", help="Atomically move an employee to a new seat.")
-    p_move.add_argument("email")
-    p_move.add_argument("new_seat_id")
+    p_move.add_argument("seat_id", help="Target seat id (where the employee will land).")
+    p_move.add_argument("email", help="Employee email of the person being moved.")
     p_move.add_argument("--note", help=_NOTE_HELP)
     p_move.add_argument("--json", action="store_true")
     add_data_dir_arg(p_move)

--- a/office_cli/explain/catalog.py
+++ b/office_cli/explain/catalog.py
@@ -169,7 +169,7 @@ store in v0.1.0 is a stand-in for the Sheets-backed store coming next.
 - `office seats list [--floor F] [--cluster L] [--vacant|--occupied] [--json]`
 - `office seats assign SEAT EMAIL [--note N] [--hidden] [--json]`
 - `office seats unassign SEAT [--note N] [--json]`
-- `office seats move EMAIL NEW_SEAT [--note N] [--json]`
+- `office seats move NEW_SEAT EMAIL [--note N] [--json]`
 - `office seats history SEAT [--json]`
 
 ## Invariants
@@ -206,7 +206,11 @@ timestamp.
 
 ## Usage
 
-    office seats move alice@tipalti.com 5-T-02
+    office seats move 5-T-02 alice@tipalti.com
+
+Argument order matches `assign`: seat first, email second. Passing the
+opposite order (`alice@tipalti.com 5-T-02`) is rejected with a
+remediation hint rather than a confusing "unknown seat" error.
 
 Fails if the email has no current seat (use `assign`) or if the target
 seat is occupied.

--- a/office_cli/seats/_service.py
+++ b/office_cli/seats/_service.py
@@ -139,7 +139,7 @@ class SeatService:
                     f"{email} is already assigned to {existing_for_email.seat_id}; "
                     "an employee can hold at most one seat globally"
                 ),
-                remediation=f"to move them, run: office seats move {email} {seat_id}",
+                remediation=f"to move them, run: office seats move {seat_id} {email}",
             )
         current = self.store.get(seat_id)
         old_email = current.employee_email if current else ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.9.5"
+version = "0.9.6"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_seats.py
+++ b/tests/test_cli_seats.py
@@ -37,7 +37,7 @@ def test_double_assign_emits_error(data_dir: Path, capsys: pytest.CaptureFixture
 def test_move_atomic(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
     main(["seats", "assign", "5-T-01", "alice@example.com", *_data(data_dir)])
     capsys.readouterr()
-    rc = main(["seats", "move", "alice@example.com", "5-T-02", *_data(data_dir)])
+    rc = main(["seats", "move", "5-T-02", "alice@example.com", *_data(data_dir)])
     assert rc == 0
     capsys.readouterr()
     rc = main(["seats", "history", "5-T-01", "--json", *_data(data_dir)])
@@ -45,6 +45,28 @@ def test_move_atomic(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None
     payload = json.loads(capsys.readouterr().out)
     actions = [e["action"] for e in payload["history"]]
     assert actions == ["assign", "unassign"]
+
+
+def test_move_rejects_swapped_order_with_hint(
+    data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Issue #30: passing ``email seat`` (the pre-0.9.6 order or the
+    assign-mirror muscle memory) is rejected with a remediation that
+    shows the correct order, instead of the previous misleading
+    "unknown seat: alice@example.com" error."""
+    main(["seats", "assign", "5-T-01", "alice@example.com", *_data(data_dir)])
+    capsys.readouterr()
+    rc = main(["seats", "move", "alice@example.com", "5-T-02", *_data(data_dir)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "looks like an email" in err
+    assert "office seats move 5-T-02 alice@example.com" in err
+    # Service was not invoked — no audit row written for the bogus call.
+    rc = main(["seats", "history", "5-T-01", "--json", *_data(data_dir)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    actions = [e["action"] for e in payload["history"]]
+    assert actions == ["assign"]
 
 
 def test_unassign(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_cli_seats.py
+++ b/tests/test_cli_seats.py
@@ -32,6 +32,8 @@ def test_double_assign_emits_error(data_dir: Path, capsys: pytest.CaptureFixture
     captured = capsys.readouterr()
     assert "already assigned" in captured.err
     assert "hint:" in captured.err
+    # Remediation must reflect the post-0.9.6 ``move`` order (seat first).
+    assert "office seats move 5-T-02 alice@example.com" in captured.err
 
 
 def test_move_atomic(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -50,9 +52,9 @@ def test_move_atomic(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None
 def test_move_rejects_swapped_order_with_hint(
     data_dir: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Issue #30: passing ``email seat`` (the pre-0.9.6 order or the
-    assign-mirror muscle memory) is rejected with a remediation that
-    shows the correct order, instead of the previous misleading
+    """Issue #30: passing ``email seat`` (the pre-0.9.6 ``move`` order)
+    is rejected with a remediation that shows the correct order,
+    instead of the previous misleading
     "unknown seat: alice@example.com" error."""
     main(["seats", "assign", "5-T-01", "alice@example.com", *_data(data_dir)])
     capsys.readouterr()

--- a/uv.lock
+++ b/uv.lock
@@ -640,7 +640,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.9.5"
+version = "0.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- `office seats move` now takes `<seat_id> <email>` to match `office seats assign`. Operators no longer have to track which verb takes which order.
- The old form (`<email> <seat_id>`) is detected in `cmd_move` and rejected with a remediation hint that prints the correct invocation, instead of falling through to the service-layer `unknown seat: alice@example.com` error.
- Pre-1.0 hard flip — no auto-swap deprecation cycle (CLAUDE.md "don't add backwards-compatibility shims").
- Help text, explain catalog (`office explain seats`, `office explain seats move`), and `docs/features/cli.md` all reflect the new order.

Closes #30.

## Breaking change

Anyone with scripts or muscle memory using:

```bash
office seats move alice@example.com 5-T-02      # old, removed
```

Should switch to:

```bash
office seats move 5-T-02 alice@example.com      # new, matches assign
```

The wrong-order case now errors loudly instead of silently going wrong, so the breakage is visible.

## Test plan

- [x] `uv run pytest -n auto -q` (316 passed; was 315 — new regression test added)
- [x] `uv run black/isort/flake8` clean
- [x] `markdownlint-cli2 CHANGELOG.md docs/features/cli.md` clean
- [x] Updated `test_move_atomic` for the new order
- [x] Added `test_move_rejects_swapped_order_with_hint` asserting the error path + remediation text + that `service.move` was not invoked (no audit row written for the bogus call)
- [ ] Live verification against a CSV-backed install: `assign 5-T-01 alice` → `move 5-T-02 alice` (seat first, succeeds) → `move alice 5-T-03` (email first, fails with hint)

- Claude