### PR TITLE
feat(slack): fuzzy match + interactive disambiguation UI (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.9] - 2026-05-05
+
+### Added
+
+- Slack `/whereis` now resolves partial / misspelled names via a
+  third resolution tier on top of the exact local-part path
+  ([#29](https://github.com/agentculture/office-agent/issues/29)) and
+  exact roster-name path
+  ([#38](https://github.com/agentculture/office-agent/issues/38)).
+  When neither exact tier hits, a stdlib-`difflib` scorer ranks the
+  union of assignment-store local-parts and Slack roster names
+  (when the directory is enabled) against the bare token. A single
+  candidate above the cutoff — or one that exceeds the runner-up by
+  the auto-pick gap — resolves directly to the seat. Otherwise the
+  handler renders an interactive disambiguation message: one section
+  per candidate with a *This person* button. Clicking the button
+  fires a new `whereis_pick` action that re-runs the lookup against
+  the picked email and replaces the original ephemeral with the seat
+  result via `response_url`. Hidden / redacted seats keep their
+  privacy treatment through both the auto-pick and button-driven
+  paths. ([#39](https://github.com/agentculture/office-agent/issues/39))
+
+- `OFFICE_FUZZY_CUTOFF` (float in `[0.0, 1.0]`, default `0.7`) and
+  `OFFICE_FUZZY_LIMIT` (positive int, default `5`) tune the new
+  tier on the slack-serve entry point. Misconfigured values raise
+  `EXIT_ENV_ERROR` before slack-bolt construction so a bad deploy
+  doesn't get masked by a downstream `BoltError`.
+  ([#39](https://github.com/agentculture/office-agent/issues/39))
+
 ## [0.9.8] - 2026-05-05
 
 ### Added

--- a/office_cli/cli/_commands/slack_serve.py
+++ b/office_cli/cli/_commands/slack_serve.py
@@ -65,6 +65,9 @@ def cmd_slack_serve(args: argparse.Namespace) -> int:
     # fires on a real network call.
     directory_enabled = parse_directory_enabled_env()
     ttl_seconds = _parse_ttl_env(os.environ.get("OFFICE_SLACK_DIRECTORY_TTL"))
+    # #39: same early-validation pattern for the fuzzy resolver knobs.
+    fuzzy_cutoff = _parse_fuzzy_cutoff_env(os.environ.get("OFFICE_FUZZY_CUTOFF"))
+    fuzzy_limit = _parse_fuzzy_limit_env(os.environ.get("OFFICE_FUZZY_LIMIT"))
 
     # slack_bolt is imported lazily inside `build_app` / `run_socket_mode`
     # so a missing extra surfaces as a clear OfficeError.
@@ -97,6 +100,8 @@ def cmd_slack_serve(args: argparse.Namespace) -> int:
         app=app,
         data_dir=data_dir,
         slack_directory=slack_directory,
+        fuzzy_cutoff=fuzzy_cutoff,
+        fuzzy_limit=fuzzy_limit,
         command_name=command_name,
     )
     emit_diagnostic(f"Slack {command_name} listener starting (Socket Mode)…")
@@ -137,6 +142,55 @@ def _parse_ttl_env(raw: str | None) -> int:
             code=EXIT_ENV_ERROR,
             message=f"OFFICE_SLACK_DIRECTORY_TTL must be > 0; got {value}",
             remediation="pick a TTL ≥ 1 second, or unset to use the 300s default",
+        )
+    return value
+
+
+def _parse_fuzzy_cutoff_env(raw: str | None) -> float:
+    """Read ``OFFICE_FUZZY_CUTOFF``. Default ``0.7``; out-of-range or
+    unparseable values raise ``OfficeError`` so a misconfiguration
+    fails loudly at startup."""
+    from office_cli.slack._fuzzy import DEFAULT_CUTOFF
+
+    if raw is None or not raw.strip():
+        return DEFAULT_CUTOFF
+    try:
+        value = float(raw.strip())
+    except ValueError as err:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message=f"OFFICE_FUZZY_CUTOFF must be a float in [0.0, 1.0]; got {raw!r}",
+            remediation="set OFFICE_FUZZY_CUTOFF to a value like 0.7 (default)",
+        ) from err
+    if not 0.0 <= value <= 1.0:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message=f"OFFICE_FUZZY_CUTOFF must be in [0.0, 1.0]; got {value}",
+            remediation="pick a cutoff in [0.0, 1.0]; 0.7 is the project default",
+        )
+    return value
+
+
+def _parse_fuzzy_limit_env(raw: str | None) -> int:
+    """Read ``OFFICE_FUZZY_LIMIT``. Default ``5``; non-positive ints
+    or unparseable values raise ``OfficeError``."""
+    from office_cli.slack._fuzzy import DEFAULT_LIMIT
+
+    if raw is None or not raw.strip():
+        return DEFAULT_LIMIT
+    try:
+        value = int(raw.strip())
+    except ValueError as err:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message=f"OFFICE_FUZZY_LIMIT must be a positive int; got {raw!r}",
+            remediation="set OFFICE_FUZZY_LIMIT to a value like 5 (default)",
+        ) from err
+    if value <= 0:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message=f"OFFICE_FUZZY_LIMIT must be > 0; got {value}",
+            remediation="pick a positive cap (Slack messages cap at 50 blocks; 5 is the default)",
         )
     return value
 

--- a/office_cli/cli/_commands/slack_serve.py
+++ b/office_cli/cli/_commands/slack_serve.py
@@ -171,9 +171,20 @@ def _parse_fuzzy_cutoff_env(raw: str | None) -> float:
     return value
 
 
+_MAX_FUZZY_LIMIT = 25
+
+
 def _parse_fuzzy_limit_env(raw: str | None) -> int:
-    """Read ``OFFICE_FUZZY_LIMIT``. Default ``5``; non-positive ints
-    or unparseable values raise ``OfficeError``."""
+    """Read ``OFFICE_FUZZY_LIMIT``. Default ``5``; must be in
+    ``[1, _MAX_FUZZY_LIMIT]``. Out-of-range or unparseable values
+    raise ``OfficeError``.
+
+    The upper bound exists because Slack hard-caps a message at 50
+    blocks; the picker uses 1 header + 1 section per candidate +
+    optional overflow context, so a runaway env-var would silently
+    break ``chat.postEphemeral`` at runtime. 25 leaves comfortable
+    headroom for that ceiling, the overflow line, and any future
+    decoration."""
     from office_cli.slack._fuzzy import DEFAULT_LIMIT
 
     if raw is None or not raw.strip():
@@ -191,6 +202,15 @@ def _parse_fuzzy_limit_env(raw: str | None) -> int:
             code=EXIT_ENV_ERROR,
             message=f"OFFICE_FUZZY_LIMIT must be > 0; got {value}",
             remediation="pick a positive cap (Slack messages cap at 50 blocks; 5 is the default)",
+        )
+    if value > _MAX_FUZZY_LIMIT:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message=(
+                f"OFFICE_FUZZY_LIMIT={value} exceeds the safe cap of "
+                f"{_MAX_FUZZY_LIMIT} (Slack messages hard-cap at 50 blocks)"
+            ),
+            remediation=f"pick a limit ≤ {_MAX_FUZZY_LIMIT}; 5 is the project default",
         )
     return value
 

