### PR TITLE
feat(floors): accept floor id as 'validate'/'doctor' arg (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-05-08
+
+### Added
+
+- `office floors validate` and `office floors doctor` accept a floor id (e.g. `tlv-floor-5`) as their positional argument, falling back to the existing path resolution when the arg doesn't match a declared id. ([#51](https://github.com/agentculture/office-agent/issues/51))
+
 ## [0.11.0] - 2026-05-08
 
 ### Added

--- a/office_cli/cli/_commands/floors.py
+++ b/office_cli/cli/_commands/floors.py
@@ -122,16 +122,23 @@ def _resolve_targets(
     args: argparse.Namespace, floor_index: dict[Path, Floor], data_dir: Path
 ) -> list[Path]:
     if args.path:
+        # First, try the arg as a floor id (`tlv-floor-5`). Operators and
+        # agents reach for this form because `office floors list` prints
+        # ids, not paths. Issue #51.
+        for path, floor in floor_index.items():
+            if floor.id == args.path:
+                return [path]
+        # Otherwise treat it as a path. Relative paths resolve against the
+        # data dir (not cwd) so they line up with floor.svg paths from
+        # offices.yaml when --data-dir != $PWD.
         p = Path(args.path)
-        # Relative paths resolve against the data dir (not cwd) so they line up
-        # with floor.svg paths from offices.yaml when --data-dir != $PWD.
         return [(p if p.is_absolute() else data_dir / p).resolve()]
     if args.all:
         return sorted(floor_index.keys())
     raise OfficeError(
         code=EXIT_USER_ERROR,
-        message="pass an SVG path or --all",
-        remediation="example: office floors validate floors/tlv-floor-5.svg",
+        message="pass a floor id, an SVG path, or --all",
+        remediation="example: office floors validate tlv-floor-5",
     )
 
 
@@ -187,7 +194,11 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_list.set_defaults(func=cmd_list)
 
     p_val = inner.add_parser("validate", help="Validate one or all floor SVGs.")
-    p_val.add_argument("path", nargs="?", help="Path to a floor SVG.")
+    p_val.add_argument(
+        "path",
+        nargs="?",
+        help="Floor id (e.g. 'tlv-floor-5') or path to a floor SVG.",
+    )
     p_val.add_argument("--all", action="store_true", help="Validate every declared SVG.")
     p_val.add_argument("--json", action="store_true", help=_HELP_JSON)
     add_data_dir_arg(p_val)
@@ -202,7 +213,11 @@ def register(sub: argparse._SubParsersAction) -> None:
             "per the floor's offices.yaml cluster spec."
         ),
     )
