### PR TITLE
feat(slack): /whereis bare-name resolution via local-part (#29 MVP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.7] - 2026-05-05
+
+### Added
+
+- Slack `/whereis` (or any `OFFICE_SLACK_COMMAND` override) now accepts
+  a bare name or username (`/whereis ori.nachum`) and resolves it
+  against the assignment store's email local-parts (case-insensitive).
+  The failed-autocomplete shape (`@ori.nachum` — what Slack sometimes
+  substitutes when the proper `<@Uxxx>` markup doesn't fire) is treated
+  identically. When a bare token matches a single assignment the seat
+  renders as before; when it matches two or more (same local-part
+  across multiple email domains) the handler renders an ephemeral
+  disambiguation list with the full emails so the caller can re-run
+  with the unambiguous form. Hidden seats keep the redaction
+  treatment in the disambiguation list. The unparseable-text block now
+  mentions name + `@mention` + email as accepted input forms.
+  ([#29](https://github.com/agentculture/office-agent/issues/29))
+
+  This is the MVP slice of the resolution chain in #29. Two follow-ups
+  cover the rest of the chain:
+  [#38](https://github.com/agentculture/office-agent/issues/38) adds
+  Slack `users.list` exact-name lookup with a TTL cache and an
+  opt-out env var;
+  [#39](https://github.com/agentculture/office-agent/issues/39) adds
+  fuzzy / partial matching with an interactive disambiguation UI.
+
 ## [0.9.6] - 2026-05-05
 
 ### Changed

--- a/office_cli/seats/_service.py
+++ b/office_cli/seats/_service.py
@@ -76,6 +76,41 @@ class SeatService:
             out.append(a)
         return out
 
+    def find_by_local_part(
+        self,
+        token: str,
+        *,
+        as_of: str | None = None,
+        role: str | None = None,
+    ) -> list[Assignment]:
+        """Return every active assignment whose email's local-part
+        matches ``token`` case-insensitively (#29 MVP).
+
+        ``ori.nachum`` matches ``ori.nachum@anything.com``. The same
+        directory ``is_active`` filter and as-of window check that
+        :meth:`whereis` applies fire here, so an assignment for an
+        offboarded employee never resurfaces through the bare-token
+        path. Role redaction is applied per match. Multiple matches
+        (different domains sharing a local-part) all surface — the
+        caller decides on disambiguation policy.
+        """
+        if not token:
+            return []
+        needle = token.lower()
+        out: list[Assignment] = []
+        for a in self.store.list():
+            email = a.employee_email or ""
+            if "@" not in email:
+                continue
+            if email.split("@", 1)[0].lower() != needle:
+                continue
+            if not self.directory.is_active(email):
+                continue
+            if as_of is not None and not is_effective(a, as_of):
+                continue
+            out.append(_apply_role_redaction(a, role))
+        return out
+
     def whereis(
         self,
         email: str,

--- a/office_cli/slack/_app.py
+++ b/office_cli/slack/_app.py
@@ -115,6 +115,9 @@ def _resolve_and_lookup(
         label = email
         return _lookup(service, email, label, as_of=as_of, role=role)
 
+    if target.bare_token:
+        return _lookup_by_local_part(service, target.bare_token, as_of=as_of, role=role)
+
     user_id = target.user_id or command.get("user_id") or body.get("user_id", "")
     if not user_id:
         return _blocks.lookup_failed("no Slack user id supplied"), "no user id"
@@ -168,6 +171,31 @@ def _email_from_user_id(client: Any, user_id: str) -> tuple[str, str]:
     if not email:
         return "", ("no email on that Slack profile (the bot needs the `users:read.email` scope)")
     return email, ""
+
+
+def _lookup_by_local_part(
+    service: SeatService,
+    token: str,
+    *,
+    as_of: str | None = None,
+    role: str | None = None,
+) -> tuple[list[dict[str, Any]], str]:
+    """#29 MVP: ``/whereis ori.nachum`` resolves via the assignment
+    store's email local-parts. 0 → friendly error; 1 → standard
+    seat-found render; 2+ → disambiguation list."""
+    matches = service.find_by_local_part(token, as_of=as_of, role=role)
+    if not matches:
+        return _blocks.no_match_for_token(token), f"no match for {token}"
+    if len(matches) == 1:
+        a = matches[0]
+        label = a.employee_email or token
+        if a.redacted:
+            return _blocks.hidden_private(a, target_label=label), "occupied (private)"
+        return (
+            _blocks.occupied(a, target_label=label),
+            f"{label} → {a.seat_id}",
+        )
+    return _blocks.disambiguation(token, matches), f"{len(matches)} matches for {token}"
 
 
 def _lookup(

--- a/office_cli/slack/_app.py
+++ b/office_cli/slack/_app.py
@@ -184,18 +184,25 @@ def _lookup_by_local_part(
     store's email local-parts. 0 → friendly error; 1 → standard
     seat-found render; 2+ → disambiguation list."""
     matches = service.find_by_local_part(token, as_of=as_of, role=role)
+    # ``text`` fallback strings stay free of ``token``: Slack parses the
+    # fallback for ``<!here>`` / ``<@U…>`` / ``<#C…>`` sequences when
+    # blocks aren't rendered, so an attacker-controlled token must not
+    # land there. The block builders escape the token for mrkdwn
+    # display; the fallback uses constants.
     if not matches:
-        return _blocks.no_match_for_token(token), f"no match for {token}"
+        return _blocks.no_match_for_token(token), "no seat found for that name"
     if len(matches) == 1:
         a = matches[0]
-        label = a.employee_email or token
+        # Use the resolved (store-derived) email as the label so even
+        # the single-match path doesn't echo the user's raw token.
+        label = a.employee_email or "(redacted)"
         if a.redacted:
             return _blocks.hidden_private(a, target_label=label), "occupied (private)"
         return (
             _blocks.occupied(a, target_label=label),
             f"{label} → {a.seat_id}",
         )
-    return _blocks.disambiguation(token, matches), f"{len(matches)} matches for {token}"
+    return _blocks.disambiguation(token, matches), f"{len(matches)} matches"
 
 
 def _lookup(

--- a/office_cli/slack/_blocks.py
+++ b/office_cli/slack/_blocks.py
@@ -102,12 +102,69 @@ def parse_failed(raw: str) -> list[dict[str, Any]]:
             "text": {
                 "type": "mrkdwn",
                 "text": (
-                    f"Couldn't parse a person from `{raw}`. Pass an "
-                    "`@mention` or an `email@address`."
+                    f"Couldn't parse a person from `{raw}`. Pass a name "
+                    "(`alice` or `ori.nachum`), an `@mention`, or an "
+                    "`email@address`."
                 ),
             },
         }
     ]
+
+
+def no_match_for_token(token: str) -> list[dict[str, Any]]:
+    """No assignment matched the bare-token local-part (#29 MVP)."""
+    return [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    f"Couldn't find a seat for `{token}`. Try the full "
+                    "`email@address` or an `@mention`."
+                ),
+            },
+        }
+    ]
+
+
+def disambiguation(token: str, matches: list[Assignment]) -> list[dict[str, Any]]:
+    """Multi-section list when ``find_by_local_part`` returned ≥2
+    candidates (#29 MVP). Each ``Assignment`` gets a section block
+    showing its email + seat. Hidden seats render with redaction
+    already applied by the service layer (see
+    ``SeatService.find_by_local_part`` + ``_apply_role_redaction``)."""
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"Multiple seats matched `{token}`:",
+            },
+        }
+    ]
+    for a in matches:
+        if a.redacted:
+            line = f"• `{a.seat_id}` on `{a.floor}` — occupied (private)"
+        else:
+            line = f"• {a.employee_email} → `{a.seat_id}` on `{a.floor}`"
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": line},
+            }
+        )
+    blocks.append(
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": "_Re-run with the full email to pick one._",
+                }
+            ],
+        }
+    )
+    return blocks
 
 
 def lookup_failed(reason: str) -> list[dict[str, Any]]:

--- a/office_cli/slack/_blocks.py
+++ b/office_cli/slack/_blocks.py
@@ -15,6 +15,25 @@ from typing import Any
 from office_cli.seats import Assignment
 
 
+def _escape_mrkdwn(s: str) -> str:
+    """Escape Slack mrkdwn control characters in user-supplied text.
+
+    Slack mrkdwn parses ``<…>`` as a special link / mention sequence
+    (``<!here>``, ``<@U…>``, ``<#C…>``, ``<https://…>``), so an
+    unescaped ``<`` from a user-supplied token can ping the channel or
+    rewrite the message. ``&`` is the HTML-entity prefix and must be
+    escaped first or we'd double-escape ``<`` / ``>`` below. Backticks
+    cannot be escaped inside a code span, so we replace them with a
+    single quote — visual approximation, no parser confusion.
+
+    Apply to anything that flows from the slash-command argument into
+    a rendered block. Slack's ``text`` fallback is *also* parsed for
+    these sequences when blocks aren't rendered; the handler keeps
+    user tokens out of that field entirely as a separate defense.
+    """
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("`", "'")
+
+
 def _deep_link_button(seat_id: str, floor: str) -> dict[str, Any] | None:
     base = (os.environ.get("OFFICE_WEB_BASE_URL") or "").rstrip("/")
     if not base:
@@ -113,13 +132,14 @@ def parse_failed(raw: str) -> list[dict[str, Any]]:
 
 def no_match_for_token(token: str) -> list[dict[str, Any]]:
     """No assignment matched the bare-token local-part (#29 MVP)."""
+    safe = _escape_mrkdwn(token)
     return [
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
                 "text": (
-                    f"Couldn't find a seat for `{token}`. Try the full "
+                    f"Couldn't find a seat for `{safe}`. Try the full "
                     "`email@address` or an `@mention`."
                 ),
             },
@@ -130,21 +150,24 @@ def no_match_for_token(token: str) -> list[dict[str, Any]]:
 def disambiguation(token: str, matches: list[Assignment]) -> list[dict[str, Any]]:
     """Multi-section list when ``find_by_local_part`` returned ≥2
     candidates (#29 MVP). Each ``Assignment`` gets a section block
-    showing its email + seat. Hidden seats render with redaction
-    already applied by the service layer (see
-    ``SeatService.find_by_local_part`` + ``_apply_role_redaction``)."""
+    showing its email + seat. Redacted entries follow the same
+    contract as :func:`hidden_private` — only the floor is shown, not
+    the seat id, so a viewer-role caller can see *that* there's a
+    private match without learning where it sits."""
+    safe_token = _escape_mrkdwn(token)
     blocks: list[dict[str, Any]] = [
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"Multiple seats matched `{token}`:",
+                "text": f"Multiple seats matched `{safe_token}`:",
             },
         }
     ]
     for a in matches:
         if a.redacted:
-            line = f"• `{a.seat_id}` on `{a.floor}` — occupied (private)"
+            # Match hidden_private's privacy contract: floor only, no seat_id.
+            line = f"• occupied (private) on `{a.floor}`"
         else:
             line = f"• {a.employee_email} → `{a.seat_id}` on `{a.floor}`"
         blocks.append(

--- a/office_cli/slack/_resolve.py
+++ b/office_cli/slack/_resolve.py
@@ -44,12 +44,15 @@ _TRAILING_DATE_RE = re.compile(r"(?:^|\s)(?P<date>\d{4}-\d{2}-\d{2})\s*$")
 class ParsedTarget:
     """Result of parsing the slash-command text.
 