--- a/office_cli/slack/_app.py
+++ b/office_cli/slack/_app.py
@@ -442,8 +442,23 @@ def _build_fuzzy_pool(
     tie" rule: emit local-parts first (the strong source — these
     are people we can definitely seat) then the Slack roster.
     """
-    full_access = is_full_access(role)
     excluded: set[str] = set()
+    yield from _yield_eligible_local_parts(
+        service, as_of=as_of, full_access=is_full_access(role), excluded=excluded
+    )
+    yield from _yield_eligible_roster(slack_directory, excluded=excluded)
+
+
+def _yield_eligible_local_parts(
+    service: SeatService,
+    *,
+    as_of: str | None,
+    full_access: bool,
+    excluded: set[str],
+) -> Iterable[tuple[str, str]]:
+    """Local-part contribution to the fuzzy pool. Mutates ``excluded``
+    so the roster contribution can drop the same hidden-seat
+    occupants if their display name matches."""
     for a in service.store.list():
         email = (a.employee_email or "").strip()
         if not email or "@" not in email:
@@ -455,15 +470,25 @@ def _build_fuzzy_pool(
             continue
         if as_of is not None and not is_effective(a, as_of):
             continue
-        local_part = email.split("@", 1)[0]
-        yield (local_part, email)
-    if slack_directory is not None and slack_directory.enabled:
-        for u in slack_directory.iter_users():
-            if not u.email or u.email.lower() in excluded:
-                continue
-            label = u.display_name or u.real_name or u.name or ""
-            if label:
-                yield (label, u.email)
+        yield (email.split("@", 1)[0], email)
+
+
+def _yield_eligible_roster(
+    slack_directory: SlackUserDirectory | None,
+    *,
+    excluded: set[str],
+) -> Iterable[tuple[str, str]]:
+    """Slack-roster contribution. Drops users whose email is in
+    ``excluded`` (the hidden-seat-for-viewer gate from the local-part
+    pass)."""
+    if slack_directory is None or not slack_directory.enabled:
+        return
+    for u in slack_directory.iter_users():
+        if not u.email or u.email.lower() in excluded:
+            continue
+        label = u.display_name or u.real_name or u.name or ""
+        if label:
+            yield (label, u.email)
 
 
 def _lookup(

--- a/office_cli/slack/_app.py
+++ b/office_cli/slack/_app.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable, Iterable
 
-from office_cli._dates import parse_iso_date, today_iso_date
-from office_cli._roles import RolesConfig, resolve_roles, role_for_email
+from office_cli._dates import is_effective, parse_iso_date, today_iso_date
+from office_cli._roles import RolesConfig, is_full_access, resolve_roles, role_for_email
 from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
 from office_cli.seats import SeatService
 from office_cli.slack import _blocks
@@ -122,10 +122,10 @@ def build_app(
         )
 
     # #39: handle the "This person" button on a fuzzy disambiguation
-    # message. The button's ``value`` carries the picked candidate's
-    # full email, so we re-run the seat lookup through ``_lookup`` and
-    # ``respond`` with ``replace_original=True`` to swap the picker
-    # for the seat result inline. ``respond`` is Bolt's
+    # message. The button's ``value`` carries a JSON payload
+    # ``{"email": ..., "as_of": ...}`` so we can re-run the seat
+    # lookup against the *same* as-of window the picker was
+    # generated for (#42 review fix). ``respond`` is Bolt's
     # ``response_url`` shortcut; tests pass a recorder.
     @app.action(_blocks.DISAMBIG_FUZZY_ACTION_ID)
     def _handle_pick(
@@ -136,7 +136,8 @@ def build_app(
     ) -> None:
         ack()
         actions = body.get("actions") or []
-        email = (actions[0].get("value", "").strip() if actions else "").strip()
+        raw_value = actions[0].get("value", "") if actions else ""
+        email, encoded_as_of = _blocks.decode_pick_value(raw_value)
         if not email:
             respond(
                 {
@@ -152,7 +153,10 @@ def build_app(
         # can read it the same way.
         synthetic_command = {"user_id": (body.get("user") or {}).get("id", "")}
         role = _resolve_caller_role(client, body, synthetic_command, roles)
-        as_of = today_iso_date(service._clock)
+        # Honor the encoded ``as_of`` if present; otherwise default to
+        # today (no_arg slash command path) so the click never resolves
+        # against an empty / past-window state by accident.
+        as_of = encoded_as_of or today_iso_date(service._clock)
         blocks, label = _lookup(service, email, label=email, as_of=as_of, role=role)
         respond({"replace_original": True, "blocks": blocks, "text": label})
 
@@ -373,16 +377,19 @@ def _lookup_by_fuzzy(
     :func:`build_app`, which re-runs the seat lookup against the
     chosen email.
     """
-    pool = list(_build_fuzzy_pool(service, slack_directory))
-    # Rank with one extra slot beyond ``limit`` so we can compute the
-    # overflow without a second pass — easier to read than a separate
-    # length query into the candidate iterator.
-    ranked = rank_candidates(token, pool, cutoff=cutoff, limit=limit + 1)
+    pool = list(_build_fuzzy_pool(service, slack_directory, as_of=as_of, role=role))
+    # Rank the FULL pool (no ``limit + 1`` cap) so:
+    #   * ``auto_pick`` sees the true runner-up — capping at
+    #     ``limit + 1`` would let ``fuzzy_limit=1`` auto-pick even
+    #     when many other candidates are within the gap.
+    #   * the overflow count reflects every above-cutoff hit, not
+    #     just one beyond the render slice.
+    # The cutoff already filters useless candidates, so a ranked
+    # list at v1 scale stays small.
+    ranked = rank_candidates(token, pool, cutoff=cutoff, limit=len(pool) or 1)
     if not ranked:
         return _blocks.no_match_for_token(token), "no seat found for that name"
-    overflow = max(0, len(ranked) - limit)
-    rendered = ranked[:limit]
-    picked = auto_pick(rendered, gap=gap)
+    picked = auto_pick(ranked, gap=gap)
     if picked is not None:
         return _lookup(
             service,
@@ -391,8 +398,10 @@ def _lookup_by_fuzzy(
             as_of=as_of,
             role=role,
         )
+    rendered = ranked[:limit]
+    overflow = max(0, len(ranked) - limit)
     return (
-        _blocks.disambiguation_fuzzy(token, rendered, overflow=overflow),
+        _blocks.disambiguation_fuzzy(token, rendered, overflow=overflow, as_of=as_of),
         f"{len(rendered)} matches",
     )
 
@@ -400,26 +409,60 @@ def _lookup_by_fuzzy(
 def _build_fuzzy_pool(
     service: SeatService,
     slack_directory: SlackUserDirectory | None,
+    *,
+    as_of: str | None,
+    role: str | None,
 ) -> Iterable[tuple[str, str]]:
-    """Yield ``(label, email)`` candidates for the fuzzy ranker.
+    """Yield ``(label, email)`` candidates for the fuzzy ranker, with
+    the same eligibility rules ``SeatService.find_by_local_part`` /
+    ``whereis`` apply.
+
+    For each assignment in the store:
+
+    * non-empty email; otherwise skip (no useful resolution target).
+    * for non-full-access (viewer) roles: skip ``hidden=True`` rows
+      entirely. The privacy contract behind ``hidden_private`` is
+      "viewers don't learn where this person sits"; surfacing the
+      email in the disambiguation list — even with the seat
+      redacted post-pick — defeats the gate. Track these emails in
+      ``excluded`` so the Slack-roster contribution can drop them
+      too (a hidden-seat occupant who shows up under their Slack
+      display name would otherwise route around the local-part skip).
+    * directory ``is_active`` filter: an offboarded employee's row
+      shouldn't surface as a fuzzy hit.
+    * ``as_of`` window: same gate ``whereis`` enforces.
+
+    For the Slack roster contribution: include every cached user
+    whose email isn't in ``excluded``. We don't apply
+    ``directory.is_active`` here because it's a different identity
+    space (Slack workspace, not BambooHR), and ``_lookup`` post-pick
+    will still apply the gate via ``service.whereis``.
 
     Order matters for ``rank_candidates``'s "first occurrence wins on
-    tie" rule: emit assignment-store local-parts first (the strongly
-    typed source — these are people we can definitely seat) then the
-    Slack roster (which may include people without seats). Empty
-    emails are skipped at the ranker layer too, so we don't need to
-    pre-filter here.
+    tie" rule: emit local-parts first (the strong source — these
+    are people we can definitely seat) then the Slack roster.
     """
+    full_access = is_full_access(role)
+    excluded: set[str] = set()
     for a in service.store.list():
         email = (a.employee_email or "").strip()
         if not email or "@" not in email:
+            continue
+        if not full_access and a.hidden:
+            excluded.add(email.lower())
+            continue
+        if not service.directory.is_active(email):
+            continue
+        if as_of is not None and not is_effective(a, as_of):
             continue
         local_part = email.split("@", 1)[0]
         yield (local_part, email)
     if slack_directory is not None and slack_directory.enabled:
         for u in slack_directory.iter_users():
+            if not u.email or u.email.lower() in excluded:
+                continue
             label = u.display_name or u.real_name or u.name or ""
-            if label and u.email:
+            if label:
                 yield (label, u.email)
 
 

--- a/office_cli/slack/_app.py
+++ b/office_cli/slack/_app.py
@@ -9,7 +9,7 @@ real Bolt app, so this module never needs the SDK at import time.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Iterable
 
 from office_cli._dates import parse_iso_date, today_iso_date
 from office_cli._roles import RolesConfig, resolve_roles, role_for_email
@@ -17,6 +17,13 @@ from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
 from office_cli.seats import SeatService
 from office_cli.slack import _blocks
 from office_cli.slack._directory import SlackUserDirectory
+from office_cli.slack._fuzzy import (
+    DEFAULT_AUTO_PICK_GAP,
+    DEFAULT_CUTOFF,
+    DEFAULT_LIMIT,
+    auto_pick,
+    rank_candidates,
+)
 from office_cli.slack._resolve import ParsedTarget, parse_target
 
 _AUTO = object()
@@ -29,6 +36,9 @@ def build_app(
     roles: Any = None,
     data_dir: Path | None = None,
     slack_directory: SlackUserDirectory | None = None,
+    fuzzy_cutoff: float = DEFAULT_CUTOFF,
+    fuzzy_limit: int = DEFAULT_LIMIT,
+    fuzzy_gap: float = DEFAULT_AUTO_PICK_GAP,
     command_name: str = "/whereis",
 ) -> Any:
     """Register the configured slash-command listener and return the app.
