### PR TITLE
fix(floors): doctor emits browser-compatible SVG root namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2026-05-08
+
+### Fixed
+
+- `office floors doctor` emits a browser-compatible SVG root again. After PR #50's review, `ET.register_namespace` calls were removed to clear Sonar S5332 hotspots, but that made ElementTree write `<ns0:svg xmlns:ns0="...">` instead of `<svg xmlns="...">`. Browsers (and the seat-map web UI) rejected the prefixed-root form as 'not a valid SVG document' even though the XML was well-formed. Restored the SVG default-namespace registration; the inkscape/sodipodi/xlink ones stay unregistered (cosmetic only, not browser-load-bearing). Sonar will flag the W3C namespace URI as a low-severity hotspot, which we accept with rationale: it's a namespace identifier, not a fetched URL.
+
 ## [0.11.1] - 2026-05-08
 
 ### Added

--- a/office_cli/floors/_doctor.py
+++ b/office_cli/floors/_doctor.py
@@ -27,6 +27,14 @@ _VIEW_H = 1080
 _DEDUP_PX = 6.0  # bounding-box centers within this distance treated as duplicates
 _ROW_TOL = 30.0  # y-pixel grouping tolerance for row-major spatial sort
 
+# Register the SVG namespace as the default so writes emit
+# <svg xmlns="..."> instead of <ns0:svg xmlns:ns0="...">. Browsers
+# reject the prefixed-root form as "not a valid SVG document"
+# even though the XML itself is well-formed (xmllint accepts it).
+# Sonar will flag the http URI as a low-severity hotspot (S5332);
+# this is a W3C namespace identifier, not a fetched URL.
+ET.register_namespace("", "http://www.w3.org/2000/svg")
+
 
 @dataclass(frozen=True)
 class DoctorReport:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.11.1"
+version = "0.11.2"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_floors_doctor.py
+++ b/tests/test_floors_doctor.py
@@ -180,6 +180,31 @@ def test_doctor_malformed_xml_raises_office_error(data_dir: Path) -> None:
     assert "well-formed" in exc.value.message.lower()
 
 
+def test_doctor_writes_browser_compatible_svg_root(data_dir: Path) -> None:
+    """Regression: doctor must emit `<svg xmlns="...">` (default
+    namespace), not `<ns0:svg xmlns:ns0="...">`. Browsers reject the
+    prefixed-root form even though the XML is well-formed."""
+    svg_path = data_dir / "floors" / "tlv-floor-5.svg"
+    polluted = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">'
+        '<rect id="g1" class="seat" x="100" y="100" width="40" height="40"/>'
+        '<rect id="off" class="seat" x="100" y="-500" width="40" height="40"/>'
+        '<polygon id="r" class="room" points="1400,300 1700,300 1700,500 1400,500"/>'
+        "</svg>\n"
+    )
+    svg_path.write_text(polluted, encoding="utf-8")
+
+    doctor_svg(svg_path, _floor(data_dir))
+
+    written = svg_path.read_text(encoding="utf-8")
+    # Root must be bare `<svg`, not `<ns0:svg`. Allow a leading XML decl.
+    assert "<ns0:svg" not in written
+    assert "<svg " in written
+    # And the SVG namespace must be the default xmlns.
+    assert 'xmlns="http://www.w3.org/2000/svg"' in written
+
+
 def test_doctor_polygon_with_malformed_points_does_not_crash(
     data_dir: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Fixes a regression I introduced in PR #50: `office floors doctor` now writes an SVG that browsers can render.
- The user hit it on the floor-5 walkthrough — the seat-map web UI failed with **"Failed to load: response is not a valid SVG document"** even though `xmllint` and `office floors validate` accepted the file.
- Root cause: PR #50's review removed `ET.register_namespace("", "http://www.w3.org/2000/svg")` to clear Sonar S5332 (http:// in URLs) hotspots. Without that registration, ElementTree writes `<ns0:svg xmlns:ns0="...">` instead of `<svg xmlns="...">`. The prefixed-root form is well-formed XML (xmllint passes) but browsers reject it.
- This PR restores the SVG default-namespace registration; the inkscape/sodipodi/xlink ones stay unregistered (cosmetic only, not browser-load-bearing) to minimize Sonar surface.

## Why we don't switch to https

`http://www.w3.org/2000/svg` is **not a URL** — it's the verbatim XML namespace identifier defined by the W3C SVG spec. Nothing fetches it. Switching to `https://www.w3.org/2000/svg` would produce a different identifier that no parser recognizes as SVG; the file would silently fail to render. S5332 is a false positive for namespace URIs.

After this PR merges and Sonar re-flags the URI, I'll accept the hotspot via `sonar.sh accept` with that rationale.

## Test plan

- [x] New regression test `test_doctor_writes_browser_compatible_svg_root` asserts the saved file has `<svg ` (not `<ns0:svg`) and `xmlns="http://www.w3.org/2000/svg"`.
- [x] Full suite: 456 passed (was 455; +1 new).
- [x] Lint clean: black / isort / flake8 / bandit / markdownlint.
- [x] Manual smoke: doctored SVG renders in Safari without "not a valid SVG document".

## Operator action after merge

Re-run `office floors doctor` against any SVG previously written by the broken doctor, then re-upload to Drive (or wherever it's served from).

Generated with Claude Code