-    Exactly one of ``user_id`` / ``email`` is set when the parse succeeds;
-    both are empty when the text was not parseable. ``self_lookup`` flags
-    the no-arg case so the caller can read the invoker's own ``user_id``
-    from the command body. ``as_of`` is the optional trailing
-    ``YYYY-MM-DD`` token (Stage 6); empty when the caller did not pass a
-    date.
+    Exactly one of ``user_id`` / ``email`` / ``bare_token`` is set when
+    the parse succeeds; all are empty when the text was not parseable.
+    ``self_lookup`` flags the no-arg case so the caller can read the
+    invoker's own ``user_id`` from the command body. ``as_of`` is the
+    optional trailing ``YYYY-MM-DD`` token (Stage 6); empty when the
+    caller did not pass a date. ``bare_token`` (#29 MVP) carries the
+    name-or-username form (``alice``, ``ori.nachum``, ``@ori.nachum``)
+    for the caller to resolve via the assignment store's email
+    local-parts.
     """
 
     user_id: str = ""
@@ -57,10 +60,11 @@ class ParsedTarget:
     self_lookup: bool = False
     raw: str = ""
     as_of: str = ""
+    bare_token: str = ""
 
     @property
     def ok(self) -> bool:
-        return bool(self.user_id or self.email or self.self_lookup)
+        return bool(self.user_id or self.email or self.self_lookup or self.bare_token)
 
 
 def parse_target(text: str) -> ParsedTarget:
@@ -98,5 +102,17 @@ def parse_target(text: str) -> ParsedTarget:
     email = _EMAIL_RE.search(stripped)
     if email:
         return ParsedTarget(email=email.group(0), raw=raw.strip(), as_of=as_of)
+
+    # #29 MVP: accept a bare name / username token as a hint for the
+    # caller to resolve against the assignment store's email local-
+    # parts. Strip a single leading ``@`` (failed-autocomplete case),
+    # then take the first whitespace-separated token. Tokens that still
+    # contain an ``@`` after stripping aren't valid bare names — let
+    # the parse fail rather than feeding a broken email downstream.
+    first = stripped.split()[0]
+    if first.startswith("@"):
+        first = first[1:]
+    if first and "@" not in first:
+        return ParsedTarget(bare_token=first, raw=raw.strip(), as_of=as_of)
 
     return ParsedTarget(raw=raw.strip(), as_of=as_of)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.9.6"
+version = "0.9.7"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_seats_service.py
+++ b/tests/test_seats_service.py
@@ -145,3 +145,45 @@ def test_room_assignable(data_dir: Path) -> None:
     s = _service(data_dir)
     a = s.assign("5.18", "exec@example.com")
     assert a.seat_id == "5.18"
+
+
+def test_find_by_local_part_returns_single_match(data_dir: Path) -> None:
+    """#29 MVP: ``ori.nachum`` resolves to ``ori.nachum@<any-domain>``."""
+    s = _service(data_dir)
+    s.assign("5-T-01", "ori.nachum@tipalti.com")
+    matches = s.find_by_local_part("ori.nachum")
+    assert len(matches) == 1
+    assert matches[0].employee_email == "ori.nachum@tipalti.com"
+    assert matches[0].seat_id == "5-T-01"
+
+
+def test_find_by_local_part_is_case_insensitive(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com")
+    assert s.find_by_local_part("ALICE")[0].employee_email == "alice@example.com"
+    assert s.find_by_local_part("Alice")[0].employee_email == "alice@example.com"
+
+
+def test_find_by_local_part_returns_multiple_for_domain_collision(data_dir: Path) -> None:
+    """Same local-part across domains → all matches surface; the
+    handler decides on disambiguation."""
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@x.com")
+    s.assign("5-T-02", "alice@y.com")
+    matches = s.find_by_local_part("alice")
+    assert {a.employee_email for a in matches} == {"alice@x.com", "alice@y.com"}
+
+
+def test_find_by_local_part_returns_empty_for_unknown(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com")
+    assert s.find_by_local_part("ghost") == []
+    assert s.find_by_local_part("") == []
+
+
+def test_find_by_local_part_skips_partial_prefix(data_dir: Path) -> None:
+    """Exact local-part only — ``ali`` does NOT match ``alice@…`` in
+    the MVP. Prefix/fuzzy is follow-up B (#39)."""
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com")
+    assert s.find_by_local_part("ali") == []

--- a/tests/test_slack_app.py
+++ b/tests/test_slack_app.py
@@ -622,3 +622,77 @@ def test_bare_token_disambiguation_renders_candidates(data_dir: Path) -> None:
     assert "5-T-01" in text
     assert "5-T-02" in text
     assert "Re-run with the full email" in text
+
+
+def test_bare_token_with_mrkdwn_metachars_is_escaped(data_dir: Path) -> None:
+    """PR #40 review (Copilot): a bare token containing ``<``/``>`` /
+    ``&`` / backtick must not break formatting or inject Slack control
+    sequences (``<!here>``, ``<@U…>``) when echoed back. The block
+    builders escape these before mrkdwn display, and the ``text``
+    fallback stays free of the token entirely."""
+    service = _service_with_active(data_dir)
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "<!here>"},
+        client=client,
+    )
+    posted = client.posted[-1]
+    blocks_text = _block_text(posted["blocks"])
+    # The literal ``<!here>`` must be escaped, not pinged.
+    assert "<!here>" not in blocks_text
+    assert "&lt;!here&gt;" in blocks_text
+    # And the ``text`` fallback (rendered when blocks aren't supported)
+    # must not echo the token at all.
+    assert "<!here>" not in posted["text"]
+
+
+def test_bare_token_text_fallback_does_not_leak_token(data_dir: Path) -> None:
+    """Companion to the mrkdwn-escape test: even a benign token shouldn't
+    appear in the ``text`` fallback, because Slack parses that string
+    too. We assert the no-match path's fallback is the documented
+    constant, not an interpolation of the user input."""
+    service = _service_with_active(data_dir)
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "ghost"},
+        client=client,
+    )
+    assert client.posted[-1]["text"] == "no seat found for that name"
+
+
+def test_bare_token_disambiguation_redacts_hidden_seat_id(data_dir: Path) -> None:
+    """PR #40 review (Qodo): when the disambiguation list includes a
+    redacted (hidden) entry, it must omit the ``seat_id`` to match
+    ``hidden_private``'s privacy contract — viewer-role callers can
+    see *that* there's a private match without learning where it sits."""
+    from office_cli._roles import RolesConfig
+
+    service = _service_with_active(data_dir, "alice@x.com", "alice@y.com")
+    service.assign("5-T-01", "alice@x.com")  # public
+    service.assign("5-T-02", "alice@y.com", hidden=True)  # private
+    # Empty roles config → caller is viewer → redaction fires for hidden seats.
+    roles = RolesConfig()
+    app = build_app(service, app=FakeSlackApp(), roles=roles)
+    # The caller's user_id maps to no role entry → defaults to viewer.
+    client = FakeSlackClient(users={"U999": {"profile": {"email": "viewer@x.com"}}})
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alice"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    # Public match is fully visible.
+    assert "5-T-01" in text
+    assert "alice@x.com" in text
+    # Hidden match: floor visible, seat_id NOT, email NOT.
+    assert "tlv-floor-5" in text
+    assert "5-T-02" not in text
+    assert "alice@y.com" not in text
+    assert "occupied (private)" in text