@@ -59,6 +69,15 @@ def build_app(
     pass an instance to enable name → email resolution against the
     Slack workspace roster. The slack-serve entry point constructs one
     by default and respects ``OFFICE_SLACK_DIRECTORY=disabled``.
+
+    ``fuzzy_cutoff`` / ``fuzzy_limit`` / ``fuzzy_gap`` (#39) tune the
+    final tier of the resolution chain: difflib-backed fuzzy matching
+    against the union of assignment-store local-parts and Slack
+    roster names, with auto-pick when the top candidate clears the
+    runner-up by ``fuzzy_gap`` and an interactive disambiguation list
+    otherwise. Defaults match :mod:`office_cli.slack._fuzzy`; the
+    slack-serve entry point exposes ``OFFICE_FUZZY_CUTOFF`` and
+    ``OFFICE_FUZZY_LIMIT`` env overrides.
     """
     command_name = command_name.strip()
     if not command_name or not command_name.startswith("/"):
@@ -80,7 +99,16 @@ def build_app(
         text = command.get("text", "")
         target = parse_target(text)
         blocks, label = _resolve_and_lookup(
-            service, client, body, command, target, roles, slack_directory
+            service,
+            client,
+            body,
+            command,
+            target,
+            roles,
+            slack_directory,
+            fuzzy_cutoff=fuzzy_cutoff,
+            fuzzy_limit=fuzzy_limit,
+            fuzzy_gap=fuzzy_gap,
         )
         # ``command`` is the slash-command payload and is the canonical
         # source for ``channel_id``/``user_id``; ``body`` is the Bolt-
@@ -93,6 +121,41 @@ def build_app(
             text=label,  # fallback for clients that ignore blocks
         )
 
+    # #39: handle the "This person" button on a fuzzy disambiguation
+    # message. The button's ``value`` carries the picked candidate's
+    # full email, so we re-run the seat lookup through ``_lookup`` and
+    # ``respond`` with ``replace_original=True`` to swap the picker
+    # for the seat result inline. ``respond`` is Bolt's
+    # ``response_url`` shortcut; tests pass a recorder.
+    @app.action(_blocks.DISAMBIG_FUZZY_ACTION_ID)
+    def _handle_pick(
+        ack: Callable[[], None],
+        body: dict,
+        respond: Callable[[dict], None],
+        client: Any,
+    ) -> None:
+        ack()
+        actions = body.get("actions") or []
+        email = (actions[0].get("value", "").strip() if actions else "").strip()
+        if not email:
+            respond(
+                {
+                    "replace_original": True,
+                    "text": "couldn't read the picked candidate",
+                }
+            )
+            return
+        # Same role gate the slash command applies — pick + lookup
+        # must use the *caller's* role, not the original ephemeral's.
+        # ``body`` for action callbacks carries ``user.id``; mirror the
+        # slash-command shape (``user_id``) so ``_resolve_caller_role``
+        # can read it the same way.
+        synthetic_command = {"user_id": (body.get("user") or {}).get("id", "")}
+        role = _resolve_caller_role(client, body, synthetic_command, roles)
+        as_of = today_iso_date(service._clock)
+        blocks, label = _lookup(service, email, label=email, as_of=as_of, role=role)
+        respond({"replace_original": True, "blocks": blocks, "text": label})
+
     return app
 
 
@@ -104,6 +167,10 @@ def _resolve_and_lookup(
     target: ParsedTarget,
     roles: RolesConfig | None,
     slack_directory: SlackUserDirectory | None = None,
+    *,
+    fuzzy_cutoff: float = DEFAULT_CUTOFF,
+    fuzzy_limit: int = DEFAULT_LIMIT,
+    fuzzy_gap: float = DEFAULT_AUTO_PICK_GAP,
 ) -> tuple[list[dict[str, Any]], str]:
     """Resolve a :class:`ParsedTarget` to an email + label and run lookup."""
     if not target.ok:
@@ -134,6 +201,9 @@ def _resolve_and_lookup(
             as_of=as_of,
             role=role,
             slack_directory=slack_directory,
+            fuzzy_cutoff=fuzzy_cutoff,
+            fuzzy_limit=fuzzy_limit,
+            fuzzy_gap=fuzzy_gap,
         )
 
     user_id = target.user_id or command.get("user_id") or body.get("user_id", "")
@@ -198,6 +268,9 @@ def _lookup_by_local_part(
     as_of: str | None = None,
     role: str | None = None,
     slack_directory: SlackUserDirectory | None = None,
+    fuzzy_cutoff: float = DEFAULT_CUTOFF,
+    fuzzy_limit: int = DEFAULT_LIMIT,
+    fuzzy_gap: float = DEFAULT_AUTO_PICK_GAP,
 ) -> tuple[list[dict[str, Any]], str]:
     """#29 MVP + #38: ``/whereis ori.nachum`` resolves via the
     assignment store's email local-parts; if no local-part hits and a
@@ -213,7 +286,16 @@ def _lookup_by_local_part(
     matches = service.find_by_local_part(token, as_of=as_of, role=role)
     if not matches:
         # #38: try the Slack workspace roster for a name match.
-        return _lookup_by_slack_directory(service, token, slack_directory, as_of=as_of, role=role)
+        return _lookup_by_slack_directory(
+            service,
+            token,
+            slack_directory,
+            as_of=as_of,
+            role=role,
+            fuzzy_cutoff=fuzzy_cutoff,
+            fuzzy_limit=fuzzy_limit,
+            fuzzy_gap=fuzzy_gap,
+        )
     if len(matches) == 1:
         a = matches[0]
         # Use the resolved (store-derived) email as the label so even
@@ -235,17 +317,15 @@ def _lookup_by_slack_directory(
     *,
     as_of: str | None,
     role: str | None,
+    fuzzy_cutoff: float = DEFAULT_CUTOFF,
+    fuzzy_limit: int = DEFAULT_LIMIT,
+    fuzzy_gap: float = DEFAULT_AUTO_PICK_GAP,
 ) -> tuple[list[dict[str, Any]], str]:
     """#38: name-match against the Slack workspace roster, with the
-    directory's TTL cache. Disabled / unavailable directory returns
-    the local-part path's no-match block — the caller perceives a
-    single resolution chain ending in the same error.
+    directory's TTL cache. Falls through to the #39 fuzzy resolver
+    when no exact name matches.
     """
-    if slack_directory is None or not slack_directory.enabled:
-        return _blocks.no_match_for_token(token), "no seat found for that name"
-    candidates = slack_directory.find_by_name(token)
-    if not candidates:
-        return _blocks.no_match_for_token(token), "no seat found for that name"
+    candidates = slack_directory.find_by_name(token) if slack_directory else []
     if len(candidates) == 1:
         return _lookup(
             service,
@@ -254,10 +334,93 @@ def _lookup_by_slack_directory(
             as_of=as_of,
             role=role,
         )
-    return (
-        _blocks.disambiguation_users(token, candidates),
-        f"{len(candidates)} matches",
+    if len(candidates) > 1:
+        return (
+            _blocks.disambiguation_users(token, candidates),
+            f"{len(candidates)} matches",
+        )
+    # Empty roster match → final tier: fuzzy across local-parts ∪ roster.
+    return _lookup_by_fuzzy(
+        service,
+        token,
+        slack_directory,
+        as_of=as_of,
+        role=role,
+        cutoff=fuzzy_cutoff,
+        limit=fuzzy_limit,
+        gap=fuzzy_gap,
     )
+
+
+def _lookup_by_fuzzy(
+    service: SeatService,
+    token: str,
+    slack_directory: SlackUserDirectory | None,
+    *,
+    as_of: str | None,
+    role: str | None,
+    cutoff: float,
+    limit: int,
+    gap: float,
+) -> tuple[list[dict[str, Any]], str]:
+    """#39: third tier of the resolution chain — fuzzy match against
+    the union of assignment-store local-parts and Slack roster names.
+
+    Auto-picks when one candidate clearly wins (top score exceeds the
+    runner-up by ``gap``); otherwise renders the interactive
+    ``disambiguation_fuzzy`` picker. The picker's button click is
+    handled by the ``whereis_pick`` action handler registered in
+    :func:`build_app`, which re-runs the seat lookup against the
+    chosen email.
+    """
+    pool = list(_build_fuzzy_pool(service, slack_directory))
+    # Rank with one extra slot beyond ``limit`` so we can compute the
+    # overflow without a second pass — easier to read than a separate
+    # length query into the candidate iterator.
+    ranked = rank_candidates(token, pool, cutoff=cutoff, limit=limit + 1)
+    if not ranked:
+        return _blocks.no_match_for_token(token), "no seat found for that name"
+    overflow = max(0, len(ranked) - limit)
+    rendered = ranked[:limit]
+    picked = auto_pick(rendered, gap=gap)
+    if picked is not None:
+        return _lookup(
+            service,
+            email=picked.email,
+            label=picked.email,
+            as_of=as_of,
+            role=role,
+        )
+    return (
+        _blocks.disambiguation_fuzzy(token, rendered, overflow=overflow),
+        f"{len(rendered)} matches",
+    )
+
+
+def _build_fuzzy_pool(
+    service: SeatService,
+    slack_directory: SlackUserDirectory | None,
+) -> Iterable[tuple[str, str]]:
+    """Yield ``(label, email)`` candidates for the fuzzy ranker.
+
+    Order matters for ``rank_candidates``'s "first occurrence wins on
+    tie" rule: emit assignment-store local-parts first (the strongly
+    typed source — these are people we can definitely seat) then the
+    Slack roster (which may include people without seats). Empty
+    emails are skipped at the ranker layer too, so we don't need to
+    pre-filter here.
+    """
+    for a in service.store.list():
+        email = (a.employee_email or "").strip()
+        if not email or "@" not in email:
+            continue
+        local_part = email.split("@", 1)[0]
+        yield (local_part, email)
+    if slack_directory is not None and slack_directory.enabled:
+        for u in slack_directory.iter_users():
+            label = u.display_name or u.real_name or u.name or ""
+            if label and u.email:
+                yield (label, u.email)
 
 
 def _lookup(

--- a/office_cli/slack/_blocks.py
+++ b/office_cli/slack/_blocks.py
@@ -14,6 +14,9 @@ from typing import Any
 
 from office_cli.seats import Assignment
 from office_cli.slack._directory import SlackUser
+from office_cli.slack._fuzzy import FuzzyCandidate
+
+DISAMBIG_FUZZY_ACTION_ID = "whereis_pick"
 
 
 def _escape_mrkdwn(s: str) -> str:
@@ -260,6 +263,72 @@ def disambiguation_users(token: str, candidates: list[SlackUser]) -> list[dict[s
             ],
         }
     )
+    return blocks
+
+
+def disambiguation_fuzzy(
+    token: str,
+    candidates: list[FuzzyCandidate],
+    *,
+    overflow: int = 0,
+) -> list[dict[str, Any]]:
+    """#39: render a fuzzy-match candidate list with a "This person"
+    button per row. The button's ``value`` carries the candidate's
+    full email so the action handler can re-run the lookup without
+    keeping per-listener state. Same mrkdwn-escape contract as
+    sibling builders.
+
+    ``overflow`` is the number of additional candidates beyond what's
+    rendered — surfaced in a context block so the caller knows to
+    refine. Slack caps a message at 50 blocks; with the issue's
+    default ``OFFICE_FUZZY_LIMIT=5`` we land far under that, but the
+    cap propagates through this builder unchanged so a higher limit
+    + overflow stays safe."""
+    safe_token = _escape_mrkdwn(token)
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"Did you mean one of these for `{safe_token}`?",
+            },
+        }
+    ]
+    for c in candidates:
+        rendered_label = _escape_mrkdwn(c.label or c.email)
+        rendered_email = _escape_mrkdwn(c.email)
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*{rendered_label}* — `{rendered_email}`",
+                },
+                "accessory": {
+                    "type": "button",
+                    "action_id": DISAMBIG_FUZZY_ACTION_ID,
+                    "text": {"type": "plain_text", "text": "This person"},
+                    # ``value`` carries the full email; the action handler
+                    # routes off it without keeping listener-side state.
+                    "value": c.email,
+                },
+            }
+        )
+    if overflow > 0:
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": (
+                            f"_…and {overflow} more — refine your search "
+                            f"(full email or `@mention`)._"
+                        ),
+                    }
+                ],
+            }
+        )
     return blocks
 
 

