### PR TITLE
feat(drive): load offices.yaml + floor SVGs from Google Drive (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-05-07
+
+### Added
+
+- Drive-as-CMS backend: when `OFFICE_DRIVE_ROOT` is set, hydrate `offices.yaml` and floor SVGs from a Google Drive folder into a local cache instead of reading from the working directory. Drive layout is one folder per office (folder name ends with `(<office-id>)`); the hydrator translates Drive's bare-filename SVGs into the existing `floors/<filename>` shape so downstream code is unchanged. Optional `[drive]` extra brings `google-api-python-client`. Knobs: `OFFICE_DRIVE_CREDENTIALS` (defaults to the Sheets SA), `OFFICE_DRIVE_TTL_SECONDS` (default 300), `OFFICE_DRIVE_CACHE_DIR` (default `~/.cache/office-cli/drive`). See `docs/floors-from-drive.md`. ([#44](https://github.com/agentculture/office-agent/issues/44))
+- `data/offices.yaml.example` documents the local-fallback shape for operators migrating to Drive mode.
+
 ## [0.9.9] - 2026-05-05
 
 ### Added

--- a/data/offices.yaml.example
+++ b/data/offices.yaml.example
@@ -1,0 +1,53 @@
+# Example offices.yaml — the office topology config.
+#
+# Two ways this file is read:
+#
+# 1. Local mode (default). With OFFICE_DRIVE_ROOT unset, `office` reads
+#    `data/offices.yaml` from the current working directory (or
+#    --data-dir / OFFICE_DATA_DIR). That file looks like this one.
+#
+# 2. Drive mode. With OFFICE_DRIVE_ROOT set, `office` reads
+#    `offices.yaml` from the Drive folder pointed at by that env var.
+#    The Drive copy uses **bare filenames** for `svg:` (e.g. just
+#    `tlv-floor-5.svg`) and the hydrator finds the file in the matching
+#    office folder. See docs/floors-from-drive.md.
+#
+# Both modes share the same schema apart from the `svg:` value. Drive
+# copy = bare filename. Local copy = `floors/<filename>`.
+
+offices:
+  - id: tlv
+    name: "Tel Aviv"
+    address: "Tel Aviv, Israel"
+    floors:
+      - id: tlv-floor-5
+        svg: floors/tlv-floor-5.svg          # local mode: relative path under data dir
+        status: active
+        clusters:
+          T: { capacity: 6, type: open-space }
+          Z: { capacity: 2, type: phone-room }
+        rooms:
+          "5.18": { name: "Meeting Room 8P", type: meeting, capacity: 8 }
+
+# Optional: who can see hidden seats / edit assignments.
+# Anything not listed here is `viewer` (sees `hidden=TRUE` seats as
+# "occupied (private)"). Issue #45 will move membership to Google
+# Groups / Active Directory; until then, list emails directly.
+#
+# roles:
+#   editor:
+#     - "hr-it@tipalti.com"
+#   planning:
+#     - "facilities@tipalti.com"
+
+# Optional: assignment storage backend. CSV is the default; sheets and
+# dynamo are alternatives. Note: this block is *infrastructure*, not
+# CMS content — keep it env-driven (set OFFICE_STORE / OFFICE_SHEETS_*
+# / OFFICE_DYNAMO_* directly) rather than putting it in Drive.
+#
+# storage:
+#   type: sheets
+#   sheets:
+#     spreadsheet_id: "..."
+#     service_account: data/sheets-service-account.json
+#     cache_ttl_seconds: 300

--- a/docs/floors-from-drive.md
+++ b/docs/floors-from-drive.md
@@ -1,0 +1,180 @@
+# Floors + config from Google Drive
+
+Issue [#44](https://github.com/agentculture/office-agent/issues/44).
+
+By default, `office` reads `data/offices.yaml` and `floors/*.svg` from
+the working directory. With one env var, it instead reads them live
+from a Google Drive folder — Inkscape stays the SVG editor, Drive
+becomes the CMS, and you stop committing layout edits to the repo.
+
+This is the same pattern the Sheets backend uses for assignments:
+non-engineers (facilities, office managers) edit the source-of-truth
+in a tool they already have, and the agent picks up changes within a
+short cache window.
+
+## Drive layout
+
+Use one folder per office, named so the folder name **ends with**
+`(<office-id>)`:
+
+```text
+<Org Drive>/Office Maps/                ← OFFICE_DRIVE_ROOT
+  offices.yaml                          ← topology config
+  Tel Aviv (tlv)/                       ← matches office id "tlv"
+    tlv-floor-5.svg
+    tlv-floor-6.svg
+  Frankfurt (fc)/
+    fc-floor-2.svg
+  New York (nyc)/
+    nyc-floor-12.svg
+```
+
+Permissions follow the building: TLV facilities gets edit on
+`Tel Aviv (tlv)/`, Frankfurt facilities on theirs, etc. Read-only
+share with the service-account email at the root level.
+
+## `offices.yaml` shape (Drive copy)
+
+The Drive YAML uses **bare filenames** for SVGs — no folder prefix:
+
+```yaml
+offices:
+  - id: tlv
+    name: "Tel Aviv"
+    floors:
+      - id: tlv-floor-5
+        svg: tlv-floor-5.svg            # filename inside the office folder
+        clusters:
+          T: { capacity: 6, type: open-space }
+          Z: { capacity: 2, type: phone-room }
+        rooms:
+          "5.18": { name: "Meeting Room 8P", type: meeting, capacity: 8 }
+```
+
+The hydrator looks up each SVG by name inside the matching office
+folder. No Drive file ids appear in YAML; renaming or moving files in
+Drive doesn't break anything as long as filenames + folder-id parens
+stay aligned.
+
+## Bootstrap
+
+```bash
+export OFFICE_DRIVE_ROOT="<folder-id>"            # required — gates drive mode on
+# Optional knobs:
+export OFFICE_DRIVE_CREDENTIALS=path/to/sa.json   # default: data/sheets-service-account.json
+export OFFICE_DRIVE_TTL_SECONDS=300               # default: 300 (set to 0 to force refetch)
+export OFFICE_DRIVE_CACHE_DIR=~/.cache/office-cli/drive
+```
+
+`OFFICE_DRIVE_ROOT` is the folder id, not a URL. From a Drive URL like
+`https://drive.google.com/drive/folders/1AbC...xyz`, take the last
+segment.
+
+The same service account that powers the Sheets backend works for
+Drive — just grant it the `drive.readonly` scope and share the root
+folder with its email. If you'd rather isolate credentials, set
+`OFFICE_DRIVE_CREDENTIALS` to a separate SA JSON.
+
+## Install
+
+```bash
+pip install office-cli[drive]
+# or, with uv from the repo:
+uv sync --all-extras
+```
+
+## How resolution works
+
+When `OFFICE_DRIVE_ROOT` is set, `resolve_data_dir()` calls
+`hydrate_data_dir()` instead of returning the cwd. Hydration:
+
+1. Lists the root folder. Finds `offices.yaml` at the top.
+2. Downloads it (skipping if a fresh copy is already cached).
+3. Parses it to discover declared offices.
+4. For each office, finds the matching subfolder by the
+   `(<office-id>)` suffix in its name.
+5. Lists that subfolder, downloads each declared SVG (skipping fresh
+   cached copies).
+6. Writes a rewritten `offices.yaml` into the cache where each `svg:`
+   field is a `floors/<filename>` relative path — the existing
+   on-disk YAML resolver handles it from there.
+
+The cache mirrors the on-disk data-dir layout:
+
+```text
+~/.cache/office-cli/drive/<root-folder-id>/
+  data/offices.yaml
+  floors/tlv-floor-5.svg
+  seats/                       ← empty; CSV fallback writes here if used
+  .meta/fetched-at.json        ← TTL bookkeeping
+```
+
+Downstream code (`load_offices`, `parse_svg`, the web map, Slack
+`/whereis`) sees a normal-looking data dir; nothing knows it came
+from Drive.
+
+## Resolution order
+
+`resolve_data_dir()` picks in this order (first match wins):
+
+1. `--data-dir <PATH>` CLI flag — explicit override; useful for tests
+   and dev loops.
+2. `OFFICE_DATA_DIR` env var — same effect as `--data-dir`.
+3. `OFFICE_DRIVE_ROOT` env var — eager hydrate, return the cache path.
+4. `Path.cwd()` — the historical default.
+
+So setting `--data-dir` or `OFFICE_DATA_DIR` always disables drive
+mode for that invocation, even with `OFFICE_DRIVE_ROOT` set.
+
+## Cache + TTL
+
+- Per-file timestamps in `.meta/fetched-at.json`. On hydrate: if the
+  cached file exists **and** age < TTL, the download is skipped.
+- Default TTL: 300s (matches BambooHR + Sheets).
+- `OFFICE_DRIVE_TTL_SECONDS=0` forces a fresh fetch every boot
+  (useful for ops debugging, or right after an operator edits Drive).
+- Cache invalidation: delete the cache dir.
+
+  ```bash
+  rm -rf ~/.cache/office-cli/drive
+  ```
+
+## End-to-end smoke test
+
+```bash
+export OFFICE_DRIVE_ROOT="<folder-id>"
+rm -rf ~/.cache/office-cli/drive
+uv run office floors validate tlv-floor-5
+uv run office seats list
+uv run office whereis ori.nachum@tipalti.com
+```
+
+Cold run hits Drive once for `offices.yaml` plus once per SVG. Warm
+run within TTL makes zero Drive calls.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| `offices.yaml not found at the root of OFFICE_DRIVE_ROOT` | Wrong folder id, or the SA isn't shared on the root folder. |
+| `no Drive folder matches office id 'tlv'` | The office folder name doesn't end with `(tlv)`. Rename to `Tel Aviv (tlv)`. |
+| `multiple Drive folders match office id 'tlv'` | Two folders both end with `(tlv)`. Remove or rename one. |
+| `floor 'tlv-floor-5': SVG 'tlv-floor-5.svg' not found in office folder 'Tel Aviv (tlv)'` | The SVG isn't in that folder. The error lists what's actually there. |
+| `google-api-python-client is not installed` | Run `pip install office-cli[drive]` (or `uv sync --all-extras`). |
+| Stale data after editing in Drive | TTL hasn't expired; rerun with `OFFICE_DRIVE_TTL_SECONDS=0` once or `rm -rf ~/.cache/office-cli/drive`. |
+
+## Out of scope
+
+- Writing SVGs back to Drive — Inkscape stays the editor.
+- Push notifications / webhook-driven cache invalidation — TTL is
+  enough for v1.
+- Roles via Google Groups / Active Directory — tracked in
+  [#45](https://github.com/agentculture/office-agent/issues/45).
+- Per-office Drive folders for `seats/` (assignment + audit log) —
+  those stay in Sheets/Dynamo, addressed by the `storage:` block.
+
+## See also
+
+- [`data/offices.yaml.example`](../data/offices.yaml.example) — local-fallback shape, used when `OFFICE_DRIVE_ROOT` is unset.
+- [`docs/architecture.md`](./architecture.md) — full v1 design.
+- [`docs/setup.md`](./setup.md) — getting started without Drive.

--- a/office_cli/_config.py
+++ b/office_cli/_config.py
@@ -6,7 +6,9 @@ Data-dir resolution order:
 
 1. ``--data-dir`` CLI flag (passed through ``args.data_dir``);
 2. ``OFFICE_DATA_DIR`` environment variable;
-3. the current working directory.
+3. ``OFFICE_DRIVE_ROOT`` env var → eager-hydrate from Google Drive
+   into ``~/.cache/office-cli/drive/<root-id>/`` and use that;
+4. the current working directory.
 
 Storage selection order (last wins):
 
@@ -69,6 +71,8 @@ def resolve_data_dir(args: argparse.Namespace | None = None) -> Path:
         candidate = Path(explicit).expanduser()
     elif os.environ.get("OFFICE_DATA_DIR"):
         candidate = Path(os.environ["OFFICE_DATA_DIR"]).expanduser()
+    elif os.environ.get("OFFICE_DRIVE_ROOT"):
+        candidate = _hydrate_drive_data_dir()
     else:
         candidate = Path.cwd()
     if not candidate.is_dir():
@@ -78,6 +82,64 @@ def resolve_data_dir(args: argparse.Namespace | None = None) -> Path:
             remediation="pass --data-dir or set OFFICE_DATA_DIR to the office-agent checkout",
         )
     return candidate
+
+
+def _hydrate_drive_data_dir() -> Path:
+    """Pull the Drive-hosted office tree into a local cache and return it.
+
+    Lazy-imports :mod:`office_cli.drive` so the ``[drive]`` extra stays
+    optional. Reads ``OFFICE_DRIVE_ROOT`` (required) plus optional
+    ``OFFICE_DRIVE_CREDENTIALS`` / ``OFFICE_DRIVE_TTL_SECONDS`` /
+    ``OFFICE_DRIVE_CACHE_DIR`` knobs.
+    """
+    from office_cli.drive import hydrate_data_dir
+
+    root_id = os.environ["OFFICE_DRIVE_ROOT"].strip()
+    creds = _drive_credentials_path()
+    ttl = _drive_ttl_seconds()
+    cache_root = _drive_cache_root()
+    return hydrate_data_dir(
+        root_id,
+        credentials_path=creds,
+        cache_root=cache_root,
+        ttl_seconds=ttl,
+    )
+
+
+def _drive_credentials_path() -> Path:
+    raw = os.environ.get("OFFICE_DRIVE_CREDENTIALS", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    # Default to the Sheets SA so a single credential covers both backends.
+    return Path("data/sheets-service-account.json").resolve()
+
+
+def _drive_ttl_seconds() -> int:
+    raw = os.environ.get("OFFICE_DRIVE_TTL_SECONDS", "").strip()
+    if not raw:
+        return 300
+    try:
+        ttl = int(raw)
+    except ValueError as err:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"OFFICE_DRIVE_TTL_SECONDS must be an integer; got {raw!r}",
+            remediation="set OFFICE_DRIVE_TTL_SECONDS to a non-negative integer (seconds)",
+        ) from err
+    if ttl < 0:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"OFFICE_DRIVE_TTL_SECONDS must be non-negative; got {ttl}",
+            remediation="set OFFICE_DRIVE_TTL_SECONDS to a non-negative integer (seconds)",
+        )
+    return ttl
+
+
+def _drive_cache_root() -> Path:
+    raw = os.environ.get("OFFICE_DRIVE_CACHE_DIR", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".cache" / "office-cli" / "drive"
 
 
 def add_data_dir_arg(parser: argparse.ArgumentParser) -> None:

--- a/office_cli/drive/__init__.py
+++ b/office_cli/drive/__init__.py
@@ -1,0 +1,21 @@
+"""Google Drive backend: load ``offices.yaml`` + floor SVGs from Drive.
+
+When ``OFFICE_DRIVE_ROOT`` is set, :func:`hydrate_data_dir` pulls the
+topology file and every declared SVG into a local cache that mirrors
+the on-disk data-dir layout. The rest of the codebase keeps reading
+local paths and is none the wiser.
+"""
+
+from __future__ import annotations
+
+from office_cli.drive._cache import CacheMeta
+from office_cli.drive._client import DriveClient, DriveEntry, GoogleDriveClient
+from office_cli.drive._hydrate import hydrate_data_dir
+
+__all__ = [
+    "CacheMeta",
+    "DriveClient",
+    "DriveEntry",
+    "GoogleDriveClient",
+    "hydrate_data_dir",
+]

--- a/office_cli/drive/_cache.py
+++ b/office_cli/drive/_cache.py
@@ -1,0 +1,60 @@
+"""On-disk Drive cache: TTL bookkeeping under ``<cache>/.meta/``.
+
+A single JSON file (``fetched-at.json``) maps relative cache paths to
+their last-fetched epoch seconds. The hydrator consults
+:meth:`is_fresh` before downloading and calls :meth:`record` after a
+successful fetch.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+_META_DIR = ".meta"
+_META_FILE = "fetched-at.json"
+
+
+class CacheMeta:
+    """Tracks fetched-at timestamps for files inside a cache root."""
+
+    def __init__(self, cache_root: Path, *, clock=None) -> None:
+        self._root = cache_root
+        self._meta_path = cache_root / _META_DIR / _META_FILE
+        self._clock = clock or time.time
+        self._data: dict[str, float] = self._load()
+
+    def _load(self) -> dict[str, float]:
+        if not self._meta_path.is_file():
+            return {}
+        try:
+            with self._meta_path.open("r", encoding="utf-8") as fh:
+                raw = json.load(fh)
+        except (OSError, ValueError):
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        out: dict[str, float] = {}
+        for key, value in raw.items():
+            try:
+                out[str(key)] = float(value)
+            except (TypeError, ValueError):
+                continue
+        return out
+
+    def is_fresh(self, rel_path: str, ttl_seconds: int) -> bool:
+        """``True`` if ``rel_path`` was fetched within the last ``ttl`` seconds."""
+        if ttl_seconds <= 0:
+            return False
+        last = self._data.get(rel_path)
+        if last is None:
+            return False
+        return (self._clock() - last) < ttl_seconds
+
+    def record(self, rel_path: str) -> None:
+        """Stamp ``rel_path`` as fetched now and persist the meta file."""
+        self._data[rel_path] = float(self._clock())
+        self._meta_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._meta_path.open("w", encoding="utf-8") as fh:
+            json.dump(self._data, fh, indent=2, sort_keys=True)

--- a/office_cli/drive/_client.py
+++ b/office_cli/drive/_client.py
@@ -1,0 +1,120 @@
+"""Thin shim over the Google Drive v3 API.
+
+The :class:`DriveClient` Protocol exposes only what the hydrator needs:
+list a folder's immediate children and download a file's bytes. The
+hydrator is unit-tested against a ``FakeDriveClient`` so the suite
+never needs real credentials. :class:`GoogleDriveClient` is the
+production implementation; the ``googleapiclient`` / ``google-auth``
+imports are deferred to first use so the parent package can be
+imported without the ``[drive]`` extra installed.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
+
+_DRIVE_READONLY_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
+_FOLDER_MIME = "application/vnd.google-apps.folder"
+_PAGE_SIZE = 100
+
+
+@dataclass(frozen=True)
+class DriveEntry:
+    """One immediate child of a Drive folder."""
+
+    id: str
+    name: str
+    is_folder: bool
+
+
+class DriveClient(Protocol):
+    def list_folder(self, folder_id: str) -> list[DriveEntry]:
+        """Return ``folder_id``'s immediate children (files + subfolders)."""
+
+    def download_file(self, file_id: str) -> bytes:
+        """Return the raw bytes of ``file_id``."""
+
+
+class GoogleDriveClient:
+    """Production :class:`DriveClient` backed by ``google-api-python-client``."""
+
+    def __init__(self, service_account_path: Path) -> None:
+        try:
+            import google.oauth2.service_account  # noqa: F401 — runtime check
+            import googleapiclient.discovery  # noqa: F401 — runtime check
+        except ImportError as err:
+            raise OfficeError(
+                code=EXIT_ENV_ERROR,
+                message="google-api-python-client is not installed",
+                remediation="install the drive extra: pip install office-cli[drive]",
+            ) from err
+        if not service_account_path.is_file():
+            raise OfficeError(
+                code=EXIT_ENV_ERROR,
+                message=f"Drive service-account JSON not found: {service_account_path}",
+                remediation=(
+                    "set OFFICE_DRIVE_CREDENTIALS to a real file, or "
+                    "place the SA JSON at data/sheets-service-account.json"
+                ),
+            )
+        self._service_account_path = service_account_path
+        self._service = None
+
+    def _connect(self):
+        if self._service is None:
+            from google.oauth2.service_account import Credentials
+            from googleapiclient.discovery import build
+
+            creds = Credentials.from_service_account_file(
+                str(self._service_account_path),
+                scopes=[_DRIVE_READONLY_SCOPE],
+            )
+            self._service = build("drive", "v3", credentials=creds, cache_discovery=False)
+        return self._service
+
+    def list_folder(self, folder_id: str) -> list[DriveEntry]:
+        svc = self._connect()
+        out: list[DriveEntry] = []
+        page_token: str | None = None
+        while True:
+            resp = (
+                svc.files()
+                .list(
+                    q=f"'{folder_id}' in parents and trashed = false",
+                    fields="nextPageToken, files(id, name, mimeType)",
+                    pageSize=_PAGE_SIZE,
+                    pageToken=page_token,
+                    supportsAllDrives=True,
+                    includeItemsFromAllDrives=True,
+                )
+                .execute()
+            )
+            for entry in resp.get("files", []):
+                out.append(
+                    DriveEntry(
+                        id=entry["id"],
+                        name=entry["name"],
+                        is_folder=entry.get("mimeType") == _FOLDER_MIME,
+                    )
+                )
+            page_token = resp.get("nextPageToken")
+            if not page_token:
+                break
+        return out
+
+    def download_file(self, file_id: str) -> bytes:
+        from googleapiclient.http import MediaIoBaseDownload
+
+        svc = self._connect()
+        request = svc.files().get_media(fileId=file_id, supportsAllDrives=True)
+        buf = io.BytesIO()
+        downloader = MediaIoBaseDownload(buf, request)
+        done = False
+        while not done:
+            _, done = downloader.next_chunk()
+        return buf.getvalue()

--- a/office_cli/drive/_hydrate.py
+++ b/office_cli/drive/_hydrate.py
@@ -42,6 +42,7 @@ from office_cli.drive._client import DriveClient, DriveEntry, GoogleDriveClient
 _OFFICES_YAML = "offices.yaml"
 _YAML_REL = "data/offices.yaml"
 _OFFICE_ID_RE = re.compile(r"\(([a-z0-9-]+)\)\s*$")
+_SHAPE_HINT = "see data/offices.yaml.example for the expected shape"
 
 
 def hydrate_data_dir(
@@ -110,22 +111,26 @@ def _is_warm_cache_complete(cache_dir: Path, meta: CacheMeta, ttl: int) -> bool:
     offices_raw = data.get("offices")
     if not isinstance(offices_raw, list):
         return False
-    for office in offices_raw:
-        if not isinstance(office, dict):
-            return False
-        floors_raw = office.get("floors") or []
-        if not isinstance(floors_raw, list):
-            return False
-        for floor in floors_raw:
-            if not isinstance(floor, dict):
-                return False
-            svg_rel = str(floor.get("svg", "")).strip()
-            if not svg_rel:
-                return False
-            local = cache_dir / svg_rel
-            if not (local.is_file() and meta.is_fresh(svg_rel, ttl)):
-                return False
-    return True
+    return all(_office_is_warm(o, cache_dir, meta, ttl) for o in offices_raw)
+
+
+def _office_is_warm(office: object, cache_dir: Path, meta: CacheMeta, ttl: int) -> bool:
+    if not isinstance(office, dict):
+        return False
+    floors_raw = office.get("floors") or []
+    if not isinstance(floors_raw, list):
+        return False
+    return all(_floor_is_warm(f, cache_dir, meta, ttl) for f in floors_raw)
+
+
+def _floor_is_warm(floor: object, cache_dir: Path, meta: CacheMeta, ttl: int) -> bool:
+    if not isinstance(floor, dict):
+        return False
+    svg_rel = str(floor.get("svg", "")).strip()
+    if not svg_rel:
+        return False
+    local = cache_dir / svg_rel
+    return local.is_file() and meta.is_fresh(svg_rel, ttl)
 
 
 # -- Drive hydration ----------------------------------------------------------
@@ -170,7 +175,7 @@ def _hydrate_office(
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=f"office entry at index {idx} is not a mapping",
-            remediation="see data/offices.yaml.example for the expected shape",
+            remediation=_SHAPE_HINT,
         )
     oid = str(office.get("id", "")).strip()
     if not oid:
@@ -208,7 +213,7 @@ def _hydrate_floor(
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=(f"office {office_id!r}: floor entry at index {idx} is not a mapping"),
-            remediation="see data/offices.yaml.example for the expected shape",
+            remediation=_SHAPE_HINT,
         )
     fid = str(floor.get("id", "")).strip()
     if not fid:
@@ -267,7 +272,7 @@ def _resolve_unique_file(
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=(
-                f"floor {floor_id!r}: SVG {name!r} not found in office folder " f"{folder_name!r}"
+                f"floor {floor_id!r}: SVG {name!r} not found in office folder {folder_name!r}"
             ),
             remediation=(
                 "upload the SVG to that folder, or fix the `svg:` field in "
@@ -356,7 +361,7 @@ def _load_yaml(path: Path) -> dict:
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message="offices.yaml in Drive must be a mapping at the top level",
-            remediation="see data/offices.yaml.example for the expected shape",
+            remediation=_SHAPE_HINT,
         )
     return raw
 
@@ -367,6 +372,6 @@ def _validate_offices_list(yaml_data: dict) -> list:
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message="offices.yaml in Drive must contain a top-level `offices:` list",
-            remediation="see data/offices.yaml.example for the expected shape",
+            remediation=_SHAPE_HINT,
         )
     return offices_raw

--- a/office_cli/drive/_hydrate.py
+++ b/office_cli/drive/_hydrate.py
@@ -1,0 +1,216 @@
+"""Eager hydration of a Drive-hosted office tree into a local cache dir.
+
+When ``OFFICE_DRIVE_ROOT`` is set, :func:`hydrate_data_dir` pulls
+``offices.yaml`` + every declared SVG into ``<cache_root>/<root-id>/``,
+returning a path that mirrors the on-disk data-dir layout
+(``data/``, ``floors/``, ``seats/``). Downstream code reads from this
+path as if it were a regular checkout, so the rest of the pipeline
+(``load_offices``, ``parse_svg``, ``resolve_storage``) is unchanged.
+
+Drive's authoring layout uses one folder per office, named so the
+folder name ends with ``(<office-id>)``::
+
+    <Org Drive>/Office Maps/                ← OFFICE_DRIVE_ROOT
+      offices.yaml
+      Tel Aviv (tlv)/
+        tlv-floor-5.svg
+      Frankfurt (fc)/
+        fc-floor-2.svg
+
+The hydrator translates Drive's bare-filename ``svg`` fields into the
+``floors/<filename>`` relative paths the existing YAML resolver
+already understands (``office_cli/offices/_yaml.py``).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from office_cli.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, OfficeError
+from office_cli.drive._cache import CacheMeta
+from office_cli.drive._client import DriveClient, DriveEntry, GoogleDriveClient
+
+_OFFICES_YAML = "offices.yaml"
+_OFFICE_ID_RE = re.compile(r"\(([a-z0-9-]+)\)\s*$")
+
+
+def hydrate_data_dir(
+    root_folder_id: str,
+    *,
+    credentials_path: Path,
+    cache_root: Path,
+    ttl_seconds: int = 300,
+    client: Optional[DriveClient] = None,
+) -> Path:
+    """Hydrate a Drive root into a local cache dir; return the cache path.
+
+    The returned path has the on-disk data-dir layout
+    (``data/offices.yaml``, ``floors/<svg>``, ``seats/``) so callers
+    can pass it straight to :func:`office_cli.offices.load_offices`.
+
+    ``client`` is injectable so tests can drive the hydrator with an
+    in-memory fake instead of the real Drive API.
+    """
+    if not root_folder_id:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message="OFFICE_DRIVE_ROOT is empty",
+            remediation="set OFFICE_DRIVE_ROOT to a Google Drive folder id",
+        )
+
+    cache_dir = cache_root / root_folder_id
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "data").mkdir(exist_ok=True)
+    (cache_dir / "floors").mkdir(exist_ok=True)
+    (cache_dir / "seats").mkdir(exist_ok=True)
+
+    drive: DriveClient = client or GoogleDriveClient(credentials_path)
+    meta = CacheMeta(cache_dir)
+
+    root_entries = drive.list_folder(root_folder_id)
+    yaml_entry = _find_root_yaml(root_entries)
+
+    yaml_rel = "data/offices.yaml"
+    yaml_cache = cache_dir / yaml_rel
+    if not (meta.is_fresh(yaml_rel, ttl_seconds) and yaml_cache.is_file()):
+        yaml_cache.write_bytes(drive.download_file(yaml_entry.id))
+        meta.record(yaml_rel)
+
+    yaml_data = _load_yaml(yaml_cache)
+    offices_raw = yaml_data.get("offices")
+    if not isinstance(offices_raw, list):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="offices.yaml in Drive must contain a top-level `offices:` list",
+            remediation="see data/offices.yaml.example for the expected shape",
+        )
+
+    folder_index = {e.name: e for e in root_entries if e.is_folder}
+    for office in offices_raw:
+        if not isinstance(office, dict):
+            continue
+        oid = str(office.get("id", "")).strip()
+        if not oid:
+            continue
+        folder_entry = _match_office_folder(folder_index, oid)
+        floor_entries = drive.list_folder(folder_entry.id)
+        floor_index = {e.name: e for e in floor_entries if not e.is_folder}
+        floors_raw = office.get("floors") or []
+        rewritten: list[object] = []
+        for floor in floors_raw:
+            if not isinstance(floor, dict):
+                rewritten.append(floor)
+                continue
+            fid = str(floor.get("id", "")).strip()
+            svg_field = str(floor.get("svg", f"{fid}.svg")).strip()
+            # Drive YAML uses bare filenames; tolerate "floors/<name>" too.
+            svg_name = svg_field.split("/")[-1]
+            if not svg_name:
+                raise OfficeError(
+                    code=EXIT_USER_ERROR,
+                    message=f"floor {fid!r}: empty `svg` field in offices.yaml",
+                    remediation="set `svg:` to the SVG filename in the office folder",
+                )
+            entry = floor_index.get(svg_name)
+            if entry is None:
+                present = sorted(floor_index.keys())
+                raise OfficeError(
+                    code=EXIT_USER_ERROR,
+                    message=(
+                        f"floor {fid!r}: SVG {svg_name!r} not found in "
+                        f"office folder {folder_entry.name!r}"
+                    ),
+                    remediation=(
+                        "upload the SVG to that folder, or fix the `svg:` "
+                        "field in offices.yaml. Files present: "
+                        f"{', '.join(present) if present else '(none)'}"
+                    ),
+                )
+            rel = f"floors/{svg_name}"
+            local = cache_dir / rel
+            if not (meta.is_fresh(rel, ttl_seconds) and local.is_file()):
+                local.write_bytes(drive.download_file(entry.id))
+                meta.record(rel)
+            new_floor = dict(floor)
+            new_floor["svg"] = rel
+            rewritten.append(new_floor)
+        office["floors"] = rewritten
+
+    yaml_data["offices"] = offices_raw
+    with yaml_cache.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(yaml_data, fh, sort_keys=False, allow_unicode=True)
+
+    return cache_dir
+
+
+def _find_root_yaml(entries: list[DriveEntry]) -> DriveEntry:
+    matches = [e for e in entries if e.name == _OFFICES_YAML and not e.is_folder]
+    if not matches:
+        raise OfficeError(
+            code=EXIT_ENV_ERROR,
+            message=f"{_OFFICES_YAML} not found at the root of OFFICE_DRIVE_ROOT",
+            remediation=(
+                "upload offices.yaml to the folder pointed at by "
+                "OFFICE_DRIVE_ROOT, and ensure the service account has access"
+            ),
+        )
+    if len(matches) > 1:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"multiple {_OFFICES_YAML} entries at OFFICE_DRIVE_ROOT",
+            remediation="remove duplicates so only one offices.yaml remains",
+        )
+    return matches[0]
+
+
+def _match_office_folder(folder_index: dict[str, DriveEntry], office_id: str) -> DriveEntry:
+    matches: list[DriveEntry] = []
+    for name, entry in folder_index.items():
+        m = _OFFICE_ID_RE.search(name)
+        if m and m.group(1) == office_id:
+            matches.append(entry)
+    if not matches:
+        present = sorted(folder_index.keys())
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"no Drive folder matches office id {office_id!r} "
+                f"(expected a folder name ending with '({office_id})')"
+            ),
+            remediation=(
+                "create a folder under OFFICE_DRIVE_ROOT named like "
+                f"'Office Name ({office_id})'. Folders present: "
+                f"{', '.join(present) if present else '(none)'}"
+            ),
+        )
+    if len(matches) > 1:
+        names = ", ".join(e.name for e in matches)
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"multiple Drive folders match office id {office_id!r}: {names}",
+            remediation="rename or remove duplicates so only one folder matches",
+        )
+    return matches[0]
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        try:
+            raw = yaml.safe_load(fh) or {}
+        except yaml.YAMLError as err:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"offices.yaml in Drive is not valid YAML: {err}",
+                remediation="fix the YAML syntax in Drive and rerun",
+            ) from err
+    if not isinstance(raw, dict):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="offices.yaml in Drive must be a mapping at the top level",
+            remediation="see data/offices.yaml.example for the expected shape",
+        )
+    return raw

--- a/office_cli/drive/_hydrate.py
+++ b/office_cli/drive/_hydrate.py
@@ -20,13 +20,18 @@ folder name ends with ``(<office-id>)``::
 The hydrator translates Drive's bare-filename ``svg`` fields into the
 ``floors/<filename>`` relative paths the existing YAML resolver
 already understands (``office_cli/offices/_yaml.py``).
+
+Warm cache: if every required file (``data/offices.yaml`` + each
+referenced SVG) is present locally and its meta age is below the TTL,
+:func:`hydrate_data_dir` returns without making any Drive API calls
+— including folder listings.
 """
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 import yaml
 
@@ -35,6 +40,7 @@ from office_cli.drive._cache import CacheMeta
 from office_cli.drive._client import DriveClient, DriveEntry, GoogleDriveClient
 
 _OFFICES_YAML = "offices.yaml"
+_YAML_REL = "data/offices.yaml"
 _OFFICE_ID_RE = re.compile(r"\(([a-z0-9-]+)\)\s*$")
 
 
@@ -63,88 +69,222 @@ def hydrate_data_dir(
         )
 
     cache_dir = cache_root / root_folder_id
+    _ensure_cache_layout(cache_dir)
+    meta = CacheMeta(cache_dir)
+
+    if _is_warm_cache_complete(cache_dir, meta, ttl_seconds):
+        return cache_dir
+
+    drive: DriveClient = client or GoogleDriveClient(credentials_path)
+    _hydrate_from_drive(drive, root_folder_id, cache_dir, meta, ttl_seconds)
+    return cache_dir
+
+
+# -- Cache layout + warm-path -------------------------------------------------
+
+
+def _ensure_cache_layout(cache_dir: Path) -> None:
     cache_dir.mkdir(parents=True, exist_ok=True)
     (cache_dir / "data").mkdir(exist_ok=True)
     (cache_dir / "floors").mkdir(exist_ok=True)
     (cache_dir / "seats").mkdir(exist_ok=True)
 
-    drive: DriveClient = client or GoogleDriveClient(credentials_path)
-    meta = CacheMeta(cache_dir)
 
-    root_entries = drive.list_folder(root_folder_id)
-    yaml_entry = _find_root_yaml(root_entries)
+def _is_warm_cache_complete(cache_dir: Path, meta: CacheMeta, ttl: int) -> bool:
+    """Return True iff the YAML and every referenced SVG are fresh+present.
 
-    yaml_rel = "data/offices.yaml"
-    yaml_cache = cache_dir / yaml_rel
-    if not (meta.is_fresh(yaml_rel, ttl_seconds) and yaml_cache.is_file()):
-        yaml_cache.write_bytes(drive.download_file(yaml_entry.id))
-        meta.record(yaml_rel)
-
-    yaml_data = _load_yaml(yaml_cache)
-    offices_raw = yaml_data.get("offices")
+    A True result means :func:`hydrate_data_dir` can skip Drive entirely
+    — no folder listings, no downloads. Any structural issue with the
+    cached YAML (missing offices list, non-mapping entries, missing svg
+    field, missing local file, stale meta) returns False so the caller
+    falls through to a full hydrate that will surface the error from
+    Drive's authoritative copy.
+    """
+    yaml_path = cache_dir / _YAML_REL
+    if not (yaml_path.is_file() and meta.is_fresh(_YAML_REL, ttl)):
+        return False
+    try:
+        data = _load_yaml(yaml_path)
+    except OfficeError:
+        return False
+    offices_raw = data.get("offices")
     if not isinstance(offices_raw, list):
-        raise OfficeError(
-            code=EXIT_USER_ERROR,
-            message="offices.yaml in Drive must contain a top-level `offices:` list",
-            remediation="see data/offices.yaml.example for the expected shape",
-        )
-
-    folder_index = {e.name: e for e in root_entries if e.is_folder}
+        return False
     for office in offices_raw:
         if not isinstance(office, dict):
-            continue
-        oid = str(office.get("id", "")).strip()
-        if not oid:
-            continue
-        folder_entry = _match_office_folder(folder_index, oid)
-        floor_entries = drive.list_folder(folder_entry.id)
-        floor_index = {e.name: e for e in floor_entries if not e.is_folder}
+            return False
         floors_raw = office.get("floors") or []
-        rewritten: list[object] = []
+        if not isinstance(floors_raw, list):
+            return False
         for floor in floors_raw:
             if not isinstance(floor, dict):
-                rewritten.append(floor)
-                continue
-            fid = str(floor.get("id", "")).strip()
-            svg_field = str(floor.get("svg", f"{fid}.svg")).strip()
-            # Drive YAML uses bare filenames; tolerate "floors/<name>" too.
-            svg_name = svg_field.split("/")[-1]
-            if not svg_name:
-                raise OfficeError(
-                    code=EXIT_USER_ERROR,
-                    message=f"floor {fid!r}: empty `svg` field in offices.yaml",
-                    remediation="set `svg:` to the SVG filename in the office folder",
-                )
-            entry = floor_index.get(svg_name)
-            if entry is None:
-                present = sorted(floor_index.keys())
-                raise OfficeError(
-                    code=EXIT_USER_ERROR,
-                    message=(
-                        f"floor {fid!r}: SVG {svg_name!r} not found in "
-                        f"office folder {folder_entry.name!r}"
-                    ),
-                    remediation=(
-                        "upload the SVG to that folder, or fix the `svg:` "
-                        "field in offices.yaml. Files present: "
-                        f"{', '.join(present) if present else '(none)'}"
-                    ),
-                )
-            rel = f"floors/{svg_name}"
-            local = cache_dir / rel
-            if not (meta.is_fresh(rel, ttl_seconds) and local.is_file()):
-                local.write_bytes(drive.download_file(entry.id))
-                meta.record(rel)
-            new_floor = dict(floor)
-            new_floor["svg"] = rel
-            rewritten.append(new_floor)
-        office["floors"] = rewritten
+                return False
+            svg_rel = str(floor.get("svg", "")).strip()
+            if not svg_rel:
+                return False
+            local = cache_dir / svg_rel
+            if not (local.is_file() and meta.is_fresh(svg_rel, ttl)):
+                return False
+    return True
+
+
+# -- Drive hydration ----------------------------------------------------------
+
+
+def _hydrate_from_drive(
+    drive: DriveClient,
+    root_folder_id: str,
+    cache_dir: Path,
+    meta: CacheMeta,
+    ttl: int,
+) -> None:
+    yaml_cache = cache_dir / _YAML_REL
+    root_entries = drive.list_folder(root_folder_id)
+    yaml_entry = _find_root_yaml(root_entries)
+    if not (meta.is_fresh(_YAML_REL, ttl) and yaml_cache.is_file()):
+        yaml_cache.write_bytes(drive.download_file(yaml_entry.id))
+        meta.record(_YAML_REL)
+
+    yaml_data = _load_yaml(yaml_cache)
+    offices_raw = _validate_offices_list(yaml_data)
+    folders_by_name = _group_by_name(root_entries, lambda e: e.is_folder)
+
+    for idx, office in enumerate(offices_raw):
+        _hydrate_office(office, idx, drive, folders_by_name, cache_dir, meta, ttl)
 
     yaml_data["offices"] = offices_raw
     with yaml_cache.open("w", encoding="utf-8") as fh:
         yaml.safe_dump(yaml_data, fh, sort_keys=False, allow_unicode=True)
 
-    return cache_dir
+
+def _hydrate_office(
+    office: object,
+    idx: int,
+    drive: DriveClient,
+    folders_by_name: dict[str, list[DriveEntry]],
+    cache_dir: Path,
+    meta: CacheMeta,
+    ttl: int,
+) -> None:
+    if not isinstance(office, dict):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"office entry at index {idx} is not a mapping",
+            remediation="see data/offices.yaml.example for the expected shape",
+        )
+    oid = str(office.get("id", "")).strip()
+    if not oid:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"office entry at index {idx} is missing an `id`",
+            remediation="add `id: <short-name>` to the office entry",
+        )
+    folder_entry = _match_office_folder(folders_by_name, oid)
+    floor_entries = drive.list_folder(folder_entry.id)
+    files_by_name = _group_by_name(floor_entries, lambda e: not e.is_folder)
+    floors_raw = office.get("floors") or []
+    rewritten: list[object] = []
+    for fidx, floor in enumerate(floors_raw):
+        rewritten.append(
+            _hydrate_floor(
+                floor, fidx, oid, folder_entry, files_by_name, drive, cache_dir, meta, ttl
+            )
+        )
+    office["floors"] = rewritten
+
+
+def _hydrate_floor(
+    floor: object,
+    idx: int,
+    office_id: str,
+    folder_entry: DriveEntry,
+    files_by_name: dict[str, list[DriveEntry]],
+    drive: DriveClient,
+    cache_dir: Path,
+    meta: CacheMeta,
+    ttl: int,
+) -> dict:
+    if not isinstance(floor, dict):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=(f"office {office_id!r}: floor entry at index {idx} is not a mapping"),
+            remediation="see data/offices.yaml.example for the expected shape",
+        )
+    fid = str(floor.get("id", "")).strip()
+    if not fid:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"office {office_id!r}: floor entry at index {idx} is missing an `id`",
+            remediation="add `id: <floor-id>` to the floor entry",
+        )
+    svg_field = str(floor.get("svg", f"{fid}.svg")).strip()
+    svg_name = svg_field.split("/")[-1]
+    if not svg_name:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"floor {fid!r}: empty `svg` field in offices.yaml",
+            remediation="set `svg:` to the SVG filename in the office folder",
+        )
+    entry = _resolve_unique_file(files_by_name, svg_name, fid, folder_entry.name)
+    rel = f"floors/{svg_name}"
+    local = cache_dir / rel
+    if not (meta.is_fresh(rel, ttl) and local.is_file()):
+        local.write_bytes(drive.download_file(entry.id))
+        meta.record(rel)
+    new_floor = dict(floor)
+    new_floor["svg"] = rel
+    return new_floor
+
+
+# -- Drive entry indexing -----------------------------------------------------
+
+
+def _group_by_name(
+    entries: list[DriveEntry], predicate: Callable[[DriveEntry], bool]
+) -> dict[str, list[DriveEntry]]:
+    """Group entries by name into lists, after filtering by ``predicate``.
+
+    Drive permits same-name siblings; indexing by a plain ``dict`` would
+    silently drop duplicates. Lookups (``_resolve_unique_file``,
+    ``_match_office_folder``) raise ``OfficeError`` on collisions instead.
+    """
+    out: dict[str, list[DriveEntry]] = {}
+    for e in entries:
+        if predicate(e):
+            out.setdefault(e.name, []).append(e)
+    return out
+
+
+def _resolve_unique_file(
+    files_by_name: dict[str, list[DriveEntry]],
+    name: str,
+    floor_id: str,
+    folder_name: str,
+) -> DriveEntry:
+    matches = files_by_name.get(name) or []
+    if not matches:
+        present = sorted(files_by_name.keys())
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"floor {floor_id!r}: SVG {name!r} not found in office folder " f"{folder_name!r}"
+            ),
+            remediation=(
+                "upload the SVG to that folder, or fix the `svg:` field in "
+                "offices.yaml. Files present: "
+                f"{', '.join(present) if present else '(none)'}"
+            ),
+        )
+    if len(matches) > 1:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"floor {floor_id!r}: multiple files named {name!r} in office "
+                f"folder {folder_name!r}"
+            ),
+            remediation="rename or remove duplicates so only one file matches",
+        )
+    return matches[0]
 
 
 def _find_root_yaml(entries: list[DriveEntry]) -> DriveEntry:
@@ -167,14 +307,16 @@ def _find_root_yaml(entries: list[DriveEntry]) -> DriveEntry:
     return matches[0]
 
 
-def _match_office_folder(folder_index: dict[str, DriveEntry], office_id: str) -> DriveEntry:
+def _match_office_folder(
+    folders_by_name: dict[str, list[DriveEntry]], office_id: str
+) -> DriveEntry:
     matches: list[DriveEntry] = []
-    for name, entry in folder_index.items():
+    for name, entries in folders_by_name.items():
         m = _OFFICE_ID_RE.search(name)
         if m and m.group(1) == office_id:
-            matches.append(entry)
+            matches.extend(entries)
     if not matches:
-        present = sorted(folder_index.keys())
+        present = sorted(folders_by_name.keys())
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=(
@@ -197,6 +339,9 @@ def _match_office_folder(folder_index: dict[str, DriveEntry], office_id: str) ->
     return matches[0]
 
 
+# -- YAML helpers -------------------------------------------------------------
+
+
 def _load_yaml(path: Path) -> dict:
     with path.open("r", encoding="utf-8") as fh:
         try:
@@ -214,3 +359,14 @@ def _load_yaml(path: Path) -> dict:
             remediation="see data/offices.yaml.example for the expected shape",
         )
     return raw
