### PR TITLE
feat(skill): process-pdf — extract a PDF page as a sized PNG

### DIFF
--- a/.claude/skills/process-pdf/SKILL.md
+++ b/.claude/skills/process-pdf/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: process-pdf
+description: >
+  Convert one page of a PDF into a PNG sized for floor-map SVG
+  backgrounds. Use when extracting a specific floor / page from a
+  multi-page architectural plan, converting PDF to PNG for an SVG
+  background, or the user says "convert pdf", "extract page",
+  "pdf to png". Requires `poppler` (pdftoppm + pdftotext) on PATH;
+  the skill never installs anything itself.
+---
+
+# process-pdf
+
+Convert a single page of a PDF into a PNG sized for the floor-map
+tracing flow. The agent's `office floors validate` contract requires
+SVGs whose `viewBox` is `0 0 1920 1080`; this skill produces a
+**1920-wide PNG** by default so the output drops straight into
+Inkscape as the `background` layer.
+
+## Why this exists
+
+Inkscape's PDF-as-vector import produces unusable SVGs for tracing
+(architect plans yield ~100k vector elements; Inkscape's Plain SVG
+export then breaks the XML somewhere in the mountain). The supported
+path is to convert the PDF page to a raster PNG, embed that as the
+`background` layer in the SVG, and trace `<rect class="seat">` /
+`<polygon class="room">` over it. This skill is the conversion step.
+
+See `docs/tracing-guide.md` for the full tracing flow.
+
+## Prerequisites
+
+The skill calls out to `poppler`'s `pdftoppm` (extract + scale) and
+`pdftotext` (label-based page lookup). It never installs them.
+
+| Platform        | Install command                |
+| --------------- | ------------------------------ |
+| macOS (Homebrew)| `brew install poppler`         |
+| Debian / Ubuntu | `apt install poppler-utils`    |
+| Fedora          | `dnf install poppler-utils`    |
+
+If either binary is missing the skill exits 2 with a hint that
+matches the platform.
+
+## Usage
+
+```bash
+bash .claude/skills/process-pdf/scripts/pdf-to-png.sh \
+    <pdf> <page-or-label> [out-png] [--width N] [--dpi N]
+```
+
+Two ways to pick the page:
+
+- **Page number** — pass a positive integer (1-based).
+- **Text label** — pass any string; the skill scans the PDF with
+  `pdftotext` and uses the page that contains it. Errors with a
+  candidate listing if zero or more than one page matches, so
+  selection is always unambiguous.
+
+Defaults:
+
+- `out-png` → `<basename-of-pdf>-page<N>.png` in the current
+  directory.
+- `--width` → `1920` (matches the floor SVG viewBox).
+- `--dpi` → `150` (good enough for tracing without bloating
+  the file).
+
+## Examples
+
+**Canonical floor-tracing case** — find the "Floor 5" page in a
+multi-floor pack and write a 1920-wide PNG:
+
+```bash
+bash .claude/skills/process-pdf/scripts/pdf-to-png.sh \
+    ~/Downloads/tipalti-floors.pdf "Floor 5" /tmp/floor5.png
+# stdout: /tmp/floor5.png
+```
+
+**Direct page number** when you already know it:
+
+```bash
+bash .claude/skills/process-pdf/scripts/pdf-to-png.sh \
+    ~/Downloads/tipalti-floors.pdf 7 /tmp/floor5.png
+```
+
+**Custom width** (e.g. for a higher-res render outside the
+floor-tracing flow):
+
+```bash
+bash .claude/skills/process-pdf/scripts/pdf-to-png.sh \
+    plans.pdf 3 cover.png --width 3840 --dpi 300
+```
+
+## Output
+
+On success: prints the absolute path of the produced PNG to stdout
+and exits 0. So callers can capture it:
+
+```bash
+out=$(bash .claude/skills/process-pdf/scripts/pdf-to-png.sh \
+    ~/Downloads/tipalti-floors.pdf "Floor 5" /tmp/floor5.png)
+file "$out"   # PNG image data
+```
+
+## Errors and exit codes
+
+- `0` — success.
+- `1` — usage error (bad flags, missing positional args).
+- `2` — environment error (poppler missing, PDF not found, label
+  matches zero or multiple pages, page number out of range).
+
+Stderr always includes a `hint:` line with the next concrete
+action.
+
+## Out of scope
+
+- PDF→SVG vector extraction (the failure mode that prompted this
+  skill).
+- Auto-install of poppler.
+- ImageMagick / sips fallbacks. Poppler is the single supported
+  toolchain.
+- Multi-page batch extract.
+- OCR.

