### PR TITLE
feat(slack): users.list name resolution with TTL cache (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.8] - 2026-05-05
+
+### Added
+
+- Slack `/whereis` now resolves bare names against the Slack workspace
+  roster as a follow-up to the email-local-part path landed in
+  [#29](https://github.com/agentculture/office-agent/issues/29).
+  When `find_by_local_part` returns no hits, the handler falls
+  through to a TTL-cached (`OFFICE_SLACK_DIRECTORY_TTL`-tunable;
+  default 300s) `users.list` lookup against `display_name`,
+  `real_name`, and `name`. Exact match wins; multiple matches render
+  the new `disambiguation_users` block (display name + email per
+  candidate) so the caller can re-run with the unambiguous email.
+  Bots, deleted users, and members without a profile email are
+  excluded from the cache. The lookup is fail-open: a transient
+  `users.list` outage keeps serving the previous cache and emits a
+  stderr diagnostic, and a first-attempt failure logs and falls
+  through to the no-match block instead of crashing the listener.
+  ([#38](https://github.com/agentculture/office-agent/issues/38))
+
+- `OFFICE_SLACK_DIRECTORY` env var (read by `office slack-serve`)
+  short-circuits the new path entirely. Set to `disabled` / `off` /
+  `0` / `false` / `no` (case-insensitive) to skip every `users.list`
+  call — recommended for workspaces with tens of thousands of
+  members where the roster fetch is wasteful and the local-part path
+  plus explicit emails are sufficient.
+  ([#38](https://github.com/agentculture/office-agent/issues/38))
+
 ## [0.9.7] - 2026-05-05
 
 ### Added

--- a/office_cli/cli/_commands/slack_serve.py
+++ b/office_cli/cli/_commands/slack_serve.py
@@ -59,6 +59,13 @@ def cmd_slack_serve(args: argparse.Namespace) -> int:
     data_dir = resolve_data_dir(args)
     service = build_service(data_dir, actor="slack")
 
+    # #38: parse the directory env vars before slack-bolt construction
+    # so a misconfigured TTL surfaces as an EXIT_ENV_ERROR rather than
+    # being masked by a downstream BoltError when the App's auth.test
+    # fires on a real network call.
+    directory_enabled = parse_directory_enabled_env()
+    ttl_seconds = _parse_ttl_env(os.environ.get("OFFICE_SLACK_DIRECTORY_TTL"))
+
     # slack_bolt is imported lazily inside `build_app` / `run_socket_mode`
     # so a missing extra surfaces as a clear OfficeError.
     try:
@@ -69,16 +76,69 @@ def cmd_slack_serve(args: argparse.Namespace) -> int:
             message="slack-bolt is not installed",
             remediation=("install the slack extra: pip install office-cli[slack]"),
         ) from err
-    from office_cli.slack import build_app, run_socket_mode
+    from office_cli.slack import SlackUserDirectory, build_app, run_socket_mode
 
     app = App(token=bot_token)
+
+    slack_directory = SlackUserDirectory(
+        app.client, enabled=directory_enabled, cache_ttl_seconds=ttl_seconds
+    )
+    if not directory_enabled:
+        emit_diagnostic(
+            "OFFICE_SLACK_DIRECTORY=disabled — name resolution falls back to "
+            "email / @mention only (no users.list lookup)."
+        )
+
     # Pass ``data_dir`` so build_app auto-resolves the roles map from
     # ``data/offices.yaml``. Without this, every Slack caller would be
     # treated as ``viewer`` regardless of the editor/planning lists.
-    build_app(service, app=app, data_dir=data_dir, command_name=command_name)
+    build_app(
+        service,
+        app=app,
+        data_dir=data_dir,
+        slack_directory=slack_directory,
+        command_name=command_name,
+    )
     emit_diagnostic(f"Slack {command_name} listener starting (Socket Mode)…")
     run_socket_mode(app, app_token)
     return 0
+
+
+_DEFAULT_TTL_SECONDS = 300
+
+
+def parse_directory_enabled_env() -> bool:
+    """Wrapper around the slack-package helper so this module doesn't
+    have to import :mod:`office_cli.slack` for what should be a pure
+    string parse — keeps the early-validation path free of slack-bolt
+    side effects."""
+    from office_cli.slack._directory import parse_directory_enabled
+
+    return parse_directory_enabled(os.environ.get("OFFICE_SLACK_DIRECTORY"))
+
+
+def _parse_ttl_env(raw: str | None) -> int:
+    """Read ``OFFICE_SLACK_DIRECTORY_TTL``. Default 300s; non-positive
+    ints or unparseable values raise ``OfficeError`` so a misconfigured
+    deployment fails loudly at startup rather than silently caching
+    forever (or hammering the API every request)."""
+    if raw is None or not raw.strip():
+        return _DEFAULT_TTL_SECONDS
+    try:
+        value = int(raw.strip())
+    except ValueError as err:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message=f"OFFICE_SLACK_DIRECTORY_TTL must be an integer; got {raw!r}",
+            remediation="set OFFICE_SLACK_DIRECTORY_TTL to a positive number of seconds",
+        ) from err
+    if value <= 0:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message=f"OFFICE_SLACK_DIRECTORY_TTL must be > 0; got {value}",
+            remediation="pick a TTL ≥ 1 second, or unset to use the 300s default",
+        )
+    return value
 
 
 def register(sub: argparse._SubParsersAction) -> None:

--- a/office_cli/slack/__init__.py
+++ b/office_cli/slack/__init__.py
@@ -17,6 +17,17 @@ can still import :mod:`office_cli` cleanly.
 from __future__ import annotations
 
 from office_cli.slack._app import build_app
+from office_cli.slack._directory import (
+    SlackUser,
+    SlackUserDirectory,
+    parse_directory_enabled,
+)
 from office_cli.slack._serve import run_socket_mode
 
-__all__ = ["build_app", "run_socket_mode"]
+__all__ = [
+    "build_app",
+    "run_socket_mode",
+    "SlackUser",
+    "SlackUserDirectory",
+    "parse_directory_enabled",
+]

--- a/office_cli/slack/_app.py
+++ b/office_cli/slack/_app.py
@@ -16,6 +16,7 @@ from office_cli._roles import RolesConfig, resolve_roles, role_for_email
 from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
 from office_cli.seats import SeatService
 from office_cli.slack import _blocks
+from office_cli.slack._directory import SlackUserDirectory
 from office_cli.slack._resolve import ParsedTarget, parse_target
 
 _AUTO = object()
@@ -27,6 +28,7 @@ def build_app(
     app: Any | None = None,
     roles: Any = None,
     data_dir: Path | None = None,
+    slack_directory: SlackUserDirectory | None = None,
     command_name: str = "/whereis",
 ) -> Any:
     """Register the configured slash-command listener and return the app.
@@ -50,6 +52,13 @@ def build_app(
     app) can rebind by setting ``OFFICE_SLACK_COMMAND`` on the
     ``slack-serve`` entry point. Surrounding whitespace is stripped;
     the resulting value must be non-empty and start with ``/``.
+
+    ``slack_directory`` (#38) is an optional :class:`SlackUserDirectory`
+    consulted when the bare-token MVP from #29 returns no local-part
+    match. ``None`` (the default) keeps the local-part-only behavior;
+    pass an instance to enable name → email resolution against the
+    Slack workspace roster. The slack-serve entry point constructs one
+    by default and respects ``OFFICE_SLACK_DIRECTORY=disabled``.
     """
     command_name = command_name.strip()
     if not command_name or not command_name.startswith("/"):
@@ -70,7 +79,9 @@ def build_app(
         ack()
         text = command.get("text", "")
         target = parse_target(text)
-        blocks, label = _resolve_and_lookup(service, client, body, command, target, roles)
+        blocks, label = _resolve_and_lookup(
+            service, client, body, command, target, roles, slack_directory
+        )
         # ``command`` is the slash-command payload and is the canonical
         # source for ``channel_id``/``user_id``; ``body`` is the Bolt-
         # wrapped envelope and may differ in some adapter shapes. Prefer
@@ -92,6 +103,7 @@ def _resolve_and_lookup(
     command: dict,
     target: ParsedTarget,
     roles: RolesConfig | None,
+    slack_directory: SlackUserDirectory | None = None,
 ) -> tuple[list[dict[str, Any]], str]:
     """Resolve a :class:`ParsedTarget` to an email + label and run lookup."""
     if not target.ok:
@@ -116,7 +128,13 @@ def _resolve_and_lookup(
         return _lookup(service, email, label, as_of=as_of, role=role)
 
     if target.bare_token:
-        return _lookup_by_local_part(service, target.bare_token, as_of=as_of, role=role)
+        return _lookup_by_local_part(
+            service,
+            target.bare_token,
+            as_of=as_of,
+            role=role,
+            slack_directory=slack_directory,
+        )
 
     user_id = target.user_id or command.get("user_id") or body.get("user_id", "")
     if not user_id:
@@ -179,18 +197,23 @@ def _lookup_by_local_part(
     *,
     as_of: str | None = None,
     role: str | None = None,
+    slack_directory: SlackUserDirectory | None = None,
 ) -> tuple[list[dict[str, Any]], str]:
-    """#29 MVP: ``/whereis ori.nachum`` resolves via the assignment
-    store's email local-parts. 0 → friendly error; 1 → standard
-    seat-found render; 2+ → disambiguation list."""
+    """#29 MVP + #38: ``/whereis ori.nachum`` resolves via the
+    assignment store's email local-parts; if no local-part hits and a
+    Slack directory is configured, fall through to a name lookup
+    against the workspace roster.
+
+    ``text`` fallback strings stay free of ``token``: Slack parses the
+    fallback for ``<!here>`` / ``<@U…>`` / ``<#C…>`` sequences when
+    blocks aren't rendered, so an attacker-controlled token must not
+    land there. The block builders escape the token for mrkdwn
+    display; the fallback uses constants.
+    """
     matches = service.find_by_local_part(token, as_of=as_of, role=role)
-    # ``text`` fallback strings stay free of ``token``: Slack parses the
-    # fallback for ``<!here>`` / ``<@U…>`` / ``<#C…>`` sequences when
-    # blocks aren't rendered, so an attacker-controlled token must not
-    # land there. The block builders escape the token for mrkdwn
-    # display; the fallback uses constants.
     if not matches:
-        return _blocks.no_match_for_token(token), "no seat found for that name"
+        # #38: try the Slack workspace roster for a name match.
+        return _lookup_by_slack_directory(service, token, slack_directory, as_of=as_of, role=role)
     if len(matches) == 1:
         a = matches[0]
         # Use the resolved (store-derived) email as the label so even
@@ -203,6 +226,38 @@ def _lookup_by_local_part(
             f"{label} → {a.seat_id}",
         )
     return _blocks.disambiguation(token, matches), f"{len(matches)} matches"
+
+
+def _lookup_by_slack_directory(
+    service: SeatService,
+    token: str,
+    slack_directory: SlackUserDirectory | None,
+    *,
+    as_of: str | None,
+    role: str | None,
+) -> tuple[list[dict[str, Any]], str]:
+    """#38: name-match against the Slack workspace roster, with the
+    directory's TTL cache. Disabled / unavailable directory returns
+    the local-part path's no-match block — the caller perceives a
+    single resolution chain ending in the same error.
+    """
+    if slack_directory is None or not slack_directory.enabled:
+        return _blocks.no_match_for_token(token), "no seat found for that name"
+    candidates = slack_directory.find_by_name(token)
+    if not candidates:
+        return _blocks.no_match_for_token(token), "no seat found for that name"
+    if len(candidates) == 1:
+        return _lookup(
+            service,
+            email=candidates[0].email,
+            label=candidates[0].email,
+            as_of=as_of,
+            role=role,
+        )
+    return (
+        _blocks.disambiguation_users(token, candidates),
+        f"{len(candidates)} matches",
+    )
 
 
 def _lookup(

--- a/office_cli/slack/_blocks.py
+++ b/office_cli/slack/_blocks.py
@@ -191,12 +191,22 @@ def disambiguation(token: str, matches: list[Assignment]) -> list[dict[str, Any]
     return blocks
 
 
+_DISAMBIG_CANDIDATE_LIMIT = 10
+
+
 def disambiguation_users(token: str, candidates: list[SlackUser]) -> list[dict[str, Any]]:
     """#38: render the multi-section list for a Slack-roster name
     match where ≥2 workspace users share the requested name. Each
     candidate gets a section showing their best-available display name
     and full email so the caller can re-run with the unambiguous
-    address. Same mrkdwn-escape contract as :func:`disambiguation`."""
+    address. Same mrkdwn-escape contract as :func:`disambiguation`.
+
+    Slack caps a message at 50 blocks total. A common name in a large
+    workspace can match dozens of users, which would push us past
+    that limit and silently break ``chat.postEphemeral``. Cap the
+    rendered candidates at :data:`_DISAMBIG_CANDIDATE_LIMIT` and add
+    a "…and N more" context line so the caller knows to refine.
+    """
     safe_token = _escape_mrkdwn(token)
     blocks: list[dict[str, Any]] = [
         {
@@ -207,7 +217,9 @@ def disambiguation_users(token: str, candidates: list[SlackUser]) -> list[dict[s
             },
         }
     ]
-    for u in candidates:
+    rendered = candidates[:_DISAMBIG_CANDIDATE_LIMIT]
+    overflow = len(candidates) - len(rendered)
+    for u in rendered:
         # Prefer display_name (what people see in Slack), fall back to
         # real_name, then to ``name``. Strip + escape to keep the
         # mrkdwn parser tame on user-supplied profile fields.
@@ -220,6 +232,21 @@ def disambiguation_users(token: str, candidates: list[SlackUser]) -> list[dict[s
                     "type": "mrkdwn",
                     "text": f"• {rendered_name} — `{rendered_email}`",
                 },
+            }
+        )
+    if overflow:
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": (
+                            f"_…and {overflow} more — refine your query "
+                            f"(full email or `@mention`)._"
+                        ),
+                    }
+                ],
             }
         )
     blocks.append(

--- a/office_cli/slack/_blocks.py
+++ b/office_cli/slack/_blocks.py
@@ -13,6 +13,7 @@ import os
 from typing import Any
 
 from office_cli.seats import Assignment
+from office_cli.slack._directory import SlackUser
 
 
 def _escape_mrkdwn(s: str) -> str:
@@ -174,6 +175,51 @@ def disambiguation(token: str, matches: list[Assignment]) -> list[dict[str, Any]
             {
                 "type": "section",
                 "text": {"type": "mrkdwn", "text": line},
+            }
+        )
+    blocks.append(
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": "_Re-run with the full email to pick one._",
+                }
+            ],
+        }
+    )
+    return blocks
+
+
+def disambiguation_users(token: str, candidates: list[SlackUser]) -> list[dict[str, Any]]:
+    """#38: render the multi-section list for a Slack-roster name
+    match where ≥2 workspace users share the requested name. Each
+    candidate gets a section showing their best-available display name
+    and full email so the caller can re-run with the unambiguous
+    address. Same mrkdwn-escape contract as :func:`disambiguation`."""
+    safe_token = _escape_mrkdwn(token)
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"Multiple Slack users matched `{safe_token}`:",
+            },
+        }
+    ]
+    for u in candidates:
+        # Prefer display_name (what people see in Slack), fall back to
+        # real_name, then to ``name``. Strip + escape to keep the
+        # mrkdwn parser tame on user-supplied profile fields.
+        rendered_name = _escape_mrkdwn(u.display_name or u.real_name or u.name or "(unnamed)")
+        rendered_email = _escape_mrkdwn(u.email)
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"• {rendered_name} — `{rendered_email}`",
+                },
             }
         )
     blocks.append(

--- a/office_cli/slack/_directory.py
+++ b/office_cli/slack/_directory.py
@@ -90,6 +90,13 @@ class SlackUserDirectory:
         self._cache_at: float = 0.0
         self._last_attempt_at: float = 0.0
         self._has_cache = False
+        # Distinct from ``_has_cache``: tracks whether *any* refresh
+        # attempt has run, so a failed first fetch still gates
+        # subsequent calls within the TTL. Without this, ``now=0.0``
+        # under a deterministic clock would leave the
+        # ``_last_attempt_at`` gate falsy and bypass rate-limiting on
+        # the failure path.
+        self._attempted_once = False
 
     @property
     def enabled(self) -> bool:
@@ -114,11 +121,17 @@ class SlackUserDirectory:
         self._cache_at = 0.0
         self._last_attempt_at = 0.0
         self._has_cache = False
+        self._attempted_once = False
 
     def _refresh_if_stale(self) -> None:
         now = self._clock()
-        if self._has_cache and (now - self._last_attempt_at) < self._ttl:
+        # Gate every refresh on ``_attempted_once`` (success or failure)
+        # so a Slack outage on the first call doesn't turn into a
+        # request storm — ``_has_cache`` would only be True after a
+        # successful fetch, leaving the failure path uncovered.
+        if self._attempted_once and (now - self._last_attempt_at) < self._ttl:
             return
+        self._attempted_once = True
         try:
             users = list(_fetch_all(self._client))
         except Exception as err:  # noqa: BLE001 — fail-open
@@ -148,28 +161,36 @@ def _fetch_all(client: Any) -> Iterable[SlackUser]:
 
     Skips bots, deleted users, and users without an email — none of
     those can be resolved to a seat assignment, so keeping them in the
-    cache wastes memory and makes ambiguous matches worse.
+    cache wastes memory and makes ambiguous matches worse. The
+    per-page filter+dedup loop lives in :func:`_yield_unique_users` so
+    this function stays under SonarCloud's cognitive-complexity cap.
     """
     cursor: str | None = None
     seen_user_ids: set[str] = set()
     while True:
-        resp = client.users_list(cursor=cursor)
-        members = (resp or {}).get("members") or []
-        for raw in members:
-            user = _user_from_member(raw)
-            if user is None:
-                continue
-            if user.user_id in seen_user_ids:
-                # Defensive: Slack has been observed to repeat entries
-                # across cursor boundaries on some endpoints. Cheap to
-                # guard, expensive to debug if it happens.
-                continue
-            seen_user_ids.add(user.user_id)
-            yield user
-        meta = (resp or {}).get("response_metadata") or {}
+        resp = client.users_list(cursor=cursor) or {}
+        members = resp.get("members") or []
+        yield from _yield_unique_users(members, seen_user_ids)
+        meta = resp.get("response_metadata") or {}
         cursor = (meta.get("next_cursor") or "").strip()
         if not cursor:
             return
+
+
+def _yield_unique_users(
+    members: Iterable[dict[str, Any]], seen_user_ids: set[str]
+) -> Iterable[SlackUser]:
+    """Filter out bots/deleted/no-email entries and dedupe by
+    ``user_id``. ``seen_user_ids`` is mutated across pages so cursor
+    repeats (rare but observed) yield each user exactly once."""
+    for raw in members:
+        user = _user_from_member(raw)
+        if user is None:
+            continue
+        if user.user_id in seen_user_ids:
+            continue
+        seen_user_ids.add(user.user_id)
+        yield user
 
 
 def _user_from_member(raw: dict[str, Any]) -> SlackUser | None:

--- a/office_cli/slack/_directory.py
+++ b/office_cli/slack/_directory.py
@@ -1,0 +1,208 @@
+"""TTL-cached Slack ``users.list`` directory for ``/whereis`` name
+resolution (#38, follow-up A to #29).
+
+When the bare-token MVP from #29 doesn't find an assignment via
+local-part match, the handler can fall through to this directory and
+try an exact-match lookup against ``display_name`` / ``real_name`` /
+``name`` from Slack's user roster.
+
+Two operational concerns drive the design:
+
+* ``users.list`` is paginated and can be slow on large workspaces, so
+  results are cached for ``cache_ttl_seconds`` (default 5 min) and
+  attempts are rate-limited against transient outages — same pattern
+  as :class:`office_cli.people.bamboohr.BambooHRDirectory`.
+* Some workspaces have tens of thousands of members and don't want
+  this path at all. ``enabled=False`` short-circuits every lookup
+  without ever calling the API.
+
+The :class:`SlackDirectoryClient` Protocol intentionally accepts only
+the one method the directory uses, so tests pass a fake without
+pulling in :mod:`slack_sdk`.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Iterable, Protocol
+
+from office_cli.cli._output import emit_diagnostic
+
+_DEFAULT_TTL_SECONDS = 300
+
+
+@dataclass(frozen=True)
+class SlackUser:
+    """Subset of a Slack user record we use for name resolution."""
+
+    user_id: str
+    display_name: str
+    real_name: str
+    name: str
+    email: str
+
+    def matches(self, token: str) -> bool:
+        """Case-insensitive exact match against any of the three name
+        fields. Empty fields are skipped — Slack often leaves
+        ``display_name`` blank for users who never customized it."""
+        needle = token.lower()
+        for field in (self.display_name, self.real_name, self.name):
+            if field and field.lower() == needle:
+                return True
+        return False
+
+
+class SlackDirectoryClient(Protocol):
+    """Structural type for the one Slack call this module needs.
+
+    The production implementation is :class:`slack_sdk.web.WebClient`,
+    whose ``users_list(cursor=...)`` returns a dict-like response with
+    ``members`` and ``response_metadata.next_cursor``.
+    """
+
+    def users_list(self, *, cursor: str | None = None) -> Any: ...
+
+
+class SlackUserDirectory:
+    """``users.list``-backed name → email resolver with TTL caching.
+
+    Construct with ``enabled=False`` (or via the
+    ``OFFICE_SLACK_DIRECTORY`` env var on the slack-serve entry point)
+    to short-circuit every lookup; this is the recommended setting for
+    workspaces with tens of thousands of members where pulling the
+    full roster every five minutes is wasteful.
+    """
+
+    def __init__(
+        self,
+        client: SlackDirectoryClient | None,
+        *,
+        enabled: bool = True,
+        cache_ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+        clock: "callable[[], float] | None" = None,  # type: ignore[name-defined]
+    ) -> None:
+        self._client = client
+        self._enabled = enabled and client is not None
+        self._ttl = cache_ttl_seconds
+        self._clock = clock or time.monotonic
+        self._users: list[SlackUser] = []
+        self._cache_at: float = 0.0
+        self._last_attempt_at: float = 0.0
+        self._has_cache = False
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def find_by_name(self, token: str) -> list[SlackUser]:
+        """Return every Slack user whose display/real/name field
+        equals ``token`` case-insensitively.
+
+        Returns an empty list when the directory is disabled or the
+        token is empty. Refresh failures preserve the previous cache
+        (fail-open, so a transient Slack outage doesn't block the
+        whole resolution chain).
+        """
+        if not self._enabled or not token:
+            return []
+        self._refresh_if_stale()
+        return [u for u in self._users if u.matches(token)]
+
+    def invalidate(self) -> None:
+        self._users = []
+        self._cache_at = 0.0
+        self._last_attempt_at = 0.0
+        self._has_cache = False
+
+    def _refresh_if_stale(self) -> None:
+        now = self._clock()
+        if self._has_cache and (now - self._last_attempt_at) < self._ttl:
+            return
+        try:
+            users = list(_fetch_all(self._client))
+        except Exception as err:  # noqa: BLE001 — fail-open
+            self._last_attempt_at = now
+            if self._has_cache:
+                age = now - self._cache_at
+                emit_diagnostic(
+                    f"Slack users.list fetch failed ({err.__class__.__name__}: {err}); "
+                    f"serving cached directory from {age:.0f}s ago"
+                )
+                return
+            emit_diagnostic(
+                f"Slack users.list fetch failed on first attempt "
+                f"({err.__class__.__name__}: {err}); name resolution disabled "
+                f"until the next refresh window"
+            )
+            self._users = []
+            return
+        self._users = users
+        self._cache_at = now
+        self._last_attempt_at = now
+        self._has_cache = True
+
+
+def _fetch_all(client: Any) -> Iterable[SlackUser]:
+    """Walk ``users_list`` pages and yield filtered :class:`SlackUser`s.
+
+    Skips bots, deleted users, and users without an email — none of
+    those can be resolved to a seat assignment, so keeping them in the
+    cache wastes memory and makes ambiguous matches worse.
+    """
+    cursor: str | None = None
+    seen_user_ids: set[str] = set()
+    while True:
+        resp = client.users_list(cursor=cursor)
+        members = (resp or {}).get("members") or []
+        for raw in members:
+            user = _user_from_member(raw)
+            if user is None:
+                continue
+            if user.user_id in seen_user_ids:
+                # Defensive: Slack has been observed to repeat entries
+                # across cursor boundaries on some endpoints. Cheap to
+                # guard, expensive to debug if it happens.
+                continue
+            seen_user_ids.add(user.user_id)
+            yield user
+        meta = (resp or {}).get("response_metadata") or {}
+        cursor = (meta.get("next_cursor") or "").strip()
+        if not cursor:
+            return
+
+
+def _user_from_member(raw: dict[str, Any]) -> SlackUser | None:
+    if not isinstance(raw, dict):
+        return None
+    if raw.get("is_bot") or raw.get("deleted"):
+        return None
+    user_id = (raw.get("id") or "").strip()
+    if not user_id:
+        return None
+    profile = raw.get("profile") or {}
+    email = (profile.get("email") or "").strip()
+    if not email:
+        return None
+    return SlackUser(
+        user_id=user_id,
+        display_name=(profile.get("display_name") or "").strip(),
+        real_name=(profile.get("real_name") or "").strip(),
+        name=(raw.get("name") or "").strip(),
+        email=email,
+    )
+
+
+_DISABLED_VALUES = frozenset({"disabled", "off", "0", "false", "no"})
+
+
+def parse_directory_enabled(raw: str | None) -> bool:
+    """Read the ``OFFICE_SLACK_DIRECTORY`` env value.
+
+    ``None`` / empty / unrecognized → enabled (default-on).
+    Any of ``disabled``/``off``/``0``/``false``/``no``
+    (case-insensitive) → disabled.
+    """
+    if raw is None:
+        return True
+    return raw.strip().lower() not in _DISABLED_VALUES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.9.7"
+version = "0.9.8"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_slack_serve.py
+++ b/tests/test_cli_slack_serve.py
@@ -63,3 +63,29 @@ def test_empty_office_slack_command_is_rejected(
     err = capsys.readouterr().err
     assert "OFFICE_SLACK_COMMAND" in err
     assert "empty" in err
+
+
+@pytest.mark.parametrize("bad", ["abc", "0", "-5", "  "])
+def test_invalid_directory_ttl_is_rejected(
+    bad: str,
+    data_dir: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``OFFICE_SLACK_DIRECTORY_TTL`` is parsed before slack-bolt
+    starts; non-positive ints / non-ints fail fast with a clear
+    remediation. ``"  "`` is treated as unset and falls back to the
+    default — exclude it from the bad-value sweep when it would
+    otherwise reach the bolt-import path."""
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+    monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-test")
+    monkeypatch.setenv("OFFICE_SLACK_DIRECTORY_TTL", bad)
+    if bad.strip() == "":
+        # Whitespace-only TTL is treated as unset → would proceed to
+        # bolt's network init, which we don't want to exercise here.
+        # The behavior is verified by the other parametrize cases.
+        return
+    rc = main(["slack-serve", "--data-dir", str(data_dir)])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "OFFICE_SLACK_DIRECTORY_TTL" in err

--- a/tests/test_cli_slack_serve.py
+++ b/tests/test_cli_slack_serve.py
@@ -65,7 +65,7 @@ def test_empty_office_slack_command_is_rejected(
     assert "empty" in err
 
 
-@pytest.mark.parametrize("bad", ["abc", "0", "-5", "  "])
+@pytest.mark.parametrize("bad", ["abc", "0", "-5"])
 def test_invalid_directory_ttl_is_rejected(
     bad: str,
     data_dir: Path,
@@ -74,18 +74,25 @@ def test_invalid_directory_ttl_is_rejected(
 ) -> None:
     """``OFFICE_SLACK_DIRECTORY_TTL`` is parsed before slack-bolt
     starts; non-positive ints / non-ints fail fast with a clear
-    remediation. ``"  "`` is treated as unset and falls back to the
-    default — exclude it from the bad-value sweep when it would
-    otherwise reach the bolt-import path."""
+    remediation, so a misconfigured deployment doesn't get masked by
+    a downstream BoltError."""
     monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
     monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-test")
     monkeypatch.setenv("OFFICE_SLACK_DIRECTORY_TTL", bad)
-    if bad.strip() == "":
-        # Whitespace-only TTL is treated as unset → would proceed to
-        # bolt's network init, which we don't want to exercise here.
-        # The behavior is verified by the other parametrize cases.
-        return
     rc = main(["slack-serve", "--data-dir", str(data_dir)])
     assert rc == 2
     err = capsys.readouterr().err
     assert "OFFICE_SLACK_DIRECTORY_TTL" in err
+
+
+def test_whitespace_directory_ttl_uses_default() -> None:
+    """``OFFICE_SLACK_DIRECTORY_TTL="   "`` (whitespace-only) is
+    treated as unset and falls back to the default. Asserted against
+    the parse helper directly so the test doesn't have to spin up
+    slack-bolt; the integration path is exercised by the bot-token
+    happy-path tests."""
+    from office_cli.cli._commands.slack_serve import _DEFAULT_TTL_SECONDS, _parse_ttl_env
+
+    assert _parse_ttl_env("   ") == _DEFAULT_TTL_SECONDS
+    assert _parse_ttl_env("") == _DEFAULT_TTL_SECONDS
+    assert _parse_ttl_env(None) == _DEFAULT_TTL_SECONDS

--- a/tests/test_slack_app.py
+++ b/tests/test_slack_app.py
@@ -777,6 +777,69 @@ def test_disabled_slack_directory_keeps_legacy_no_match_path(data_dir: Path) -> 
     assert "Couldn't find a seat for `ghost`" in text
 
 
+def test_disambiguation_users_caps_render_with_overflow_hint(data_dir: Path) -> None:
+    """PR #41 review (Copilot): Slack messages cap at 50 blocks; a
+    common name in a large workspace can match dozens of users. The
+    builder must render at most ``_DISAMBIG_CANDIDATE_LIMIT``
+    candidates and add a context block reporting the rest, so
+    ``chat.postEphemeral`` doesn't reject the payload silently."""
+    from office_cli.slack._blocks import _DISAMBIG_CANDIDATE_LIMIT, disambiguation_users
+    from office_cli.slack._directory import SlackUser
+
+    candidates = [
+        SlackUser(
+            user_id=f"U_{i}",
+            display_name=f"Alex {i}",
+            real_name=f"Alex {i}",
+            name=f"alex.{i}",
+            email=f"alex.{i}@example.com",
+        )
+        for i in range(25)
+    ]
+    blocks = disambiguation_users("alex", candidates)
+
+    # Header + at-most-cap sections + overflow context + final hint.
+    section_blocks = [b for b in blocks if b.get("type") == "section"]
+    assert len(section_blocks) == 1 + _DISAMBIG_CANDIDATE_LIMIT  # header + capped list
+
+    # Overflow context block reports the remainder.
+    text = _block_text(blocks)
+    overflow = 25 - _DISAMBIG_CANDIDATE_LIMIT
+    assert f"…and {overflow} more" in text
+    assert "Re-run with the full email" in text
+
+    # Total payload stays well under Slack's 50-block ceiling.
+    assert len(blocks) < 50
+
+
+def test_disambiguation_users_no_overflow_hint_when_under_cap(data_dir: Path) -> None:
+    """When candidate count is at or below the cap, no overflow context
+    block is added — only the standard "re-run with full email" hint."""
+    from office_cli.slack._blocks import disambiguation_users
+    from office_cli.slack._directory import SlackUser
+
+    candidates = [
+        SlackUser(
+            user_id="U_A",
+            display_name="Alice",
+            real_name="Alice A",
+            name="alice.a",
+            email="alice.a@example.com",
+        ),
+        SlackUser(
+            user_id="U_B",
+            display_name="Alice",
+            real_name="Alice B",
+            name="alice.b",
+            email="alice.b@example.com",
+        ),
+    ]
+    blocks = disambiguation_users("Alice", candidates)
+    text = _block_text(blocks)
+    assert "more — refine" not in text
+    assert "Re-run with the full email" in text
+
+
 def test_local_part_wins_before_slack_directory(data_dir: Path) -> None:
     """The Slack directory is consulted only when the local-part path
     misses; an existing assignment short-circuits the API call."""

--- a/tests/test_slack_app.py
+++ b/tests/test_slack_app.py
@@ -666,6 +666,147 @@ def test_bare_token_text_fallback_does_not_leak_token(data_dir: Path) -> None:
     assert client.posted[-1]["text"] == "no seat found for that name"
 
 
+def test_slack_directory_resolves_single_match_to_seat(data_dir: Path) -> None:
+    """#38: when local-part match misses, fall through to a Slack
+    workspace name match. One match → use the candidate's email →
+    standard seat-found render via ``_lookup``.
+    """
+    from office_cli.slack._directory import SlackUser, SlackUserDirectory
+
+    service = _service_with_active(data_dir, "alice@example.com")
+    service.assign("5-T-01", "alice@example.com")
+
+    class StaticDirectory(SlackUserDirectory):
+        def __init__(self, users: list[SlackUser]) -> None:
+            self._users_static = users
+            self._enabled = True
+
+        def find_by_name(self, token: str) -> list[SlackUser]:  # type: ignore[override]
+            return [u for u in self._users_static if u.matches(token)]
+
+    directory = StaticDirectory(
+        [
+            SlackUser(
+                user_id="U_ALICE",
+                display_name="Alice",
+                real_name="Alice Smith",
+                name="alice",
+                email="alice@example.com",
+            )
+        ]
+    )
+    app = build_app(service, app=FakeSlackApp(), slack_directory=directory)
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "Alice"},  # display name, not the local-part
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "5-T-01" in text
+    assert "alice@example.com" in text
+
+
+def test_slack_directory_disambiguation_for_multiple_matches(data_dir: Path) -> None:
+    """≥2 Slack users sharing the matched name render the new
+    ``disambiguation_users`` block (display name + email per
+    candidate, no seat info)."""
+    from office_cli.slack._directory import SlackUser, SlackUserDirectory
+
+    service = _service_with_active(data_dir, "alice.x@x.com", "alice.y@y.com")
+
+    class StaticDirectory(SlackUserDirectory):
+        def __init__(self, users: list[SlackUser]) -> None:
+            self._users_static = users
+            self._enabled = True
+
+        def find_by_name(self, token: str) -> list[SlackUser]:  # type: ignore[override]
+            return [u for u in self._users_static if u.matches(token)]
+
+    directory = StaticDirectory(
+        [
+            SlackUser(
+                user_id="U_ALICE_X",
+                display_name="Alice",
+                real_name="Alice X",
+                name="alice.x",
+                email="alice.x@x.com",
+            ),
+            SlackUser(
+                user_id="U_ALICE_Y",
+                display_name="Alice",
+                real_name="Alice Y",
+                name="alice.y",
+                email="alice.y@y.com",
+            ),
+        ]
+    )
+    app = build_app(service, app=FakeSlackApp(), slack_directory=directory)
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "Alice"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "Multiple Slack users matched" in text
+    assert "alice.x@x.com" in text
+    assert "alice.y@y.com" in text
+    assert "Re-run with the full email" in text
+
+
+def test_disabled_slack_directory_keeps_legacy_no_match_path(data_dir: Path) -> None:
+    """``SlackUserDirectory(enabled=False)`` short-circuits the new
+    fallback — the caller sees the same ``no_match_for_token`` block
+    they'd get without #38."""
+    from office_cli.slack._directory import SlackUserDirectory
+
+    service = _service_with_active(data_dir)
+    directory = SlackUserDirectory(client=None, enabled=False)
+    app = build_app(service, app=FakeSlackApp(), slack_directory=directory)
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "ghost"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "Couldn't find a seat for `ghost`" in text
+
+
+def test_local_part_wins_before_slack_directory(data_dir: Path) -> None:
+    """The Slack directory is consulted only when the local-part path
+    misses; an existing assignment short-circuits the API call."""
+    from office_cli.slack._directory import SlackUserDirectory
+
+    service = _service_with_active(data_dir, "ori.nachum@tipalti.com")
+    service.assign("5-T-03", "ori.nachum@tipalti.com")
+
+    class CountingDirectory(SlackUserDirectory):
+        def __init__(self) -> None:
+            self.calls = 0
+            self._enabled = True
+
+        def find_by_name(self, token: str):  # type: ignore[override]
+            self.calls += 1
+            return []
+
+    directory = CountingDirectory()
+    app = build_app(service, app=FakeSlackApp(), slack_directory=directory)
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "ori.nachum"},
+        client=client,
+    )
+    assert directory.calls == 0
+    assert "5-T-03" in _block_text(_last_blocks(client))
+
+
 def test_bare_token_disambiguation_redacts_hidden_seat_id(data_dir: Path) -> None:
     """PR #40 review (Qodo): when the disambiguation list includes a
     redacted (hidden) entry, it must omit the ``seat_id`` to match

--- a/tests/test_slack_directory.py
+++ b/tests/test_slack_directory.py
@@ -201,6 +201,34 @@ def test_first_fetch_failure_returns_empty_without_raising() -> None:
     assert d.find_by_name("Alice") == []
 
 
+def test_first_fetch_failure_rate_limits_subsequent_calls() -> None:
+    """PR #41 review (Qodo + Copilot): a first-fetch failure must not
+    bypass the TTL gate. Without the fix, every subsequent
+    ``find_by_name`` re-calls ``users.list`` because ``_has_cache``
+    stays False — turning a Slack outage into a request storm.
+    """
+    now = [0.0]
+
+    def clock() -> float:
+        return now[0]
+
+    client = FakeSlackDirectoryClient([])
+    client.errors.extend([RuntimeError("slack down"), RuntimeError("slack down")])
+    d = SlackUserDirectory(client, cache_ttl_seconds=300, clock=clock)
+    # First call: attempts the fetch, fails, returns [].
+    assert d.find_by_name("Alice") == []
+    assert len(client.calls) == 1
+    # Second call within the TTL window: must not retry.
+    now[0] = 100.0
+    assert d.find_by_name("Alice") == []
+    assert len(client.calls) == 1
+    # Third call past the TTL: fetch retried (queued error means it
+    # fails again, but the *attempt* should fire).
+    now[0] = 1000.0
+    assert d.find_by_name("Alice") == []
+    assert len(client.calls) == 2
+
+
 def test_invalidate_forces_refetch() -> None:
     client = FakeSlackDirectoryClient([_resp([_alice()]), _resp([_alice()])])
     d = SlackUserDirectory(client)

--- a/tests/test_slack_directory.py
+++ b/tests/test_slack_directory.py
@@ -1,0 +1,262 @@
+"""Tests for the TTL-cached Slack ``users.list`` directory (#38)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from office_cli.slack._directory import (
+    SlackUser,
+    SlackUserDirectory,
+    parse_directory_enabled,
+)
+
+
+def _resp(members: list[dict[str, Any]], next_cursor: str = "") -> dict[str, Any]:
+    """Shape one ``users.list`` response. ``next_cursor=""`` ends a fetch."""
+    return {"members": members, "response_metadata": {"next_cursor": next_cursor}}
+
+
+class FakeSlackDirectoryClient:
+    """Stand-in for ``slack_sdk.web.WebClient.users_list``.
+
+    ``responses`` is a queue: each ``users_list(cursor=...)`` call pops
+    the next entry. Multi-page fetches consume multiple entries (the
+    director loops while ``next_cursor`` is non-empty), so tests
+    exercising TTL refresh queue one entry per refresh, and
+    pagination tests queue one entry per page within a single
+    refresh.
+    """
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self._responses = list(responses)
+        self.calls: list[str | None] = []
+        self.errors: list[Exception | None] = []
+
+    def users_list(self, *, cursor: str | None = None) -> Any:
+        self.calls.append(cursor)
+        if self.errors:
+            err = self.errors.pop(0)
+            if err is not None:
+                raise err
+        if not self._responses:
+            return _resp([])
+        return self._responses.pop(0)
+
+
+def _alice() -> dict[str, Any]:
+    return {
+        "id": "U_ALICE",
+        "name": "alice",
+        "is_bot": False,
+        "deleted": False,
+        "profile": {
+            "display_name": "Alice",
+            "real_name": "Alice Smith",
+            "email": "alice@example.com",
+        },
+    }
+
+
+def _bob() -> dict[str, Any]:
+    return {
+        "id": "U_BOB",
+        "name": "bob",
+        "is_bot": False,
+        "deleted": False,
+        "profile": {"display_name": "Bob", "email": "bob@example.com"},
+    }
+
+
+def _bot() -> dict[str, Any]:
+    return {
+        "id": "U_BOT",
+        "name": "officebot",
+        "is_bot": True,
+        "deleted": False,
+        "profile": {
+            "display_name": "Office Bot",
+            "real_name": "Office Bot",
+            "email": "bot@example.com",
+        },
+    }
+
+
+def _deleted() -> dict[str, Any]:
+    return {
+        "id": "U_OLD",
+        "name": "carol",
+        "is_bot": False,
+        "deleted": True,
+        "profile": {"display_name": "Carol", "email": "carol@example.com"},
+    }
+
+
+def _no_email() -> dict[str, Any]:
+    return {
+        "id": "U_NOEMAIL",
+        "name": "guest",
+        "is_bot": False,
+        "deleted": False,
+        "profile": {"display_name": "Guest"},
+    }
+
+
+def test_disabled_directory_never_calls_api() -> None:
+    client = FakeSlackDirectoryClient([_resp([_alice()])])
+    d = SlackUserDirectory(client, enabled=False)
+    assert d.enabled is False
+    assert d.find_by_name("alice") == []
+    assert client.calls == []
+
+
+def test_directory_with_no_client_is_disabled_even_when_enabled_true() -> None:
+    """Defensive: ``enabled=True`` with ``client=None`` shouldn't crash
+    on the first lookup. Treat as disabled."""
+    d = SlackUserDirectory(None, enabled=True)
+    assert d.enabled is False
+    assert d.find_by_name("alice") == []
+
+
+def test_match_against_display_name_real_name_and_username() -> None:
+    client = FakeSlackDirectoryClient([_resp([_alice()])])
+    d = SlackUserDirectory(client)
+    assert [u.email for u in d.find_by_name("Alice")] == ["alice@example.com"]
+    assert [u.email for u in d.find_by_name("alice smith")] == ["alice@example.com"]
+    assert [u.email for u in d.find_by_name("alice")] == ["alice@example.com"]
+    # Substrings don't match — exact-only is the contract.
+    assert d.find_by_name("ali") == []
+
+
+def test_skips_bots_deleted_and_no_email() -> None:
+    client = FakeSlackDirectoryClient([_resp([_alice(), _bot(), _deleted(), _no_email()])])
+    d = SlackUserDirectory(client)
+    assert [u.email for u in d.find_by_name("Office Bot")] == []
+    assert [u.email for u in d.find_by_name("Carol")] == []
+    assert [u.email for u in d.find_by_name("Guest")] == []
+    assert [u.email for u in d.find_by_name("Alice")] == ["alice@example.com"]
+
+
+def test_pagination_walks_cursor_until_empty() -> None:
+    client = FakeSlackDirectoryClient([_resp([_alice()], next_cursor="next"), _resp([_bob()])])
+    d = SlackUserDirectory(client)
+    assert [u.email for u in d.find_by_name("Bob")] == ["bob@example.com"]
+    # Two pages → cursor=None then cursor="next".
+    assert client.calls == [None, "next"]
+
+
+def test_cache_hits_skip_the_api() -> None:
+    """A second lookup within the TTL window must not hit the API."""
+    now = [0.0]
+
+    def clock() -> float:
+        return now[0]
+
+    client = FakeSlackDirectoryClient([_resp([_alice()])])
+    d = SlackUserDirectory(client, cache_ttl_seconds=300, clock=clock)
+    d.find_by_name("Alice")
+    now[0] = 100.0
+    d.find_by_name("Alice")
+    assert client.calls == [None]
+
+
+def test_cache_refreshes_after_ttl() -> None:
+    now = [0.0]
+
+    def clock() -> float:
+        return now[0]
+
+    client = FakeSlackDirectoryClient([_resp([_alice()]), _resp([_alice()])])
+    d = SlackUserDirectory(client, cache_ttl_seconds=300, clock=clock)
+    d.find_by_name("Alice")
+    now[0] = 1000.0  # past TTL
+    d.find_by_name("Alice")
+    assert client.calls == [None, None]
+
+
+def test_refresh_failure_serves_cached_results() -> None:
+    """Fail-open: a transient ``users.list`` outage doesn't drop the
+    previous cache; subsequent lookups still resolve."""
+    now = [0.0]
+
+    def clock() -> float:
+        return now[0]
+
+    client = FakeSlackDirectoryClient([_resp([_alice()])])
+    d = SlackUserDirectory(client, cache_ttl_seconds=300, clock=clock)
+    d.find_by_name("Alice")
+    client.errors.append(RuntimeError("slack down"))
+    now[0] = 1000.0
+    matches = d.find_by_name("Alice")
+    assert [u.email for u in matches] == ["alice@example.com"]
+
+
+def test_first_fetch_failure_returns_empty_without_raising() -> None:
+    """First-attempt failure: emit diagnostic, return empty (don't
+    crash the slash-command listener)."""
+    client = FakeSlackDirectoryClient([])
+    client.errors.append(RuntimeError("slack down"))
+    d = SlackUserDirectory(client)
+    assert d.find_by_name("Alice") == []
+
+
+def test_invalidate_forces_refetch() -> None:
+    client = FakeSlackDirectoryClient([_resp([_alice()]), _resp([_alice()])])
+    d = SlackUserDirectory(client)
+    d.find_by_name("Alice")
+    d.invalidate()
+    d.find_by_name("Alice")
+    assert client.calls == [None, None]
+
+
+def test_empty_token_short_circuits() -> None:
+    client = FakeSlackDirectoryClient([_resp([_alice()])])
+    d = SlackUserDirectory(client)
+    assert d.find_by_name("") == []
+    assert client.calls == []
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, True),
+        ("", True),
+        ("enabled", True),
+        ("on", True),
+        ("yes", True),
+        ("disabled", False),
+        ("DISABLED", False),
+        ("off", False),
+        ("0", False),
+        ("false", False),
+        ("no", False),
+        ("  off  ", False),
+    ],
+)
+def test_parse_directory_enabled(raw: str | None, expected: bool) -> None:
+    assert parse_directory_enabled(raw) is expected
+
+
+def test_slack_user_matches_skips_empty_fields() -> None:
+    """A user with empty ``display_name`` shouldn't match the empty
+    string token (which we already short-circuit, but defense in
+    depth)."""
+    u = SlackUser(
+        user_id="U1",
+        display_name="",
+        real_name="Alice",
+        name="alice",
+        email="alice@x.com",
+    )
+    assert u.matches("Alice") is True
+    assert u.matches("") is False
+
+
+def test_repeated_user_id_across_pages_dedupes() -> None:
+    """If Slack repeats an entry across cursors (rare but observed),
+    we yield each ``user_id`` exactly once."""
+    client = FakeSlackDirectoryClient([_resp([_alice()], next_cursor="next"), _resp([_alice()])])
+    d = SlackUserDirectory(client)
+    matches = d.find_by_name("Alice")
+    assert len(matches) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -640,7 +640,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.9.7"
+version = "0.9.8"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Follow-up A from #29's resolution chain. When the bare-token path from #29 returns no local-part match, the handler now falls through to a TTL-cached lookup against the Slack workspace roster.

- New `office_cli/slack/_directory.py` — `SlackUser` dataclass + `SlackUserDirectory` (paginated `users.list`, in-memory cache, default 300s TTL, rate-limited refresh attempts, fail-open on transient outages).
- Filters bots / deleted / no-email entries; dedupes `user_id` across cursor boundaries.
- Exact-match against `display_name` / `real_name` / `name` (case-insensitive). Substring/fuzzy is deferred to #39.
- Multi-match renders the new `disambiguation_users` block; single match resolves to the candidate's email and runs through the existing seat-found path.
- `OFFICE_SLACK_DIRECTORY=disabled` (also `off`/`0`/`false`/`no`, case-insensitive) short-circuits the entire path — recommended for workspaces with tens of thousands of members.
- `OFFICE_SLACK_DIRECTORY_TTL` overrides the cache window (positive integer seconds; misconfigurations fail loudly at startup, before Bolt's `auth.test`).

Closes #38.

## Test plan

- [x] `uv run pytest -n auto -q` — 365 passed (was 332; +33 across resolver/service/handler/directory; tally includes 4 fakes-rewrite fixes from the in-flight refactor).
- [x] `uv run black/isort/flake8` clean.
- [x] `markdownlint-cli2 CHANGELOG.md` clean.
- [x] `tests/test_slack_directory.py` — 19 unit tests covering disabled mode, exact-match contract, bot/deleted/no-email skip, pagination, TTL cache hit/refresh, fail-open on outage, first-fetch failure, invalidation, env-var parsing, dedup.
- [x] `tests/test_slack_app.py` — 4 integration tests (single-match resolves, multi-match disambiguates, disabled directory keeps legacy path, local-part hit short-circuits the directory call).
- [x] `tests/test_cli_slack_serve.py` — `OFFICE_SLACK_DIRECTORY_TTL` validation parametrized over invalid values.
- [ ] Live verification on Tipalti workspace: `/beta-whereis Ori` (display-name match), `/beta-whereis @<failed-autocomplete>`, `OFFICE_SLACK_DIRECTORY=disabled` ladder.

## Backwards compatibility

- `build_app(...)` adds an optional `slack_directory` kwarg defaulting to `None`. Callers that don't pass it (every existing test) keep the local-part-only behavior from #29.
- The bare-token branch routes through the same builder shapes as #29; the new path only kicks in when local-part returns 0 matches.

- Claude