--- a/office_cli/slack/_blocks.py
+++ b/office_cli/slack/_blocks.py
@@ -9,6 +9,7 @@ Stage 7 lands roles.
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Any
 
@@ -266,17 +267,50 @@ def disambiguation_users(token: str, candidates: list[SlackUser]) -> list[dict[s
     return blocks
 
 
+def _encode_pick_value(email: str, as_of: str | None) -> str:
+    """Pack the seat-resolution context into the action button's
+    ``value`` field. Slack caps ``value`` at 2000 chars; an email +
+    a date is well under that even with JSON overhead. The action
+    handler decodes via :func:`decode_pick_value`; both functions
+    are deterministic and stdlib-only so tests don't need fixtures."""
+    payload: dict[str, str] = {"email": email}
+    if as_of:
+        payload["as_of"] = as_of
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def decode_pick_value(raw: str) -> tuple[str, str | None]:
+    """Reverse :func:`_encode_pick_value`. Tolerant of the legacy
+    plain-email shape so a button minted before this change still
+    routes; never raises — a malformed payload returns ``("", None)``
+    and the caller renders an error."""
+    raw = (raw or "").strip()
+    if not raw:
+        return "", None
+    if raw.startswith("{"):
+        try:
+            payload = json.loads(raw)
+        except (ValueError, TypeError):
+            return "", None
+        if not isinstance(payload, dict):
+            return "", None
+        return (payload.get("email") or "").strip(), (payload.get("as_of") or None)
+    # Legacy shape: a bare email.
+    return raw, None
+
+
 def disambiguation_fuzzy(
     token: str,
     candidates: list[FuzzyCandidate],
     *,
     overflow: int = 0,
+    as_of: str | None = None,
 ) -> list[dict[str, Any]]:
     """#39: render a fuzzy-match candidate list with a "This person"
-    button per row. The button's ``value`` carries the candidate's
-    full email so the action handler can re-run the lookup without
-    keeping per-listener state. Same mrkdwn-escape contract as
-    sibling builders.
+    button per row. The button's ``value`` carries a JSON payload
+    ``{"email": ..., "as_of": ...}`` so the action handler can re-run
+    the lookup with the same as-of date the picker was generated
+    for. Same mrkdwn-escape contract as sibling builders.
 
     ``overflow`` is the number of additional candidates beyond what's
     rendered — surfaced in a context block so the caller knows to
@@ -308,9 +342,10 @@ def disambiguation_fuzzy(
                     "type": "button",
                     "action_id": DISAMBIG_FUZZY_ACTION_ID,
                     "text": {"type": "plain_text", "text": "This person"},
-                    # ``value`` carries the full email; the action handler
-                    # routes off it without keeping listener-side state.
-                    "value": c.email,
+                    # JSON payload carries email + as_of so the click
+                    # honors the same date window the picker was
+                    # generated for (#42 review fix).
+                    "value": _encode_pick_value(c.email, as_of),
                 },
             }
         )

--- a/office_cli/slack/_directory.py
+++ b/office_cli/slack/_directory.py
@@ -102,6 +102,17 @@ class SlackUserDirectory:
     def enabled(self) -> bool:
         return self._enabled
 
+    def iter_users(self) -> list[SlackUser]:
+        """Read-only snapshot of the cached roster, refreshed first
+        if stale. Used by the #39 fuzzy resolver to seed the
+        candidate pool from the Slack workspace; returns ``[]`` when
+        the directory is disabled (so callers can union without an
+        ``if enabled`` branch each time)."""
+        if not self._enabled:
+            return []
+        self._refresh_if_stale()
+        return list(self._users)
+
     def find_by_name(self, token: str) -> list[SlackUser]:
         """Return every Slack user whose display/real/name field
         equals ``token`` case-insensitively.

--- a/office_cli/slack/_fuzzy.py
+++ b/office_cli/slack/_fuzzy.py
@@ -1,0 +1,95 @@
+"""Pure fuzzy scoring for ``/whereis`` partial-name resolution (#39).
+
+The third tier of the resolution chain after the exact local-part path
+(#29) and exact Slack-name path (#38). The scorer is intentionally
+small and dependency-free: stdlib :mod:`difflib` is enough at v1
+scale, and keeping the function pure makes it cheap to test
+deterministically.
+
+This module never imports the Slack SDK or touches a network. Callers
+hand it a `(label, email)` iterable and read back ranked
+:class:`FuzzyCandidate` results.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Iterable
+
+DEFAULT_CUTOFF = 0.7
+DEFAULT_LIMIT = 5
+DEFAULT_AUTO_PICK_GAP = 0.05
+
+
+@dataclass(frozen=True)
+class FuzzyCandidate:
+    """One ranked hit. ``email`` is the resolution target;
+    ``label`` is what to render in the UI; ``score`` is the
+    :class:`difflib.SequenceMatcher` ratio against the search token
+    (0.0–1.0, higher is better)."""
+
+    email: str
+    label: str
+    score: float
+
+
+def rank_candidates(
+    token: str,
+    candidates: Iterable[tuple[str, str]],
+    *,
+    cutoff: float = DEFAULT_CUTOFF,
+    limit: int = DEFAULT_LIMIT,
+) -> list[FuzzyCandidate]:
+    """Score every ``(label, email)`` against ``token`` (case-
+    insensitive), drop everything below ``cutoff``, dedupe by email
+    keeping the highest-scoring label, sort by score desc, and cap at
+    ``limit``.
+
+    Dedup is critical: the same person frequently appears via both
+    the assignment-store local-part path and the Slack roster, and we
+    don't want them rendered twice or competing for the auto-pick
+    gap. When two labels tie on score, the one encountered first
+    wins (callers control order — local-parts before roster names is
+    the convention).
+    """
+    if not token:
+        return []
+    needle = token.lower()
+    best: dict[str, FuzzyCandidate] = {}
+    for label, email in candidates:
+        if not email or not label:
+            continue
+        score = SequenceMatcher(None, needle, label.lower()).ratio()
+        if score < cutoff:
+            continue
+        existing = best.get(email)
+        if existing is None or score > existing.score:
+            best[email] = FuzzyCandidate(email=email, label=label, score=score)
+    ranked = sorted(best.values(), key=lambda c: c.score, reverse=True)
+    return ranked[:limit]
+
+
+def auto_pick(
+    candidates: list[FuzzyCandidate],
+    *,
+    gap: float = DEFAULT_AUTO_PICK_GAP,
+) -> FuzzyCandidate | None:
+    """Decide whether the top candidate is unambiguously the best.
+
+    Returns the top :class:`FuzzyCandidate` iff exactly one candidate
+    cleared the cutoff, or the top score exceeds the runner-up by at
+    least ``gap``. Otherwise ``None`` — the caller should render an
+    interactive disambiguation list.
+
+    The "wrong auto-pick" cost is high (publicly mis-naming someone
+    in a Slack channel), so the gap defaults to a conservative 0.05
+    — about three SequenceMatcher edits' worth of confidence.
+    """
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+    if candidates[0].score - candidates[1].score >= gap:
+        return candidates[0]
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.9.8"
+version = "0.9.9"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_slack_serve.py
+++ b/tests/test_cli_slack_serve.py
@@ -96,3 +96,52 @@ def test_whitespace_directory_ttl_uses_default() -> None:
     assert _parse_ttl_env("   ") == _DEFAULT_TTL_SECONDS
     assert _parse_ttl_env("") == _DEFAULT_TTL_SECONDS
     assert _parse_ttl_env(None) == _DEFAULT_TTL_SECONDS
+
+
+@pytest.mark.parametrize("bad", ["abc", "2.0", "-0.1", "1.5"])
+def test_invalid_fuzzy_cutoff_is_rejected(bad: str) -> None:
+    """``OFFICE_FUZZY_CUTOFF`` must be a float in [0.0, 1.0]; any
+    out-of-range or non-float value raises ``OfficeError`` so the
+    listener fails fast."""
+    from office_cli.cli._commands.slack_serve import _parse_fuzzy_cutoff_env
+    from office_cli.cli._errors import OfficeError
+
+    with pytest.raises(OfficeError) as exc:
+        _parse_fuzzy_cutoff_env(bad)
+    assert "OFFICE_FUZZY_CUTOFF" in exc.value.message
+
+
+@pytest.mark.parametrize("good", ["0.0", "0.7", "1.0", "  0.5  "])
+def test_valid_fuzzy_cutoff_parses(good: str) -> None:
+    from office_cli.cli._commands.slack_serve import _parse_fuzzy_cutoff_env
+
+    assert 0.0 <= _parse_fuzzy_cutoff_env(good) <= 1.0
+
+
+def test_whitespace_fuzzy_cutoff_uses_default() -> None:
+    from office_cli.cli._commands.slack_serve import _parse_fuzzy_cutoff_env
+    from office_cli.slack._fuzzy import DEFAULT_CUTOFF
+
+    assert _parse_fuzzy_cutoff_env(None) == DEFAULT_CUTOFF
+    assert _parse_fuzzy_cutoff_env("") == DEFAULT_CUTOFF
+    assert _parse_fuzzy_cutoff_env("   ") == DEFAULT_CUTOFF
+
+
+@pytest.mark.parametrize("bad", ["abc", "0", "-3", "1.5"])
+def test_invalid_fuzzy_limit_is_rejected(bad: str) -> None:
+    """``OFFICE_FUZZY_LIMIT`` must be a positive integer."""
+    from office_cli.cli._commands.slack_serve import _parse_fuzzy_limit_env
+    from office_cli.cli._errors import OfficeError
+
+    with pytest.raises(OfficeError) as exc:
+        _parse_fuzzy_limit_env(bad)
+    assert "OFFICE_FUZZY_LIMIT" in exc.value.message
+
+
+def test_whitespace_fuzzy_limit_uses_default() -> None:
+    from office_cli.cli._commands.slack_serve import _parse_fuzzy_limit_env
+    from office_cli.slack._fuzzy import DEFAULT_LIMIT
+
+    assert _parse_fuzzy_limit_env(None) == DEFAULT_LIMIT
+    assert _parse_fuzzy_limit_env("") == DEFAULT_LIMIT
+    assert _parse_fuzzy_limit_env("   ") == DEFAULT_LIMIT

--- a/tests/test_cli_slack_serve.py
+++ b/tests/test_cli_slack_serve.py
@@ -127,15 +127,25 @@ def test_whitespace_fuzzy_cutoff_uses_default() -> None:
     assert _parse_fuzzy_cutoff_env("   ") == DEFAULT_CUTOFF
 
 
-@pytest.mark.parametrize("bad", ["abc", "0", "-3", "1.5"])
+@pytest.mark.parametrize("bad", ["abc", "0", "-3", "1.5", "26", "999"])
 def test_invalid_fuzzy_limit_is_rejected(bad: str) -> None:
-    """``OFFICE_FUZZY_LIMIT`` must be a positive integer."""
+    """``OFFICE_FUZZY_LIMIT`` must be a positive integer at or below
+    the safe cap. PR #42 review (Qodo + Copilot): without the upper
+    bound, the picker can exceed Slack's 50-block cap and silently
+    break ``chat.postEphemeral`` at runtime."""
     from office_cli.cli._commands.slack_serve import _parse_fuzzy_limit_env
     from office_cli.cli._errors import OfficeError
 
     with pytest.raises(OfficeError) as exc:
         _parse_fuzzy_limit_env(bad)
     assert "OFFICE_FUZZY_LIMIT" in exc.value.message
+
+
+def test_max_fuzzy_limit_accepted() -> None:
+    """The cap itself is a valid value — boundary check."""
+    from office_cli.cli._commands.slack_serve import _MAX_FUZZY_LIMIT, _parse_fuzzy_limit_env
+
+    assert _parse_fuzzy_limit_env(str(_MAX_FUZZY_LIMIT)) == _MAX_FUZZY_LIMIT
 
 
 def test_whitespace_fuzzy_limit_uses_default() -> None:

--- a/tests/test_slack_app.py
+++ b/tests/test_slack_app.py
@@ -21,14 +21,23 @@ from tests.test_bamboohr_directory import FakeBambooHRClient
 
 
 class FakeSlackApp:
-    """Captures `app.command(name)`-decorated handlers for direct invocation."""
+    """Captures `app.command(name)`- and `app.action(action_id)`-
+    decorated handlers for direct invocation."""
 
     def __init__(self) -> None:
         self.handlers: dict[str, Any] = {}
+        self.actions: dict[str, Any] = {}
 
     def command(self, name: str):
         def decorator(fn):
             self.handlers[name] = fn
+            return fn
+
+        return decorator
+
+    def action(self, action_id: str):
+        def decorator(fn):
+            self.actions[action_id] = fn
             return fn
 
         return decorator
@@ -56,6 +65,24 @@ class FakeSlackClient:
 def _invoke(app, body, command, client) -> None:
     """Call the registered /whereis handler with a no-op ack."""
     app.handlers["/whereis"](ack=lambda: None, body=body, command=command, client=client)
+
+
+def _invoke_pick_action(app, value: str, client) -> list[dict[str, Any]]:
+    """Invoke the registered ``whereis_pick`` action handler with a
+    button-click body whose ``actions[0].value`` is ``value``. Returns
+    the list of payloads the handler passed to ``respond``."""
+    posted: list[dict[str, Any]] = []
+    body = {
+        "user": {"id": "U999"},
+        "actions": [{"action_id": "whereis_pick", "value": value}],
+    }
+    app.actions["whereis_pick"](
+        ack=lambda: None,
+        body=body,
+        respond=lambda payload: posted.append(payload),
+        client=client,
+    )
+    return posted
 
 
 def _service_with_active(data_dir: Path, *active_emails: str):
@@ -900,3 +927,142 @@ def test_bare_token_disambiguation_redacts_hidden_seat_id(data_dir: Path) -> Non
     assert "5-T-02" not in text
     assert "alice@y.com" not in text
     assert "occupied (private)" in text
+
+
+# ----------------------------------------------------------------------
+# #39 — fuzzy match + interactive disambiguation
+# ----------------------------------------------------------------------
+
+
+def test_fuzzy_auto_picks_when_one_clear_winner(data_dir: Path) -> None:
+    """Bare token misses local-part exact and roster exact, but
+    fuzzy ranks ``alice.smith`` as the only candidate above the
+    cutoff. With a single hit, ``auto_pick`` returns it and the
+    handler renders the seat directly — no picker."""
+    service = _service_with_active(data_dir, "alice.smith@example.com")
+    service.assign("5-T-01", "alice.smith@example.com")
+    # Cutoff 0.5 is below the SequenceMatcher ratio of "alic" vs
+    # "alice.smith" (~0.53) so the candidate clears it; the default
+    # 0.7 would filter it out, which is exactly the operator-tunable
+    # behavior the env var exposes.
+    app = build_app(service, app=FakeSlackApp(), fuzzy_cutoff=0.5)
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alic"},  # close to "alice.smith" local-part
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "5-T-01" in text
+    assert "alice.smith@example.com" in text
+
+
+def test_fuzzy_disambiguation_renders_buttons_with_overflow(data_dir: Path) -> None:
+    """Multiple candidates within the auto-pick gap → render the
+    interactive picker. Cap at fuzzy_limit; surplus surfaces in the
+    overflow context block."""
+    service = _service_with_active(
+        data_dir,
+        "alec@example.com",
+        "alice@example.com",
+        "alyssa@example.com",
+        "alyx@example.com",
+    )
+    service.assign("5-T-01", "alec@example.com")
+    service.assign("5-T-02", "alice@example.com")
+    service.assign("5-T-03", "alyssa@example.com")
+    service.assign("5-T-04", "alyx@example.com")
+    app = build_app(
+        service,
+        app=FakeSlackApp(),
+        fuzzy_cutoff=0.4,
+        fuzzy_limit=2,
+        fuzzy_gap=0.5,  # force ambiguity even when scores differ slightly
+    )
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "al"},
+        client=client,
+    )
+    blocks = _last_blocks(client)
+    # One header + two candidate sections + overflow context.
+    section_blocks = [b for b in blocks if b.get("type") == "section"]
+    assert len(section_blocks) == 3  # header + 2 candidates
+    # Each candidate section carries a ``This person`` button.
+    buttons = [b.get("accessory") for b in blocks if isinstance(b.get("accessory"), dict)]
+    assert len(buttons) == 2
+    assert all(btn.get("action_id") == "whereis_pick" for btn in buttons)
+    assert all(btn.get("value", "").endswith("@example.com") for btn in buttons)
+    # Overflow context block reports the remaining candidates.
+    text = _block_text(blocks)
+    assert "more — refine" in text
+
+
+def test_fuzzy_no_match_falls_through_to_no_match_block(data_dir: Path) -> None:
+    """When even fuzzy can't find anyone above the cutoff, the
+    handler renders the same friendly no-match block the local-part
+    path uses — single error path, no resolution-tier surface."""
+    service = _service_with_active(data_dir, "alice@example.com")
+    service.assign("5-T-01", "alice@example.com")
+    app = build_app(service, app=FakeSlackApp(), fuzzy_cutoff=0.95)
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "xqz"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "Couldn't find a seat for `xqz`" in text
+
+
+def test_pick_action_re_runs_lookup_and_replaces(data_dir: Path) -> None:
+    """Clicking a candidate's button posts a ``whereis_pick`` action
+    with the picked email as ``value``. The handler must respond with
+    ``replace_original=True`` and the seat-found blocks for that
+    email."""
+    service = _service_with_active(data_dir, "alice.smith@example.com")
+    service.assign("5-T-03", "alice.smith@example.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+
+    [payload] = _invoke_pick_action(app, "alice.smith@example.com", client)
+    assert payload["replace_original"] is True
+    text = _block_text(payload["blocks"])
+    assert "5-T-03" in text
+    assert "alice.smith@example.com" in text
+
+
+def test_pick_action_with_empty_value_responds_with_error(data_dir: Path) -> None:
+    """Defensive: a malformed action payload (missing ``value``)
+    shouldn't crash the listener — respond with a friendly error."""
+    service = _service_with_active(data_dir)
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+    [payload] = _invoke_pick_action(app, "", client)
+    assert payload["replace_original"] is True
+    assert "couldn't read" in payload["text"]
+
+
+def test_fuzzy_path_does_not_regress_exact_local_part(data_dir: Path) -> None:
+    """Sanity: an exact local-part match still wins immediately —
+    fuzzy never fires when an earlier tier resolves."""
+    service = _service_with_active(data_dir, "ori.nachum@tipalti.com")
+    service.assign("5-T-03", "ori.nachum@tipalti.com")
+    app = build_app(service, app=FakeSlackApp(), fuzzy_cutoff=0.0)
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "ori.nachum"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    assert "5-T-03" in text
+    # The auto-pick path uses the email directly as the label, but
+    # local-part exact uses the same value, so this assertion still
+    # holds for the first-tier resolution.
+    assert "ori.nachum@tipalti.com" in text

--- a/tests/test_slack_app.py
+++ b/tests/test_slack_app.py
@@ -991,11 +991,16 @@ def test_fuzzy_disambiguation_renders_buttons_with_overflow(data_dir: Path) -> N
     # One header + two candidate sections + overflow context.
     section_blocks = [b for b in blocks if b.get("type") == "section"]
     assert len(section_blocks) == 3  # header + 2 candidates
-    # Each candidate section carries a ``This person`` button.
+    # Each candidate section carries a ``This person`` button. The
+    # value is now a JSON payload encoding ``{email, as_of}`` so the
+    # action handler can preserve the date window across the click.
+    from office_cli.slack._blocks import decode_pick_value
+
     buttons = [b.get("accessory") for b in blocks if isinstance(b.get("accessory"), dict)]
     assert len(buttons) == 2
     assert all(btn.get("action_id") == "whereis_pick" for btn in buttons)
-    assert all(btn.get("value", "").endswith("@example.com") for btn in buttons)
+    decoded_emails = [decode_pick_value(btn.get("value", ""))[0] for btn in buttons]
+    assert all(e.endswith("@example.com") for e in decoded_emails)
     # Overflow context block reports the remaining candidates.
     text = _block_text(blocks)
     assert "more — refine" in text
@@ -1066,3 +1071,164 @@ def test_fuzzy_path_does_not_regress_exact_local_part(data_dir: Path) -> None:
     # local-part exact uses the same value, so this assertion still
     # holds for the first-tier resolution.
     assert "ori.nachum@tipalti.com" in text
+
+
+# ----------------------------------------------------------------------
+# #42 review fixes
+# ----------------------------------------------------------------------
+
+
+def test_fuzzy_pool_excludes_hidden_seat_for_viewer(data_dir: Path) -> None:
+    """PR #42 review (Qodo + Copilot, security): the fuzzy pool must
+    not surface hidden-seat occupants to viewer-role callers, or the
+    auto-pick path would render their email + redacted seat — leaking
+    identity. With the gate, viewers fall through to no-match
+    instead.
+    """
+    from office_cli._roles import RolesConfig
+
+    service = _service_with_active(data_dir, "alice.exec@example.com")
+    service.assign("5-T-04", "alice.exec@example.com", hidden=True)
+    # Empty roles config → caller is viewer.
+    roles = RolesConfig()
+    app = build_app(service, app=FakeSlackApp(), roles=roles, fuzzy_cutoff=0.4, fuzzy_gap=0.0)
+    client = FakeSlackClient(users={"U999": {"profile": {"email": "viewer@x.com"}}})
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alice"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    # No leak: email and seat for the hidden assignment must not surface.
+    assert "alice.exec@example.com" not in text
+    assert "5-T-04" not in text
+
+
+def test_fuzzy_pool_includes_hidden_seat_for_full_access(data_dir: Path) -> None:
+    """Sister test: editors / planning roles see hidden-seat
+    occupants in the fuzzy pool — the redaction is viewer-specific."""
+    from office_cli._roles import RolesConfig
+
+    service = _service_with_active(data_dir, "alice.exec@example.com")
+    service.assign("5-T-04", "alice.exec@example.com", hidden=True)
+    # Caller is mapped as editor → full access.
+    roles = RolesConfig(editor=frozenset({"editor@x.com"}))
+    app = build_app(service, app=FakeSlackApp(), roles=roles, fuzzy_cutoff=0.4, fuzzy_gap=0.0)
+    client = FakeSlackClient(users={"U999": {"profile": {"email": "editor@x.com"}}})
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alice"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    # Editor sees full details for hidden seats.
+    assert "alice.exec@example.com" in text
+    assert "5-T-04" in text
+
+
+def test_fuzzy_auto_pick_honors_full_ranked_runner_up(data_dir: Path) -> None:
+    """PR #42 review (Qodo): with ``fuzzy_limit=1`` the previous
+    implementation auto-picked from the truncated render list,
+    ignoring an actual runner-up. With the fix, ``auto_pick`` runs
+    over the full ranked list and refuses to pick when the gap
+    isn't met."""
+    service = _service_with_active(
+        data_dir, "alice@example.com", "alica@example.com", "alice.smith@example.com"
+    )
+    service.assign("5-T-01", "alice@example.com")
+    service.assign("5-T-02", "alica@example.com")
+    service.assign("5-T-03", "alice.smith@example.com")
+    # Limit=1 would render only the top hit; the fix runs auto_pick
+    # against the full ranked list so the runner-up still blocks
+    # the auto-pick.
+    app = build_app(
+        service,
+        app=FakeSlackApp(),
+        fuzzy_cutoff=0.4,
+        fuzzy_limit=1,
+        fuzzy_gap=0.5,
+    )
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alic"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    # Picker (not auto-pick): the disambiguation header is rendered.
+    assert "Did you mean one of these" in text
+    # Overflow context reports the rest (we limited render to 1).
+    assert "more — refine" in text
+
+
+def test_pick_action_preserves_as_of_from_button(data_dir: Path) -> None:
+    """PR #42 review (Qodo + Copilot): the picker button now encodes
+    ``{email, as_of}`` so a click against a future-dated query
+    re-runs the lookup with the same window, not today."""
+    import json
+
+    service = _service_with_active(data_dir, "alice.future@example.com")
+    # Assign with an effective_from in the future (past today=2026-05-05).
+    service.assign("5-T-05", "alice.future@example.com", effective_from="2027-01-01")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+
+    # Button value carries ``{email, as_of=2027-06-01}`` — a click
+    # at run-time should resolve against that window.
+    encoded = json.dumps({"email": "alice.future@example.com", "as_of": "2027-06-01"})
+    [payload] = _invoke_pick_action(app, encoded, client)
+    text = _block_text(payload["blocks"])
+    # The future-dated assignment is in-window for as_of=2027-06-01,
+    # so the seat surfaces. Without the fix (always today=2026-05-05),
+    # the assignment would render as no_seat.
+    assert "5-T-05" in text
+
+
+def test_pick_action_decodes_legacy_plain_email_value(data_dir: Path) -> None:
+    """Backwards-compatibility: a button minted before this fix
+    carried just the email as ``value``. ``decode_pick_value`` still
+    routes those without erroring."""
+    service = _service_with_active(data_dir, "alice@example.com")
+    service.assign("5-T-01", "alice@example.com")
+    app = build_app(service, app=FakeSlackApp())
+    client = FakeSlackClient()
+
+    [payload] = _invoke_pick_action(app, "alice@example.com", client)
+    text = _block_text(payload["blocks"])
+    assert "5-T-01" in text
+
+
+def test_fuzzy_pool_excludes_inactive_employees(data_dir: Path) -> None:
+    """PR #42 review (Qodo + Copilot): an offboarded employee — one
+    whose email isn't in the directory's ``is_active`` set — must not
+    surface as a fuzzy hit even if their assignment row still exists.
+    """
+    service = _service_with_active(data_dir, "active.alice@example.com")
+    service.assign("5-T-01", "active.alice@example.com")
+    # Stash a row for someone the directory will reject.
+    service.store.upsert(
+        # Use the public API so audit/effective-window are coherent.
+        service.assign.__self__.store.list()[0].__class__(
+            seat_id="5-T-02",
+            floor="tlv-floor-5",
+            employee_email="ghost.alice@example.com",
+            last_updated="2026-05-01T00:00:01Z",
+        )
+    )
+    app = build_app(service, app=FakeSlackApp(), fuzzy_cutoff=0.4, fuzzy_gap=0.0)
+    client = FakeSlackClient()
+    _invoke(
+        app,
+        body={"channel_id": "C1", "user_id": "U999"},
+        command={"text": "alice"},
+        client=client,
+    )
+    text = _block_text(_last_blocks(client))
+    # Active alice is reachable.
+    assert "active.alice@example.com" in text or "5-T-01" in text
+    # Ghost alice (not in the directory) must not surface.
+    assert "ghost.alice@example.com" not in text
+    assert "5-T-02" not in text

--- a/tests/test_slack_fuzzy.py
+++ b/tests/test_slack_fuzzy.py
@@ -1,0 +1,105 @@
+"""Unit tests for the pure fuzzy scorer (#39)."""
+
+from __future__ import annotations
+
+import pytest
+
+from office_cli.slack._fuzzy import auto_pick, rank_candidates
+
+
+def test_exact_match_scores_one() -> None:
+    [c] = rank_candidates("alice", [("alice", "alice@example.com")], cutoff=0.0)
+    assert c.email == "alice@example.com"
+    assert c.score == pytest.approx(1.0)
+
+
+def test_below_cutoff_is_filtered() -> None:
+    """A clearly different label drops out at cutoff=0.7."""
+    ranked = rank_candidates("alice", [("zachary", "z@x.com")], cutoff=0.7)
+    assert ranked == []
+
+
+def test_dedup_by_email_keeps_higher_score() -> None:
+    """Same email seen via two labels: best score wins, only one row
+    survives."""
+    ranked = rank_candidates(
+        "alice",
+        [
+            ("Alice Smith", "alice@example.com"),  # weaker fuzzy match
+            ("alice", "alice@example.com"),  # exact local-part match
+        ],
+        cutoff=0.0,
+    )
+    assert len(ranked) == 1
+    assert ranked[0].label == "alice"
+    assert ranked[0].score == pytest.approx(1.0)
+
+
+def test_results_sorted_descending_and_capped() -> None:
+    """Three candidates above cutoff, ``limit=2`` keeps the top two
+    by score."""
+    pool = [
+        ("alic", "a@x.com"),  # very close to "alice" (~0.89)
+        ("alice", "b@x.com"),  # exact (1.0)
+        ("alica", "c@x.com"),  # 0.8
+    ]
+    ranked = rank_candidates("alice", pool, cutoff=0.7, limit=2)
+    assert [c.email for c in ranked] == ["b@x.com", "a@x.com"]
+
+
+def test_empty_token_returns_empty() -> None:
+    assert rank_candidates("", [("alice", "a@x.com")]) == []
+
+
+def test_blank_label_or_email_skipped() -> None:
+    """Defensive: a candidate with an empty label or email is skipped
+    silently (no exception)."""
+    ranked = rank_candidates(
+        "alice",
+        [
+            ("", "a@x.com"),  # no label
+            ("alice", ""),  # no email
+            ("alice", "alice@x.com"),  # valid
+        ],
+        cutoff=0.0,
+    )
+    assert len(ranked) == 1
+    assert ranked[0].email == "alice@x.com"
+
+
+def test_case_insensitive() -> None:
+    ranked = rank_candidates("ALICE", [("Alice", "a@x.com")], cutoff=0.0)
+    assert ranked[0].score == pytest.approx(1.0)
+
+
+def test_auto_pick_single_candidate() -> None:
+    [c] = rank_candidates("alice", [("alice", "a@x.com")])
+    assert auto_pick([c]) == c
+
+
+def test_auto_pick_clear_gap_picks_top() -> None:
+    pool = [
+        ("alice", "alice@x.com"),  # 1.0
+        ("alec", "alec@x.com"),  # ~0.5
+    ]
+    ranked = rank_candidates("alice", pool, cutoff=0.0)
+    picked = auto_pick(ranked, gap=0.1)
+    assert picked is not None
+    assert picked.email == "alice@x.com"
+
+
+def test_auto_pick_returns_none_within_gap() -> None:
+    """Top vs runner-up within the gap → ambiguous; render the
+    picker instead of choosing."""
+    pool = [
+        ("alice", "alice@x.com"),
+        ("alica", "alica@x.com"),  # very close fuzzy match
+    ]
+    ranked = rank_candidates("alice", pool, cutoff=0.0)
+    # Force a small gap so this assertion is robust to difflib drift.
+    picked = auto_pick(ranked, gap=0.5)
+    assert picked is None
+
+
+def test_auto_pick_empty_returns_none() -> None:
+    assert auto_pick([]) is None

--- a/uv.lock
+++ b/uv.lock
@@ -640,7 +640,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.9.8"
+version = "0.9.9"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Third and final tier of the `/whereis` resolution chain, after exact local-part (#29) and exact roster name (#38). When both exact paths miss, a `difflib.SequenceMatcher`-backed scorer ranks the union of assignment-store local-parts and Slack roster names against the bare token. A clear winner auto-picks; otherwise the handler renders an **interactive** picker — one section per candidate with a *This person* button — and a `whereis_pick` Bolt action handler re-runs the lookup against the chosen email and replaces the original ephemeral via `response_url`.

- `office_cli/slack/_fuzzy.py` — pure scorer + auto-pick (no new deps; `difflib` is stdlib).
- `office_cli/slack/_app.py` — `_lookup_by_fuzzy` integration + `whereis_pick` action handler.
- `office_cli/slack/_blocks.py` — `disambiguation_fuzzy` builder with mrkdwn-escape + overflow context.
- `office_cli/slack/_directory.py` — `iter_users()` accessor for the fuzzy pool builder.
- `office_cli/cli/_commands/slack_serve.py` — `OFFICE_FUZZY_CUTOFF` (float in `[0.0, 1.0]`, default `0.7`) + `OFFICE_FUZZY_LIMIT` (positive int, default `5`), validated before slack-bolt construction.

Privacy: hidden seats preserve their redaction treatment through both auto-pick and button-driven paths via the existing `_lookup` → `service.whereis` chain.

Closes #39.

## Test plan

- [x] `uv run pytest -n auto -q` — 399 passed (was 368; +31 across `test_slack_fuzzy.py`, fuzzy handler integration in `test_slack_app.py`, env-var validation in `test_cli_slack_serve.py`).
- [x] `uv run black/isort/flake8` clean.
- [x] `markdownlint-cli2 CHANGELOG.md` clean.
- [x] Pure scorer: 11 tests (exact match, sub-cutoff filter, dedupe by email, sort+cap, case-insensitive, single-hit auto-pick, gap-picking, within-gap-returns-None, empty input).
- [x] Handler: auto-pick → seat, ambiguous → buttons + overflow, fuzzy miss → no-match block, button click → respond with seat (replace_original), empty value → friendly error, local-part still wins on the early tier.
- [x] CLI: invalid cutoff (`abc`/`2.0`/`-0.1`/`1.5`), invalid limit (`abc`/`0`/`-3`/`1.5`), whitespace defaults.
- [ ] Live: `/beta-whereis ali` (auto-pick when alone), `/beta-whereis al` (ambiguous → buttons → click → seat), `OFFICE_FUZZY_LIMIT=2 /beta-whereis al` (overflow).

## Backwards compatibility

- Existing slash-command tests still pass — they don't register the action, but they don't need to.
- Default knobs match the issue's recommendations (cutoff 0.7, limit 5, gap 0.05).
- Exact-match paths from #29 / #38 short-circuit before fuzzy fires; no regression on those tiers.

## Out of scope (per issue)

- BambooHR as a candidate source (gates on #1).
- CLI fuzzy parity (separate, smaller issue if prioritized).
- Retrofitting buttons onto local-part / roster-exact disambiguations — those have different match semantics and the existing "re-run with full email" hint is sufficient there.

- Claude