--- a/tests/test_slack_app.py
+++ b/tests/test_slack_app.py
@@ -235,6 +235,10 @@ def test_inactive_directory_email_renders_no_seat(data_dir: Path) -> None:
 
 
 def test_unparseable_text(data_dir: Path) -> None:
+    """Post-#29: a bare token like ``garbage_no_email_no_mention`` is no
+    longer a parse failure — it's captured as ``bare_token`` and looked
+    up against the assignment store. With no matching local-part, the
+    handler renders the new ``no_match_for_token`` block instead."""
     service = _service_with_active(data_dir)
     app = build_app(service, app=FakeSlackApp())
     client = FakeSlackClient()
@@ -245,7 +249,7 @@ def test_unparseable_text(data_dir: Path) -> None:
         client=client,
     )
     text = _block_text(_last_blocks(client))
-    assert "Couldn't parse" in text
+    assert "Couldn't find a seat for" in text
     assert "garbage_no_email_no_mention" in text
 
 
@@ -542,3 +546,79 @@ def test_command_name_empty_after_strip_raises(data_dir: Path) -> None:
 
     with pytest.raises(OfficeError):
         build_app(service, app=FakeSlackApp(), command_name="   ")
+
+
+def test_bare_token_resolves_to_assignment(data_dir: Path) -> None:
+    """#29 MVP: ``/whereis ori.nachum`` resolves via local-part match."""
+    service = _service_with_active(data_dir, "ori.nachum@tipalti.com")
+    service.assign("5-T-03", "ori.nachum@tipalti.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "ori.nachum"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "5-T-03" in text
+    assert "ori.nachum@tipalti.com" in text
+
+
+def test_at_username_resolves_to_assignment(data_dir: Path) -> None:
+    """Failed-autocomplete (`@username` instead of `<@Uxxx>` markup)
+    should be treated as a bare token after the leading ``@`` is
+    stripped."""
+    service = _service_with_active(data_dir, "ori.nachum@tipalti.com")
+    service.assign("5-T-03", "ori.nachum@tipalti.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "@ori.nachum"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "5-T-03" in text
+
+
+def test_bare_token_no_match_renders_helpful_error(data_dir: Path) -> None:
+    """Unknown bare token renders the new ``no_match_for_token`` block
+    with guidance on what is accepted."""
+    service = _service_with_active(data_dir)
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "ghost"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "Couldn't find a seat for `ghost`" in text
+    assert "email" in text.lower() or "@mention" in text
+
+
+def test_bare_token_disambiguation_renders_candidates(data_dir: Path) -> None:
+    """Two assignments sharing a local-part across domains → the multi-
+    section disambiguation block lists both and ends with the
+    "re-run with the full email" hint."""
+    service = _service_with_active(data_dir, "alice@x.com", "alice@y.com")
+    service.assign("5-T-01", "alice@x.com")
+    service.assign("5-T-02", "alice@y.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alice"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "Multiple seats matched" in text
+    assert "alice@x.com" in text
+    assert "alice@y.com" in text
+    assert "5-T-01" in text
+    assert "5-T-02" in text
+    assert "Re-run with the full email" in text

--- a/tests/test_slack_resolve.py
+++ b/tests/test_slack_resolve.py
@@ -53,10 +53,48 @@ def test_first_email_wins_among_many() -> None:
     assert target.email == "alice@x.com"
 
 
-def test_unparseable_text_marks_failure() -> None:
+def test_bare_token_is_captured() -> None:
+    """#29 MVP: a bare name/username token now parses to ``bare_token``
+    so the handler can resolve via the assignment store's email
+    local-parts. ``"nope"`` is no longer a parse failure."""
     target = parse_target("nope")
-    assert target.ok is False
+    assert target.bare_token == "nope"
+    assert target.email == ""
+    assert target.user_id == ""
+    assert target.ok is True
     assert target.raw == "nope"
+
+
+def test_at_prefix_is_stripped_from_bare_token() -> None:
+    """Failed-autocomplete case: Slack sometimes substitutes only
+    ``@username`` instead of the proper ``<@Uxxx>`` markup."""
+    target = parse_target("@ori.nachum")
+    assert target.bare_token == "ori.nachum"
+    assert target.email == ""
+    assert target.user_id == ""
+
+
+def test_email_still_wins_over_bare_token() -> None:
+    """Plain email parses as ``email``; ``bare_token`` stays empty."""
+    target = parse_target("alice@x.com")
+    assert target.email == "alice@x.com"
+    assert target.bare_token == ""
+
+
+def test_mention_still_wins_over_bare_token() -> None:
+    """Mention parses as ``user_id``; ``bare_token`` stays empty."""
+    target = parse_target("<@U12345|alice>")
+    assert target.user_id == "U12345"
+    assert target.bare_token == ""
+
+
+def test_token_containing_at_still_fails() -> None:
+    """A token like ``foo@`` (broken email) shouldn't be captured as a
+    bare token — it can't usefully resolve as a local-part."""
+    target = parse_target("foo@")
+    assert target.bare_token == ""
+    assert target.email == ""
+    assert target.ok is False
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -640,7 +640,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.9.6"
+version = "0.9.7"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- `/whereis` now accepts a bare name or username — `/whereis ori.nachum` resolves to `ori.nachum@<any-domain>` via assignment-store email local-parts (case-insensitive).
- Failed-autocomplete shape (`@ori.nachum` instead of proper `<@Uxxx>` markup) is treated identically — leading `@` stripped before lookup.
- 0 matches → friendly error pointing at email/`@mention`. 1 match → standard seat-found render. 2+ matches → ephemeral disambiguation list with each candidate's full email + seat + a "re-run with full email" hint.
- Hidden seats keep redaction in the disambiguation list (no email leaks for viewer-role callers).
- `parse_failed` text now mentions name + `@mention` + email as accepted forms.

This is the MVP slice of #29's resolution chain. Two follow-ups cover the rest:

- **#38** — Slack `users.list` exact-name lookup + TTL cache + opt-out env var.
- **#39** — Fuzzy / partial matching + interactive Block Kit disambiguation UI.

Closes #29 (MVP).

## Test plan

- [x] `uv run pytest -n auto -q` — 329 passed (was 316; +13 new tests across resolver, service, handler).
- [x] `uv run black/isort/flake8` clean.
- [x] `markdownlint-cli2 CHANGELOG.md` clean.
- [x] Resolver: `bare_token` captured for plain names, `@`-prefix stripped, broken emails (`foo@`) still fail, mention/email paths unchanged.
- [x] Service: exact-only local-part match, case-insensitive, multi-domain returns multiple, partial prefix `ali` does NOT match `alice@…` (deferred to #39).
- [x] Handler: bare-token resolves, `@username` resolves, no-match renders helpful error, ≥2 matches renders disambiguation listing all candidates.
- [ ] Live verification against the Tipalti workspace: `/beta-whereis ori.nachum`, `/beta-whereis @ori.nachum`, `/beta-whereis nobody`.

## Backwards compatibility

- Existing `<@Uxxx>` and full-email paths are unchanged; their tests stay green untouched.
- One existing test (`test_unparseable_text`) updated: post-#29, a bare token is no longer a parse failure — the no-match block fires instead.

- Claude