--- a/.claude/skills/process-pdf/scripts/pdf-to-png.sh
+++ b/.claude/skills/process-pdf/scripts/pdf-to-png.sh
@@ -110,10 +110,22 @@ else
     # \x0c). Walk the output, count form feeds, find pages that contain
     # the label (case-insensitive substring). Require exactly one match.
     label_lower="$(printf '%s' "$PAGE_OR_LABEL" | tr '[:upper:]' '[:lower:]')"
+
+    # Capture pdftotext's output and exit code separately so a poppler
+    # failure (encrypted PDF, corrupt structure, etc.) surfaces as a
+    # clean env error rather than getting confused with "0 matches".
+    pdftotext_err="$(mktemp)"
+    trap 'rm -f "$pdftotext_err"' EXIT
+    if ! text="$(pdftotext -layout "$PDF" - 2>"$pdftotext_err")"; then
+        err_msg="$(cat "$pdftotext_err")"
+        hint "the PDF may be encrypted, corrupt, or unreadable by poppler"
+        [[ -n "$err_msg" ]] && hint "pdftotext said: $err_msg"
+        die 2 "pdftotext failed reading $PDF"
+    fi
+
     matches=()
     page_no=1
     page_buf=""
-    # shellcheck disable=SC2002 — explicit cat keeps the loop readable.
     while IFS= read -r line; do
         if [[ "$line" == $'\x0c'* ]]; then
             if [[ "$(printf '%s' "$page_buf" | tr '[:upper:]' '[:lower:]')" == *"$label_lower"* ]]; then
@@ -124,7 +136,7 @@ else
         else
             page_buf+="$line"$'\n'
         fi
-    done < <(pdftotext -layout "$PDF" -)
+    done <<<"$text"
     # Tail page (no trailing form feed):
     if [[ "$(printf '%s' "$page_buf" | tr '[:upper:]' '[:lower:]')" == *"$label_lower"* ]]; then
         matches+=("$page_no")
@@ -148,7 +160,10 @@ fi
 
 # Make output dir absolute / accessible.
 out_dir="$(dirname "$OUT_PNG")"
-[[ -d "$out_dir" ]] || die 2 "output directory does not exist: $out_dir"
+if [[ ! -d "$out_dir" ]]; then
+    hint "create the directory first (mkdir -p '$out_dir') or pass an existing path"
+    die 2 "output directory does not exist: $out_dir"
+fi
 
 # --- extract + scale -------------------------------------------------------
 
@@ -156,22 +171,35 @@ out_dir="$(dirname "$OUT_PNG")"
 # width (so page 7 of a 21-page doc → "<prefix>-07.png"). Use a tmp
 # prefix and rename with a glob so we don't have to predict the padding.
 tmpdir="$(mktemp -d)"
-trap 'rm -rf "$tmpdir"' EXIT
+# Extend the EXIT trap to also clean up the tmpdir without dropping the
+# pdftotext_err cleanup set above (if label-search ran).
+trap 'rm -rf "$tmpdir"; rm -f "${pdftotext_err:-}"' EXIT
 prefix="$tmpdir/page"
 