-    p_doc.add_argument("path", nargs="?", help="Path to a floor SVG.")
+    p_doc.add_argument(
+        "path",
+        nargs="?",
+        help="Floor id (e.g. 'tlv-floor-5') or path to a floor SVG.",
+    )
     p_doc.add_argument("--all", action="store_true", help="Doctor every declared SVG.")
     p_doc.add_argument(
         "--dry-run",

--- a/office_cli/cli/_commands/floors.py
+++ b/office_cli/cli/_commands/floors.py
@@ -125,9 +125,21 @@ def _resolve_targets(
         # First, try the arg as a floor id (`tlv-floor-5`). Operators and
         # agents reach for this form because `office floors list` prints
         # ids, not paths. Issue #51.
-        for path, floor in floor_index.items():
-            if floor.id == args.path:
-                return [path]
+        #
+        # Floor-id uniqueness is enforced within an office by
+        # office_cli/offices/_yaml.py, but NOT globally — two offices
+        # could declare the same floor id. Refuse to pick arbitrarily,
+        # especially because `doctor` mutates in place.
+        id_matches = [path for path, floor in floor_index.items() if floor.id == args.path]
+        if len(id_matches) == 1:
+            return [id_matches[0]]
+        if len(id_matches) > 1:
+            joined = ", ".join(str(p) for p in id_matches)
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"floor id {args.path!r} is ambiguous — matches: {joined}",
+                remediation="pass an explicit SVG path to disambiguate",
+            )
         # Otherwise treat it as a path. Relative paths resolve against the
         # data dir (not cwd) so they line up with floor.svg paths from
         # offices.yaml when --data-dir != $PWD.
@@ -197,7 +209,7 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_val.add_argument(
         "path",
         nargs="?",
-        help="Floor id (e.g. 'tlv-floor-5') or path to a floor SVG.",
+        help="Path to a floor SVG, or a floor id (e.g. 'tlv-floor-5').",
     )
     p_val.add_argument("--all", action="store_true", help="Validate every declared SVG.")
     p_val.add_argument("--json", action="store_true", help=_HELP_JSON)
@@ -216,7 +228,7 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_doc.add_argument(
         "path",
         nargs="?",
-        help="Floor id (e.g. 'tlv-floor-5') or path to a floor SVG.",
+        help="Path to a floor SVG, or a floor id (e.g. 'tlv-floor-5').",
     )
     p_doc.add_argument("--all", action="store_true", help="Doctor every declared SVG.")
     p_doc.add_argument(

--- a/office_cli/explain/catalog.py
+++ b/office_cli/explain/catalog.py
@@ -149,9 +149,14 @@ Errors fail the run with exit code 1; warnings do not.
 
 ## Usage
 
+    office floors validate tlv-floor-5
     office floors validate floors/tlv-floor-5.svg
     office floors validate --all
     office floors validate --all --json
+
+A bare argument is tried first as a floor id (matched against
+`offices.yaml`), then falls back to a path resolved against the
+data dir.
 
 ## Output
 
@@ -169,10 +174,15 @@ file passes `office floors validate`.
 
 ## Usage
 
+    office floors doctor tlv-floor-5
+    office floors doctor tlv-floor-5 --dry-run
     office floors doctor floors/tlv-floor-5.svg
-    office floors doctor floors/tlv-floor-5.svg --dry-run
     office floors doctor --all
-    office floors doctor floors/tlv-floor-5.svg --json
+    office floors doctor tlv-floor-5 --json
+
+A bare argument is tried first as a floor id (matched against
+`offices.yaml`), then falls back to a path resolved against the
+data dir.
 
 ## What it does (in order)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.11.0"
+version = "0.11.1"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_floors.py
+++ b/tests/test_cli_floors.py
@@ -195,6 +195,38 @@ def test_floors_validate_path_form_still_works(
     assert payload["results"][0]["ok"] is True
 
 
+def test_floors_validate_ambiguous_id_raises(
+    data_dir: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Floor id uniqueness is enforced within an office, not globally.
+    If two offices declare the same id, the resolver must refuse to pick
+    arbitrarily — especially important for `doctor`, which mutates in
+    place. Qodo PR-#52 review."""
+    # Stage a second office in offices.yaml that re-uses `tlv-floor-5`.
+    yaml_path = data_dir / "data" / "offices.yaml"
+    appended = yaml_path.read_text(encoding="utf-8") + (
+        "\n  - id: dup\n"
+        "    name: Duplicate Office\n"
+        "    floors:\n"
+        "      - id: tlv-floor-5\n"
+        "        svg: floors/dup.svg\n"
+        "        clusters:\n"
+        "          T: { capacity: 1, type: open-space }\n"
+    )
+    yaml_path.write_text(appended, encoding="utf-8")
+    # The dup SVG just needs to exist; content doesn't matter for resolver test.
+    (data_dir / "floors" / "dup.svg").write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080"/>\n',
+        encoding="utf-8",
+    )
+
+    rc = main(["floors", "validate", "tlv-floor-5", "--json", "--data-dir", str(data_dir)])
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "ambiguous" in err
+    assert "tlv-floor-5" in err
+
+
 def test_floors_validate_unknown_id_falls_back_to_path(
     data_dir: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_cli_floors.py
+++ b/tests/test_cli_floors.py
@@ -143,6 +143,78 @@ def test_floors_doctor_writes_and_validate_passes(
     assert result["errors"] == []
 
 
+def test_floors_validate_by_id(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Issue #51: passing a floor id (no path) resolves against
+    offices.yaml, not as a relative path."""
+    rc = main(["floors", "validate", "tlv-floor-5", "--json", "--data-dir", str(data_dir)])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    result = payload["results"][0]
+    assert result["floor"] == "tlv-floor-5"
+    assert result["ok"] is True
+
+
+def test_floors_doctor_by_id(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """`office floors doctor tlv-floor-5 --dry-run` works the same as
+    the path form."""
+    rc = main(
+        [
+            "floors",
+            "doctor",
+            "tlv-floor-5",
+            "--dry-run",
+            "--json",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    result = payload["results"][0]
+    assert result["floor"] == "tlv-floor-5"
+    assert result["dry_run"] is True
+
+
+def test_floors_validate_path_form_still_works(
+    data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Path-form invocations with the .svg suffix don't accidentally
+    match a floor id (defensive against future ids that look like paths)."""
+    rc = main(
+        [
+            "floors",
+            "validate",
+            "floors/tlv-floor-5.svg",
+            "--json",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["results"][0]["ok"] is True
+
+
+def test_floors_validate_unknown_id_falls_back_to_path(
+    data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Unknown id falls through to path resolution; the resulting error
+    is the existing 'not declared in offices.yaml' message — unchanged."""
+    rc = main(
+        [
+            "floors",
+            "validate",
+            "no-such-floor",
+            "--json",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "not declared in offices.yaml" in err
+
+
 def test_floors_validate_requires_target(
     data_dir: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -713,7 +713,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

- Closes #51. `office floors validate <floor-id>` and `office floors doctor <floor-id>` now work as a first-class form alongside the path form. I tripped on this during the floor-5 walkthrough: the natural agent invocation `office floors validate tlv-floor-5` was producing the unhelpful "SVG … is not declared in offices.yaml" error.
- Extension is contained to `_resolve_targets` (try id first; fall back to path); both verbs share the resolver.
- Help text and `office explain` output updated to advertise the id form.

## Behavior change

```bash
# All four work:
office floors validate tlv-floor-5
office floors validate floors/tlv-floor-5.svg
office floors doctor tlv-floor-5 --dry-run
office floors doctor floors/tlv-floor-5.svg
```

Unknown arg → existing path-resolution error (unchanged).

## Test plan

- [x] 4 new CLI tests: `validate` by id, `doctor` by id (dry-run), path form still works, unknown id falls back to path.
- [x] Full suite: 454 passed (was 450; +4 new).
- [x] Lint clean: black / isort / flake8 / bandit / markdownlint.
- [x] Manual smoke against this checkout — both \`validate tlv-floor-5\` and \`doctor tlv-floor-5 --dry-run\` produce the expected output without any path argument.

Generated with Claude Code