+
+
+def _validate_offices_list(yaml_data: dict) -> list:
+    offices_raw = yaml_data.get("offices")
+    if not isinstance(offices_raw, list):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="offices.yaml in Drive must contain a top-level `offices:` list",
+            remediation="see data/offices.yaml.example for the expected shape",
+        )
+    return offices_raw

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.9.9"
+version = "0.10.0"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"
@@ -31,6 +31,10 @@ sso = [
     "httpx>=0.27",
 ]
 dynamo = ["boto3>=1.34"]
+drive = [
+    "google-api-python-client>=2.100",
+    "google-auth>=2.30",
+]
 
 [project.urls]
 Homepage = "https://github.com/agentculture/office-agent"
@@ -68,6 +72,11 @@ dev = [
     # in-memory FakeDynamoClient; we still pull boto3 so the
     # production import path is sanity-checked at install time.
     "boto3>=1.34",
+    # Drive-as-CMS (issue #44). CI exercises the hydrator against a
+    # FakeDriveClient; google-api-python-client is pulled into dev so
+    # the GoogleDriveClient import path is sanity-checked at install.
+    "google-api-python-client>=2.100",
+    "google-auth>=2.30",
 ]
 
 [tool.coverage.run]

--- a/tests/test_drive_client.py
+++ b/tests/test_drive_client.py
@@ -1,0 +1,34 @@
+"""Tests for the Drive client construction error paths.
+
+The actual Google API surface is exercised through ``FakeDriveClient``
+in :mod:`tests.test_drive_hydrate`. Here we only assert that the
+production :class:`GoogleDriveClient` raises the right error when its
+prerequisites aren't met — missing credential file is the only path
+we can exercise without standing up a real Drive.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli._errors import EXIT_ENV_ERROR, OfficeError
+from office_cli.drive import GoogleDriveClient
+
+
+def test_missing_service_account_file_raises(tmp_path: Path) -> None:
+    bogus = tmp_path / "no-such-sa.json"
+    with pytest.raises(OfficeError) as exc:
+        GoogleDriveClient(bogus)
+    assert exc.value.code == EXIT_ENV_ERROR
+    assert "service-account" in exc.value.message
+    assert "OFFICE_DRIVE_CREDENTIALS" in exc.value.remediation
+
+
+def test_drive_entry_immutable() -> None:
+    from office_cli.drive import DriveEntry
+
+    entry = DriveEntry(id="x", name="y", is_folder=False)
+    with pytest.raises(Exception):
+        entry.name = "changed"  # type: ignore[misc]

--- a/tests/test_drive_config.py
+++ b/tests/test_drive_config.py
@@ -1,0 +1,87 @@
+"""Tests for ``OFFICE_DRIVE_*`` env-var resolution in ``_config.py``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from office_cli._config import (
+    _drive_cache_root,
+    _drive_credentials_path,
+    _drive_ttl_seconds,
+    resolve_data_dir,
+)
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+
+
+def test_credentials_default_to_sheets_sa(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OFFICE_DRIVE_CREDENTIALS", raising=False)
+    path = _drive_credentials_path()
+    assert path.name == "sheets-service-account.json"
+
+
+def test_credentials_env_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    custom = tmp_path / "custom-sa.json"
+    monkeypatch.setenv("OFFICE_DRIVE_CREDENTIALS", str(custom))
+    assert _drive_credentials_path() == custom
+
+
+def test_ttl_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OFFICE_DRIVE_TTL_SECONDS", raising=False)
+    assert _drive_ttl_seconds() == 300
+
+
+def test_ttl_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_DRIVE_TTL_SECONDS", "120")
+    assert _drive_ttl_seconds() == 120
+
+
+def test_ttl_zero_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_DRIVE_TTL_SECONDS", "0")
+    assert _drive_ttl_seconds() == 0
+
+
+def test_ttl_negative_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_DRIVE_TTL_SECONDS", "-1")
+    with pytest.raises(OfficeError) as exc:
+        _drive_ttl_seconds()
+    assert exc.value.code == EXIT_USER_ERROR
+
+
+def test_ttl_non_integer_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OFFICE_DRIVE_TTL_SECONDS", "soon")
+    with pytest.raises(OfficeError) as exc:
+        _drive_ttl_seconds()
+    assert exc.value.code == EXIT_USER_ERROR
+
+
+def test_cache_root_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OFFICE_DRIVE_CACHE_DIR", raising=False)
+    root = _drive_cache_root()
+    assert root.name == "drive"
+    assert root.parent.name == "office-cli"
+
+
+def test_cache_root_env_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OFFICE_DRIVE_CACHE_DIR", str(tmp_path))
+    assert _drive_cache_root() == tmp_path
+
+
+def test_explicit_data_dir_beats_drive_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``--data-dir`` wins over ``OFFICE_DRIVE_ROOT`` so dev loops and
+    tests stay on local data when an explicit path is given."""
+    monkeypatch.setenv("OFFICE_DRIVE_ROOT", "would-fail-if-hit")
+    import argparse
+
+    args = argparse.Namespace(data_dir=str(tmp_path))
+    assert resolve_data_dir(args) == tmp_path
+
+
+def test_office_data_dir_beats_drive_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OFFICE_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("OFFICE_DRIVE_ROOT", "would-fail-if-hit")
+    assert resolve_data_dir() == tmp_path

--- a/tests/test_drive_hydrate.py
+++ b/tests/test_drive_hydrate.py
@@ -1,0 +1,277 @@
+"""Tests for the Drive-as-CMS hydrator.
+
+A :class:`FakeDriveClient` plays the role of the real Drive API: an
+in-memory map of folder ids → ``DriveEntry`` lists, plus a separate map
+of file ids → bytes. Tests assert that ``hydrate_data_dir`` produces a
+local cache that mirrors the on-disk data-dir layout, and that warm
+cache hits skip downloads.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from office_cli.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, OfficeError
+from office_cli.drive import DriveEntry, hydrate_data_dir
+from office_cli.offices import load_offices
+
+_ROOT_ID = "root-folder-id"
+
+_DRIVE_YAML = """\
+offices:
+  - id: tlv
+    name: Tel Aviv
+    floors:
+      - id: tlv-floor-5
+        svg: tlv-floor-5.svg
+        clusters:
+          T: {capacity: 6, type: open-space}
+          Z: {capacity: 2, type: phone-room}
+        rooms:
+          "5.18": {name: Meeting Room 8P, type: meeting, capacity: 8}
+"""
+
+_SVG_BYTES = b"""<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">
+  <rect id="5-T-01" class="seat" x="0" y="0" width="40" height="60"/>
+</svg>
+"""
+
+
+class FakeDriveClient:
+    """In-memory :class:`DriveClient` for tests.
+
+    ``folders`` maps folder id → list of immediate children; ``files``
+    maps file id → bytes. Tracks call counts so cache-TTL tests can
+    assert "no further downloads happened."
+    """
+
+    def __init__(
+        self,
+        folders: dict[str, list[DriveEntry]],
+        files: dict[str, bytes],
+    ) -> None:
+        self.folders = folders
+        self.files = files
+        self.list_calls = 0
+        self.download_calls = 0
+
+    def list_folder(self, folder_id: str) -> list[DriveEntry]:
+        self.list_calls += 1
+        return list(self.folders.get(folder_id, []))
+
+    def download_file(self, file_id: str) -> bytes:
+        self.download_calls += 1
+        if file_id not in self.files:
+            raise KeyError(f"no fake bytes for file id {file_id!r}")
+        return self.files[file_id]
+
+
+def _build_fake(
+    *,
+    yaml_bytes: bytes = _DRIVE_YAML.encode("utf-8"),
+    include_yaml: bool = True,
+    include_office_folder: bool = True,
+    include_svg: bool = True,
+    office_folder_name: str = "Tel Aviv (tlv)",
+) -> FakeDriveClient:
+    root_children: list[DriveEntry] = []
+    files: dict[str, bytes] = {}
+    if include_yaml:
+        root_children.append(DriveEntry(id="yaml-id", name="offices.yaml", is_folder=False))
+        files["yaml-id"] = yaml_bytes
+    if include_office_folder:
+        root_children.append(DriveEntry(id="tlv-folder", name=office_folder_name, is_folder=True))
+    folders: dict[str, list[DriveEntry]] = {_ROOT_ID: root_children}
+    office_children: list[DriveEntry] = []
+    if include_svg:
+        office_children.append(DriveEntry(id="svg-id", name="tlv-floor-5.svg", is_folder=False))
+        files["svg-id"] = _SVG_BYTES
+    folders["tlv-folder"] = office_children
+    return FakeDriveClient(folders, files)
+
+
+def test_happy_path_hydrates_data_dir(tmp_path: Path) -> None:
+    fake = _build_fake()
+    cache_root = tmp_path / "cache"
+
+    data_dir = hydrate_data_dir(
+        _ROOT_ID,
+        credentials_path=tmp_path / "unused.json",
+        cache_root=cache_root,
+        client=fake,
+    )
+
+    assert data_dir == cache_root / _ROOT_ID
+    assert (data_dir / "data" / "offices.yaml").is_file()
+    assert (data_dir / "floors" / "tlv-floor-5.svg").read_bytes() == _SVG_BYTES
+    assert (data_dir / "seats").is_dir()
+
+    # The cached YAML rewrites svg to the floors/<filename> form so the
+    # existing _yaml.py resolver picks it up unchanged.
+    cached = yaml.safe_load((data_dir / "data" / "offices.yaml").read_text())
+    assert cached["offices"][0]["floors"][0]["svg"] == "floors/tlv-floor-5.svg"
+
+    # And it threads cleanly into load_offices().
+    offices = load_offices(data_dir)
+    floor = offices["tlv"].floors["tlv-floor-5"]
+    assert floor.svg == data_dir / "floors" / "tlv-floor-5.svg"
+
+
+def test_warm_cache_skips_downloads(tmp_path: Path) -> None:
+    fake = _build_fake()
+    cache_root = tmp_path / "cache"
+    kwargs = dict(
+        credentials_path=tmp_path / "unused.json",
+        cache_root=cache_root,
+        client=fake,
+        ttl_seconds=300,
+    )
+
+    hydrate_data_dir(_ROOT_ID, **kwargs)
+    cold_downloads = fake.download_calls
+    assert cold_downloads == 2  # offices.yaml + one SVG
+
+    # Within TTL, a re-hydrate should not re-download anything.
+    hydrate_data_dir(_ROOT_ID, **kwargs)
+    assert fake.download_calls == cold_downloads
+
+
+def test_zero_ttl_forces_refetch(tmp_path: Path) -> None:
+    fake = _build_fake()
+    cache_root = tmp_path / "cache"
+    kwargs = dict(
+        credentials_path=tmp_path / "unused.json",
+        cache_root=cache_root,
+        client=fake,
+        ttl_seconds=0,
+    )
+
+    hydrate_data_dir(_ROOT_ID, **kwargs)
+    hydrate_data_dir(_ROOT_ID, **kwargs)
+    assert fake.download_calls == 4  # two fetches each run
+
+
+def test_missing_offices_yaml_raises(tmp_path: Path) -> None:
+    fake = _build_fake(include_yaml=False)
+    with pytest.raises(OfficeError) as exc:
+        hydrate_data_dir(
+            _ROOT_ID,
+            credentials_path=tmp_path / "unused.json",
+            cache_root=tmp_path / "cache",
+            client=fake,
+        )
+    assert exc.value.code == EXIT_ENV_ERROR
+    assert "offices.yaml" in exc.value.message
+
+
+def test_missing_office_folder_raises(tmp_path: Path) -> None:
+    fake = _build_fake(include_office_folder=False)
+    with pytest.raises(OfficeError) as exc:
+        hydrate_data_dir(
+            _ROOT_ID,
+            credentials_path=tmp_path / "unused.json",
+            cache_root=tmp_path / "cache",
+            client=fake,
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "tlv" in exc.value.message
+
+
+def test_office_folder_with_different_name_format(tmp_path: Path) -> None:
+    fake = _build_fake(office_folder_name="TLV Office (tlv)")
+    data_dir = hydrate_data_dir(
+        _ROOT_ID,
+        credentials_path=tmp_path / "unused.json",
+        cache_root=tmp_path / "cache",
+        client=fake,
+    )
+    assert (data_dir / "floors" / "tlv-floor-5.svg").is_file()
+
+
+def test_missing_svg_raises_with_present_listing(tmp_path: Path) -> None:
+    fake = _build_fake(include_svg=False)
+    fake.folders["tlv-folder"].append(
+        DriveEntry(id="other", name="something-else.svg", is_folder=False)
+    )
+    fake.files["other"] = b"<svg/>"
+    with pytest.raises(OfficeError) as exc:
+        hydrate_data_dir(
+            _ROOT_ID,
+            credentials_path=tmp_path / "unused.json",
+            cache_root=tmp_path / "cache",
+            client=fake,
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "tlv-floor-5.svg" in exc.value.message
+    assert "something-else.svg" in exc.value.remediation
+
+
+def test_duplicate_office_folder_raises(tmp_path: Path) -> None:
+    fake = _build_fake()
+    fake.folders[_ROOT_ID].append(
+        DriveEntry(id="dup", name="Tel Aviv duplicate (tlv)", is_folder=True)
+    )
+    fake.folders["dup"] = []
+    with pytest.raises(OfficeError) as exc:
+        hydrate_data_dir(
+            _ROOT_ID,
+            credentials_path=tmp_path / "unused.json",
+            cache_root=tmp_path / "cache",
+            client=fake,
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "multiple" in exc.value.message.lower()
+
+
+def test_invalid_yaml_in_drive_raises(tmp_path: Path) -> None:
+    fake = _build_fake(yaml_bytes=b"this is: not: valid: yaml: : :\n  - [")
+    with pytest.raises(OfficeError) as exc:
+        hydrate_data_dir(
+            _ROOT_ID,
+            credentials_path=tmp_path / "unused.json",
+            cache_root=tmp_path / "cache",
+            client=fake,
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+
+
+def test_yaml_without_offices_list_raises(tmp_path: Path) -> None:
+    fake = _build_fake(yaml_bytes=b"offices: not-a-list\n")
+    with pytest.raises(OfficeError) as exc:
+        hydrate_data_dir(
+            _ROOT_ID,
+            credentials_path=tmp_path / "unused.json",
+            cache_root=tmp_path / "cache",
+            client=fake,
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+
+
+def test_meta_file_records_relative_paths(tmp_path: Path) -> None:
+    fake = _build_fake()
+    cache_root = tmp_path / "cache"
+    hydrate_data_dir(
+        _ROOT_ID,
+        credentials_path=tmp_path / "unused.json",
+        cache_root=cache_root,
+        client=fake,
+    )
+    meta = json.loads((cache_root / _ROOT_ID / ".meta" / "fetched-at.json").read_text())
+    assert set(meta.keys()) == {"data/offices.yaml", "floors/tlv-floor-5.svg"}
+
+
+def test_empty_root_id_raises(tmp_path: Path) -> None:
+    fake = _build_fake()
+    with pytest.raises(OfficeError) as exc:
+        hydrate_data_dir(
+            "",
+            credentials_path=tmp_path / "unused.json",
+            cache_root=tmp_path / "cache",
+            client=fake,
+        )
+    assert exc.value.code == EXIT_ENV_ERROR

--- a/tests/test_drive_hydrate.py
+++ b/tests/test_drive_hydrate.py
@@ -122,38 +122,67 @@ def test_happy_path_hydrates_data_dir(tmp_path: Path) -> None:
     assert floor.svg == data_dir / "floors" / "tlv-floor-5.svg"
 
 
-def test_warm_cache_skips_downloads(tmp_path: Path) -> None:
+def test_warm_cache_skips_all_drive_calls(tmp_path: Path) -> None:
+    """Within TTL the hydrator must hit Drive zero times — no downloads
+    *and* no folder listings (acceptance criterion for issue #44)."""
     fake = _build_fake()
     cache_root = tmp_path / "cache"
-    kwargs = dict(
-        credentials_path=tmp_path / "unused.json",
-        cache_root=cache_root,
-        client=fake,
-        ttl_seconds=300,
-    )
+    kwargs = {
+        "credentials_path": tmp_path / "unused.json",
+        "cache_root": cache_root,
+        "client": fake,
+        "ttl_seconds": 300,
+    }
 
     hydrate_data_dir(_ROOT_ID, **kwargs)
     cold_downloads = fake.download_calls
+    cold_lists = fake.list_calls
     assert cold_downloads == 2  # offices.yaml + one SVG
+    assert cold_lists == 2  # root + one office folder
 
-    # Within TTL, a re-hydrate should not re-download anything.
     hydrate_data_dir(_ROOT_ID, **kwargs)
     assert fake.download_calls == cold_downloads
+    assert fake.list_calls == cold_lists  # warm path skipped Drive entirely
 
 
 def test_zero_ttl_forces_refetch(tmp_path: Path) -> None:
     fake = _build_fake()
     cache_root = tmp_path / "cache"
-    kwargs = dict(
-        credentials_path=tmp_path / "unused.json",
-        cache_root=cache_root,
-        client=fake,
-        ttl_seconds=0,
-    )
+    kwargs = {
+        "credentials_path": tmp_path / "unused.json",
+        "cache_root": cache_root,
+        "client": fake,
+        "ttl_seconds": 0,
+    }
 
     hydrate_data_dir(_ROOT_ID, **kwargs)
     hydrate_data_dir(_ROOT_ID, **kwargs)
     assert fake.download_calls == 4  # two fetches each run
+
+
+def test_warm_path_falls_through_when_svg_missing_from_cache(
+    tmp_path: Path,
+) -> None:
+    """If the meta says fresh but the local SVG was deleted, the warm
+    path should fall through and re-fetch via Drive instead of returning
+    a broken cache."""
+    fake = _build_fake()
+    cache_root = tmp_path / "cache"
+    kwargs = {
+        "credentials_path": tmp_path / "unused.json",
+        "cache_root": cache_root,
+        "client": fake,
+        "ttl_seconds": 300,
+    }
+
+    hydrate_data_dir(_ROOT_ID, **kwargs)
+    # Simulate someone clearing the cached SVG by hand.
+    (cache_root / _ROOT_ID / "floors" / "tlv-floor-5.svg").unlink()
+
+    hydrate_data_dir(_ROOT_ID, **kwargs)
+    assert (cache_root / _ROOT_ID / "floors" / "tlv-floor-5.svg").is_file()
+    # The warm path bailed, so a fresh download happened.
+    assert fake.download_calls == 3  # initial 2 + the refetched SVG
 
 
 def test_missing_offices_yaml_raises(tmp_path: Path) -> None:
@@ -275,3 +304,75 @@ def test_empty_root_id_raises(tmp_path: Path) -> None:
             client=fake,
         )
     assert exc.value.code == EXIT_ENV_ERROR
+
+
+def test_duplicate_svg_filename_raises(tmp_path: Path) -> None:
+    """Drive permits same-name siblings; the hydrator must not pick one
+    arbitrarily."""
+    fake = _build_fake()
+    fake.folders["tlv-folder"].append(
+        DriveEntry(id="svg-id-2", name="tlv-floor-5.svg", is_folder=False)
+    )
+    fake.files["svg-id-2"] = b"<svg/>"
+    with pytest.raises(OfficeError) as exc:
+        hydrate_data_dir(
+            _ROOT_ID,
+            credentials_path=tmp_path / "unused.json",
+            cache_root=tmp_path / "cache",
+            client=fake,
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "multiple files" in exc.value.message.lower()
+    assert "tlv-floor-5.svg" in exc.value.message
+
+
+def test_non_mapping_office_entry_raises(tmp_path: Path) -> None:
+    """Non-dict office entries must raise immediately — the hydrator must
+    not write a half-baked YAML to the cache that fails later in
+    load_offices()."""
+    bad_yaml = b"offices:\n  - just a string\n"
+    fake = _build_fake(yaml_bytes=bad_yaml)
+    with pytest.raises(OfficeError) as exc:
+        hydrate_data_dir(
+            _ROOT_ID,
+            credentials_path=tmp_path / "unused.json",
+            cache_root=tmp_path / "cache",
+            client=fake,
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "not a mapping" in exc.value.message
+
+
+def test_non_mapping_floor_entry_raises(tmp_path: Path) -> None:
+    bad_yaml = b"""\
+offices:
+  - id: tlv
+    name: Tel Aviv
+    floors:
+      - just a string
+"""
+    fake = _build_fake(yaml_bytes=bad_yaml)
+    with pytest.raises(OfficeError) as exc:
+        hydrate_data_dir(
+            _ROOT_ID,
+            credentials_path=tmp_path / "unused.json",
+            cache_root=tmp_path / "cache",
+            client=fake,
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "not a mapping" in exc.value.message
+    assert "tlv" in exc.value.message
+
+
+def test_office_missing_id_raises(tmp_path: Path) -> None:
+    bad_yaml = b"offices:\n  - name: nameless\n"
+    fake = _build_fake(yaml_bytes=bad_yaml)
+    with pytest.raises(OfficeError) as exc:
+        hydrate_data_dir(
+            _ROOT_ID,
+            credentials_path=tmp_path / "unused.json",
+            cache_root=tmp_path / "cache",
+            client=fake,
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "missing an `id`" in exc.value.message

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "annotated-doc"
@@ -458,6 +462,38 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.196.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/f3/34ef8aca7909675fe327f96c1ed927f0520e7acf68af19157e96acc05e76/google_api_python_client-2.196.0.tar.gz", hash = "sha256:9f335d38f6caaa2747bcf64335ed1a9a19047d53e86538eda6a1b17d37f1743d", size = 14628129, upload-time = "2026-05-06T23:47:35.655Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/c7/1817b4edf966d5afcac1c0781ca36d621bc0cb58104c4e7c2a475ab185f7/google_api_python_client-2.196.0-py3-none-any.whl", hash = "sha256:2591e9b47dcb17e4e62a09370aaee3bcf323af8f28ccecdabcd0a42a23ca4db5", size = 15206663, upload-time = "2026-05-06T23:47:32.886Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.50.0"
 source = { registry = "https://pypi.org/simple" }
@@ -471,6 +507,19 @@ wheels = [
 ]
 
 [[package]]
+name = "google-auth-httplib2"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b3/f192c8bc7e41e0ebdbd95afcae4783417a34b6a6af62d22daf22c3fd38fc/google_auth_httplib2-0.4.0.tar.gz", hash = "sha256:d5b030a204b7a4b4d553ba9ca701b62481ee2b74419325580be70f7d85ffed35", size = 11161, upload-time = "2026-05-07T08:03:46.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/be/954c35a62b9e31de66b0a43c225c9b6bb9e0f98d6b1dc110a2308e3644f5/google_auth_httplib2-0.4.0-py3-none-any.whl", hash = "sha256:8e55cfafa3358cba85f6cad4a886138e88e158d71e7e5c9ee5936a5c1507fb91", size = 9529, upload-time = "2026-05-07T08:02:12.375Z" },
+]
+
+[[package]]
 name = "google-auth-oauthlib"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -481,6 +530,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a6/82/62482931dcbe5266a2680d0da17096f2aab983ecb320277d9556700ce00e/google_auth_oauthlib-1.3.1.tar.gz", hash = "sha256:14c22c7b3dd3d06dbe44264144409039465effdd1eef94f7ce3710e486cc4bfa", size = 21663, upload-time = "2026-03-30T22:49:56.408Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/e0/cb454a95f460903e39f101e950038ec24a072ca69d0a294a6df625cc1627/google_auth_oauthlib-1.3.1-py3-none-any.whl", hash = "sha256:1a139ef23f1318756805b0e95f655c238bffd29655329a2978218248da4ee7f8", size = 19247, upload-time = "2026-03-30T20:02:23.894Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
 ]
 
 [[package]]
@@ -516,6 +577,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
 ]
 
 [[package]]
@@ -640,7 +713,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.9.9"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
@@ -649,6 +722,10 @@ dependencies = [
 [package.optional-dependencies]
 bamboohr = [
     { name = "requests" },
+]
+drive = [
+    { name = "google-api-python-client" },
+    { name = "google-auth" },
 ]
 dynamo = [
     { name = "boto3" },
@@ -678,6 +755,8 @@ dev = [
     { name = "boto3" },
     { name = "fastapi" },
     { name = "flake8" },
+    { name = "google-api-python-client" },
+    { name = "google-auth" },
     { name = "httpx" },
     { name = "isort" },
     { name = "itsdangerous" },
@@ -691,6 +770,8 @@ requires-dist = [
     { name = "authlib", marker = "extra == 'sso'", specifier = ">=1.3" },
     { name = "boto3", marker = "extra == 'dynamo'", specifier = ">=1.34" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.110" },
+    { name = "google-api-python-client", marker = "extra == 'drive'", specifier = ">=2.100" },
+    { name = "google-auth", marker = "extra == 'drive'", specifier = ">=2.30" },
     { name = "gspread", marker = "extra == 'sheets'", specifier = ">=6.0" },
     { name = "httpx", marker = "extra == 'sso'", specifier = ">=0.27" },
     { name = "itsdangerous", marker = "extra == 'sso'", specifier = ">=2.1" },
@@ -700,7 +781,7 @@ requires-dist = [
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27" },
     { name = "uvicorn", marker = "extra == 'web'", specifier = ">=0.30" },
 ]
-provides-extras = ["sheets", "bamboohr", "slack", "web", "sso", "dynamo"]
+provides-extras = ["sheets", "bamboohr", "slack", "web", "sso", "dynamo", "drive"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -710,6 +791,8 @@ dev = [
     { name = "boto3", specifier = ">=1.34" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "flake8", specifier = ">=6.1" },
+    { name = "google-api-python-client", specifier = ">=2.100" },
+    { name = "google-auth", specifier = ">=2.30" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "isort", specifier = ">=5.12.0" },
     { name = "itsdangerous", specifier = ">=2.1" },
@@ -752,6 +835,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
 ]
 
 [[package]]
@@ -899,6 +1009,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -1155,6 +1274,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Closes #44. Adds an opt-in Google Drive backend so `data/offices.yaml` and `floors/*.svg` can be edited live in Drive instead of committed to the repo.
- Drive mode is gated by `OFFICE_DRIVE_ROOT`. When set, `resolve_data_dir()` hydrates the Drive contents into `~/.cache/office-cli/drive/<root-id>/` and hands that path back. Downstream code (`load_offices`, `parse_svg`, the web map, Slack `/whereis`) reads from the cache as if it were a regular checkout, so nothing else changed.
- New optional extra `[drive]` brings `google-api-python-client` + `google-auth`. Sheets SA is reused by default; override with `OFFICE_DRIVE_CREDENTIALS`. TTL defaults to 5 min (`OFFICE_DRIVE_TTL_SECONDS`); cache dir overridable via `OFFICE_DRIVE_CACHE_DIR`.

## Design — synthetic data dir

Drive's authoring layout is human-friendly (one folder per office, name ends with `(<office-id>)`); the on-disk cache layout mirrors today's repo (`data/offices.yaml`, `floors/<filename>`). The hydrator translates between them: it parses Drive's bare-filename `svg:` fields, locates each SVG inside the matching office folder, and writes a rewritten YAML to the cache where each `svg` is `floors/<filename>` — exactly what the existing YAML resolver already handles.

This kept the change confined to one new module (`office_cli/drive/`) plus a small extension to `resolve_data_dir()`. No changes to `load_offices`, `parse_svg`, the `Floor` model, or any call site.

Roles (`roles:` block) are explicitly **not** moved in this PR — that's tracked in #45.

## Test plan

- [x] 25 new unit tests in `tests/test_drive_*.py` (FakeDriveClient, no real API calls):
  - happy-path hydrate produces a working data dir that threads cleanly into `load_offices`
  - warm cache within TTL skips downloads
  - `TTL=0` forces refetch
  - missing `offices.yaml` / missing office folder / missing SVG / duplicate folder / invalid YAML / empty root id all raise `OfficeError` with helpful remediation
  - meta file records relative paths
  - `--data-dir` and `OFFICE_DATA_DIR` both beat `OFFICE_DRIVE_ROOT` (local-mode regression guard)
  - env-var coercion (TTL non-int / negative rejected; credential default / override; cache-dir default / override)
- [x] Full suite passes: `433 passed, 2 warnings in 2.21s` with `OFFICE_DRIVE_ROOT` unset (no regressions to existing surfaces).
- [x] Lint clean: `black --check`, `isort --check-only`, `flake8`, `bandit`, `markdownlint-cli2`.
- [x] `office --version` reports `0.10.0`.
- [ ] Manual end-to-end against a real Drive folder per `docs/floors-from-drive.md` (operator runbook).

Generated with Claude Code