-pdftoppm \
-    -png \
-    -f "$PAGE" -l "$PAGE" \
-    -r "$DPI" \
-    -scale-to-x "$WIDTH" \
-    -scale-to-y -1 \
-    "$PDF" "$prefix"
+# Capture pdftoppm's exit code and stderr separately so an out-of-range
+# page or encrypted PDF surfaces as an env error with a clear hint
+# rather than just the bare poppler diagnostic.
+pdftoppm_err="$(mktemp)"
+trap 'rm -rf "$tmpdir"; rm -f "${pdftotext_err:-}" "${pdftoppm_err:-}"' EXIT
+if ! pdftoppm \
+        -png \
+        -f "$PAGE" -l "$PAGE" \
+        -r "$DPI" \
+        -scale-to-x "$WIDTH" \
+        -scale-to-y -1 \
+        "$PDF" "$prefix" 2>"$pdftoppm_err"; then
+    err_msg="$(cat "$pdftoppm_err")"
+    hint "page $PAGE may be out of range, or the PDF may be encrypted/corrupt"
+    [[ -n "$err_msg" ]] && hint "pdftoppm said: $err_msg"
+    die 2 "pdftoppm failed for page $PAGE of $PDF"
+fi
 
 # Glob for the produced file. There must be exactly one.
 shopt -s nullglob
 produced=( "$prefix"-*.png )
 shopt -u nullglob
 if [[ ${#produced[@]} -ne 1 ]]; then
+    hint "this is unexpected — please report it with the PDF page count and the page number you passed"
     die 2 "pdftoppm wrote ${#produced[@]} files, expected 1 (page $PAGE)"
 fi
 

--- a/.claude/skills/process-pdf/scripts/pdf-to-png.sh
+++ b/.claude/skills/process-pdf/scripts/pdf-to-png.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# pdf-to-png — extract one page of a PDF as a 1920-wide PNG, sized
+# for the floor-map tracing background. See ../SKILL.md.
+#
+# Usage:
+#   pdf-to-png.sh <pdf> <page-or-label> [out-png] [--width N] [--dpi N]
+#
+# Exits:
+#   0 success; out-png path printed to stdout
+#   1 usage error
+#   2 environment error (missing tool, missing pdf, ambiguous label, etc.)
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+pdf-to-png — extract one page of a PDF as a PNG for floor-map tracing.
+
+Usage:
+  pdf-to-png.sh <pdf> <page-or-label> [out-png] [--width N] [--dpi N]
+
+Arguments:
+  <pdf>           Source PDF.
+  <page-or-label> 1-based page number, OR a text label to search for.
+                  Label mode requires the label to match exactly one page.
+  [out-png]       Output path. Default: <pdf-basename>-page<N>.png in cwd.
+
+Options:
+  --width N       Output width in px (default 1920).
+  --dpi N         Render DPI before scaling (default 150).
+  --help          Show this message.
+
+Requires poppler (pdftoppm + pdftotext) on PATH.
+EOF
+}
+
+die() {
+    local code=$1
+    shift
+    {
+        echo "error: $*"
+    } >&2
+    exit "$code"
+}
+
+hint() {
+    echo "hint: $*" >&2
+}
+
+# --- argparse ---------------------------------------------------------------
+
+PDF=""
+PAGE_OR_LABEL=""
+OUT_PNG=""
+WIDTH=1920
+DPI=150
+
+positional=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h) usage; exit 0 ;;
+        --width)   WIDTH="${2:?--width needs a value}"; shift 2 ;;
+        --dpi)     DPI="${2:?--dpi needs a value}"; shift 2 ;;
+        --) shift; positional+=("$@"); break ;;
+        --*) die 1 "unknown option: $1" ;;
+        *) positional+=("$1"); shift ;;
+    esac
+done
+
+if [[ ${#positional[@]} -lt 2 ]]; then
+    usage >&2
+    die 1 "missing required arguments"
+fi
+
+PDF="${positional[0]}"
+PAGE_OR_LABEL="${positional[1]}"
+OUT_PNG="${positional[2]:-}"
+
+# --- prereq checks ----------------------------------------------------------
+
+install_hint() {
+    case "$(uname)" in
+        Darwin) hint "install poppler: brew install poppler" ;;
+        Linux)  hint "install poppler: apt install poppler-utils (Debian/Ubuntu) or dnf install poppler-utils (Fedora)" ;;
+        *)      hint "install poppler from your platform's package manager" ;;
+    esac
+}
+
+if ! command -v pdftoppm >/dev/null 2>&1; then
+    install_hint
+    die 2 "pdftoppm not found on PATH"
+fi
+if ! command -v pdftotext >/dev/null 2>&1; then
+    install_hint
+    die 2 "pdftotext not found on PATH"
+fi
+
+if [[ ! -f "$PDF" ]]; then
+    hint "check the path; '~' is expanded by the shell so quote carefully"
+    die 2 "PDF not found: $PDF"
+fi
+
+# --- resolve page number ---------------------------------------------------
+
+PAGE=""
+if [[ "$PAGE_OR_LABEL" =~ ^[0-9]+$ ]]; then
+    PAGE="$PAGE_OR_LABEL"
+else
+    # Label search. pdftotext emits each page separated by ^L (form feed,
+    # \x0c). Walk the output, count form feeds, find pages that contain
+    # the label (case-insensitive substring). Require exactly one match.
+    label_lower="$(printf '%s' "$PAGE_OR_LABEL" | tr '[:upper:]' '[:lower:]')"
+    matches=()
+    page_no=1
+    page_buf=""
+    # shellcheck disable=SC2002 — explicit cat keeps the loop readable.
+    while IFS= read -r line; do
+        if [[ "$line" == $'\x0c'* ]]; then
+            if [[ "$(printf '%s' "$page_buf" | tr '[:upper:]' '[:lower:]')" == *"$label_lower"* ]]; then
+                matches+=("$page_no")
+            fi
+            page_no=$((page_no + 1))
+            page_buf="${line#$'\x0c'}"
+        else
+            page_buf+="$line"$'\n'
+        fi
+    done < <(pdftotext -layout "$PDF" -)
+    # Tail page (no trailing form feed):
+    if [[ "$(printf '%s' "$page_buf" | tr '[:upper:]' '[:lower:]')" == *"$label_lower"* ]]; then
+        matches+=("$page_no")
+    fi
+    case "${#matches[@]}" in
+        0) hint "no page contains '$PAGE_OR_LABEL' — try a different label or use a 1-based page number"
+           die 2 "label '$PAGE_OR_LABEL' matched 0 pages" ;;
+        1) PAGE="${matches[0]}" ;;
+        *) hint "label '$PAGE_OR_LABEL' matched pages: ${matches[*]} — narrow the label or use a page number"
+           die 2 "label matched ${#matches[@]} pages, expected exactly 1" ;;
+    esac
+fi
+
+# --- resolve output path ----------------------------------------------------
+
+if [[ -z "$OUT_PNG" ]]; then
+    base="$(basename "$PDF")"
+    base="${base%.*}"
+    OUT_PNG="${base}-page${PAGE}.png"
+fi
+
+# Make output dir absolute / accessible.
+out_dir="$(dirname "$OUT_PNG")"
+[[ -d "$out_dir" ]] || die 2 "output directory does not exist: $out_dir"
+
+# --- extract + scale -------------------------------------------------------
+
+# pdftoppm writes <prefix>-<NN>.png with N zero-padded to the page-count
+# width (so page 7 of a 21-page doc → "<prefix>-07.png"). Use a tmp
+# prefix and rename with a glob so we don't have to predict the padding.
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+prefix="$tmpdir/page"
+
+pdftoppm \
+    -png \
+    -f "$PAGE" -l "$PAGE" \
+    -r "$DPI" \
+    -scale-to-x "$WIDTH" \
+    -scale-to-y -1 \
+    "$PDF" "$prefix"
+
+# Glob for the produced file. There must be exactly one.
+shopt -s nullglob
+produced=( "$prefix"-*.png )
+shopt -u nullglob
+if [[ ${#produced[@]} -ne 1 ]]; then
+    die 2 "pdftoppm wrote ${#produced[@]} files, expected 1 (page $PAGE)"
+fi
+
+mv "${produced[0]}" "$OUT_PNG"
+
+# Resolve to an absolute path for stdout.
+if [[ "$OUT_PNG" = /* ]]; then
+    abs="$OUT_PNG"
+else
+    abs="$(cd "$(dirname "$OUT_PNG")" && pwd)/$(basename "$OUT_PNG")"
+fi
+printf '%s\n' "$abs"

--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,15 @@ SLACK_APP_TOKEN=xapp-...
 # value must start with '/' and match what's registered in your Slack
 # app's "Slash Commands" page.
 # OFFICE_SLACK_COMMAND=/whereis
+
+# Drive-as-CMS (issue #44). When set, `office` reads `offices.yaml` and
+# floor SVGs from this Drive folder instead of the working directory.
+# See docs/floors-from-drive.md. The value is a folder id, not a URL —
+# from a URL like https://drive.google.com/drive/folders/<id>, copy
+# everything after `/folders/`.
+# OFFICE_DRIVE_ROOT=
+#
+# Optional knobs (defaults shown as comments):
+# OFFICE_DRIVE_CREDENTIALS=data/sheets-service-account.json
+# OFFICE_DRIVE_TTL_SECONDS=300
+# OFFICE_DRIVE_CACHE_DIR=~/.cache/office-cli/drive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2026-05-08
+
+### Added
+
+- `.claude/skills/process-pdf` skill: `pdf-to-png.sh` extracts a single page from a multi-page PDF as a 1920-wide PNG suitable for the floor-map tracing background. Pages can be selected by 1-based number or by text label (`pdftotext` search). Requires `poppler` (`pdftoppm` + `pdftotext`); the skill never installs anything itself. Documented in SKILL.md and cross-linked from `docs/tracing-guide.md`. Replaces the manual `sips`+page-extraction dance that was inline in the trace flow.
+- `.env.example` documents the `OFFICE_DRIVE_*` env vars introduced in #44 so operators have one place to copy from.
+
 ## [0.10.1] - 2026-05-07
 
 ### Added

--- a/docs/tracing-guide.md
+++ b/docs/tracing-guide.md
@@ -27,6 +27,25 @@ Pick `File → Document Properties` to set the page; pick
 `File → Import` and choose **Embed** (not Link) when adding the
 architect's plan.
 
+If the source plan is a multi-page PDF (e.g. an architect's pack
+covering several floors), don't import the PDF directly — Inkscape's
+PDF-as-vector import produces ~100k vector elements that break the
+Plain SVG export. Convert the relevant page to a raster PNG first
+using the `process-pdf` skill, then import the PNG with **Embed**:
+
+```bash
+bash .claude/skills/process-pdf/scripts/pdf-to-png.sh \
+    ~/Downloads/plans.pdf "Fifth Floor" /tmp/floor5.png
+# Or by 1-based page number:
+bash .claude/skills/process-pdf/scripts/pdf-to-png.sh \
+    ~/Downloads/plans.pdf 7 /tmp/floor5.png
+```
+
+The skill produces a 1920-wide PNG that drops straight into the
+`background` layer. See `.claude/skills/process-pdf/SKILL.md` for
+the full surface (it requires `poppler`; the skill prints a clear
+install hint if missing).
+
 ## The ID contract
 
 Every shape the agent cares about has both an `id` and a `class`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.10.1"
+version = "0.10.2"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -713,7 +713,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- New Claude Code skill at `.claude/skills/process-pdf/` that extracts one page from a PDF as a 1920-wide PNG, sized for the floor-map tracing background.
- Encodes the conversion path the floor-5 walkthrough surfaced: Inkscape's PDF-as-vector import produces ~100k vector elements whose Plain SVG export breaks the XML; raster background is the supported path.
- Page selection by **1-based integer** or **text label** (label search via `pdftotext`, errors out unless the match is unique). Defaults: 1920 wide, 150 DPI, output `<basename>-page<N>.png`.
- **No auto-install** — `poppler` is a documented prerequisite. The skill exits 2 with a platform-specific `brew install poppler` / `apt install poppler-utils` hint if `pdftoppm` or `pdftotext` is missing.
- Bundled: `docs/tracing-guide.md` cross-link to the skill, plus a small `.env.example` block documenting the `OFFICE_DRIVE_*` env vars from #44.

## Test plan

- [x] **Live PDF run.** `bash .claude/skills/process-pdf/scripts/pdf-to-png.sh ~/Downloads/tipalti-floors.pdf "Fifth Floor" /tmp/floor5.png` produced a clean **1920×1080 PNG, 668KB** from the user's 21-page architectural pack.
- [x] **Page-number mode** with the same PDF (page 7) produces an identical-shape PNG.
- [x] **Error paths** verified: missing PDF (exit 2 + hint), zero-match label (exit 2 + hint), missing arguments (exit 1 + usage), `--help` (exit 0).
- [x] `markdownlint-cli2 --fix` clean on the new SKILL.md, the modified tracing guide, and CHANGELOG.
- [ ] CI: `version-check` will pass (0.10.1 → 0.10.2 patch).
- [ ] Read-through (you): does the SKILL.md description trigger the way you'd expect when you ask "extract Floor 5 from the PDF"?

Generated with Claude Code