### PR TITLE
feat(floors): copy-layout + new verbs (no more hand-editing offices.yaml)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-05-08
+
+### Added
+
+- `office floors copy-layout <src> <dst> [--overwrite]` — copy `<rect class="seat">` and `<polygon class="room">` geometry from one floor's SVG into another, renumbering ids per the destination's cluster spec. Many floors share a layout (same column grid, same desk arrangement); this verb avoids re-tracing each one in Inkscape. Reuses the doctor verb's `_assign_ids` / `_select` / `_capacity_warnings` / `_seat_ids_for` helpers — same renumbering contract, just sourcing elements from another file. Refuses to clobber a `status: active` destination without `--overwrite`. Issue #54 follow-up.
+- `office floors new <floor-id> --pdf <p> --page <N|label> [--office <oid>] [--copy-from <src-id>]` — end-to-end "create a floor" verb. Appends the entry to `data/offices.yaml` (status: draft), scaffolds the SVG, and optionally copies layout from an existing floor in one shot. With `--copy-from`, the new entry inherits the source's full cluster + room spec so the copied seats/rooms fit cleanly. Refuses if the floor id is already declared anywhere in offices.yaml.
+- `office_cli/offices/append_floor_entry` — textual splice into `data/offices.yaml` that preserves comments, indentation, and field ordering. PyYAML's `safe_dump` would reorder fields and strip comments; we instead parse for validation and locate the right `floors:` list, then insert a new entry at the end of that list as raw YAML text. Errors with a clear remediation if the file's indentation doesn't match — operators hand-edit rather than risk a guess.
+
+### Changed
+
+### Fixed
+
 ## [0.12.0] - 2026-05-08
 
 ### Added

--- a/office_cli/cli/_commands/floors.py
+++ b/office_cli/cli/_commands/floors.py
@@ -541,9 +541,7 @@ def _ensure_floor_id_not_declared(floor_id: str, offices: dict) -> None:
         if floor_id in office.floors:
             raise OfficeError(
                 code=EXIT_USER_ERROR,
-                message=(
-                    f"floor id {floor_id!r} is already declared under office " f"{office.id!r}"
-                ),
+                message=f"floor id {floor_id!r} is already declared under office {office.id!r}",
                 remediation=(
                     "delete the existing entry first, or pick a different id "
                     "(refusing to silently overwrite)"

--- a/office_cli/cli/_commands/floors.py
+++ b/office_cli/cli/_commands/floors.py
@@ -461,37 +461,77 @@ def cmd_new(args: argparse.Namespace) -> int:
     pdf_path = _require_pdf(args)
     page = _coerce_page(args.page) if args.page else _require_page(args)
 
+    # Atomic flow (Qodo PR #57 review): scaffold + copy + validate
+    # all happen BEFORE we touch offices.yaml. If anything fails, the
+    # only side-effect is a partial SVG at dst_path (rolled back below);
+    # the YAML stays untouched so a fresh `floors new` works.
     new_entry = _build_floor_entry(floor_id, src_floor)
-    yaml_path = data_dir / "data" / "offices.yaml"
-    append_floor_entry(yaml_path, office_id, new_entry)
-
-    # Reload to get a Floor object pointing at the on-disk path.
-    offices_after = load_offices(data_dir)
-    dst_floor = offices_after[office_id].floors[floor_id]
-    dst_path = dst_floor.svg
-    dst_path.parent.mkdir(parents=True, exist_ok=True)
-    svg_bytes = scaffold_svg(floor=dst_floor, pdf=pdf_path, page=page)
-    dst_path.write_bytes(svg_bytes)
-    actions = [f"appended {floor_id} under office {office_id}", "scaffolded SVG"]
-
-    if src_floor is not None and src_path is not None:
-        copy_layout(
-            src_path=src_path,
-            src_floor=src_floor,
-            dst_path=dst_path,
-            dst_floor=dst_floor,
+    dst_path = data_dir / new_entry["svg"]
+    if dst_path.exists():
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"refusing to overwrite existing SVG: {dst_path}",
+            remediation=(
+                "delete the file first, or pick a different floor id "
+                "(refusing to silently overwrite operator state)"
+            ),
         )
-        actions.append(f"copied layout from {src_floor.id}")
+    synthetic_floor = Floor(
+        id=floor_id,
+        svg=dst_path,
+        clusters=_synth_clusters(new_entry["clusters"]),
+        rooms=_synth_rooms(new_entry["rooms"]),
+        status="draft",
+    )
+    actions = ["scaffolded SVG"]
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        svg_bytes = scaffold_svg(floor=synthetic_floor, pdf=pdf_path, page=page)
+        dst_path.write_bytes(svg_bytes)
+        if src_floor is not None and src_path is not None:
+            copy_layout(
+                src_path=src_path,
+                src_floor=src_floor,
+                dst_path=dst_path,
+                dst_floor=synthetic_floor,
+            )
+            actions.append(f"copied layout from {src_floor.id}")
+        issues = validate_floor(parse_svg(dst_path), synthetic_floor)
+    except Exception:
+        # Roll back the partial SVG so a re-run isn't blocked on
+        # stale-file detection.
+        if dst_path.exists():
+            dst_path.unlink()
+        raise
 
-    issues = validate_floor(parse_svg(dst_path), dst_floor)
     errors = [i for i in issues if i.severity is Severity.ERROR]
     warnings = [i for i in issues if i.severity is Severity.WARNING]
+    if errors:
+        # Validation failed — roll back the SVG and refuse to write the
+        # YAML entry. Operator fixes the underlying issue and re-runs.
+        dst_path.unlink()
+        for err in errors:
+            emit_diagnostic(f"  error [{err.rule}]: {err.message}")
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"generated SVG for {floor_id!r} has {len(errors)} validation "
+                "error(s); rolled back, no YAML written"
+            ),
+            remediation="fix the source layout (or pick a different page) and re-run",
+        )
+
+    # Only commit YAML now that we have a clean, validated SVG on disk.
+    yaml_path = data_dir / "data" / "offices.yaml"
+    append_floor_entry(yaml_path, office_id, new_entry)
+    actions.append(f"appended {floor_id} under office {office_id}")
+
     payload = {
         "office": office_id,
         "floor": floor_id,
         "svg": str(dst_path),
         "actions": actions,
-        "errors": [i.to_dict() for i in errors],
+        "errors": [],
         "warnings": [i.to_dict() for i in warnings],
     }
     if args.json:
@@ -502,13 +542,44 @@ def cmd_new(args: argparse.Namespace) -> int:
             emit_diagnostic(f"  {action}")
         for warn in warnings:
             emit_diagnostic(f"  warn  [{warn.rule}]: {warn.message}")
-        for err in errors:
-            emit_diagnostic(f"  error [{err.rule}]: {err.message}")
         emit_diagnostic(
             "  next: trace seats in Inkscape, then `office floors doctor "
             f"{floor_id}`, then upload to Drive."
         )
     return 0
+
+
+def _synth_clusters(spec: object) -> dict:
+    """Materialize the dict-of-Cluster used by `Floor` from a YAML-shape spec."""
+    from office_cli.offices._models import Cluster
+
+    out: dict = {}
+    if isinstance(spec, dict):
+        for letter, sub in spec.items():
+            if isinstance(sub, dict):
+                out[letter] = Cluster(
+                    letter=letter,
+                    capacity=int(sub.get("capacity", 1)),
+                    type=str(sub.get("type", "open-space")),
+                )
+    return out
+
+
+def _synth_rooms(spec: object) -> dict:
+    """Materialize the dict-of-Room used by `Floor` from a YAML-shape spec."""
+    from office_cli.offices._models import Room
+
+    out: dict = {}
+    if isinstance(spec, dict):
+        for rid, sub in spec.items():
+            if isinstance(sub, dict):
+                out[rid] = Room(
+                    id=rid,
+                    name=str(sub.get("name", rid)),
+                    type=str(sub.get("type", "meeting")),
+                    capacity=int(sub.get("capacity", 0)),
+                )
+    return out
 
 
 def _resolve_new_office(args: argparse.Namespace, offices: dict) -> str:

--- a/office_cli/cli/_commands/floors.py
+++ b/office_cli/cli/_commands/floors.py
@@ -449,24 +449,41 @@ def cmd_copy_layout(args: argparse.Namespace) -> int:
 def cmd_new(args: argparse.Namespace) -> int:
     """Create a new floor end-to-end: append `offices.yaml` entry,
     scaffold the SVG, optionally copy layout from an existing floor.
+
+    Atomic flow (Qodo PR #57 review): scaffold + copy + validate all
+    happen BEFORE we touch offices.yaml. If anything fails, the only
+    side-effect is a partial SVG at dst_path (rolled back below); the
+    YAML stays untouched so a fresh `floors new` works.
+
+    Decomposed into helpers so cognitive complexity stays under
+    Sonar's S3776 threshold.
     """
     data_dir = resolve_data_dir(args)
     offices = load_offices(data_dir)
     office_id = _resolve_new_office(args, offices)
-    floor_id = args.floor_id
-    _ensure_floor_id_not_declared(floor_id, offices)
+    _ensure_floor_id_not_declared(args.floor_id, offices)
 
     floor_index = _index_floors(offices)
     src_floor, src_path = _resolve_optional_src(args, floor_index)
     pdf_path = _require_pdf(args)
     page = _coerce_page(args.page) if args.page else _require_page(args)
 
-    # Atomic flow (Qodo PR #57 review): scaffold + copy + validate
-    # all happen BEFORE we touch offices.yaml. If anything fails, the
-    # only side-effect is a partial SVG at dst_path (rolled back below);
-    # the YAML stays untouched so a fresh `floors new` works.
-    new_entry = _build_floor_entry(floor_id, src_floor)
+    new_entry = _build_floor_entry(args.floor_id, src_floor)
     dst_path = data_dir / new_entry["svg"]
+    _ensure_dst_unused(dst_path)
+    synthetic_floor = _synth_floor(args.floor_id, dst_path, new_entry)
+
+    actions, warnings = _render_and_validate(
+        synthetic_floor, dst_path, pdf_path, page, src_floor, src_path
+    )
+    yaml_path = data_dir / "data" / "offices.yaml"
+    append_floor_entry(yaml_path, office_id, new_entry)
+    actions.append(f"appended {args.floor_id} under office {office_id}")
+    _emit_new_result(args, office_id, args.floor_id, dst_path, actions, warnings)
+    return 0
+
+
+def _ensure_dst_unused(dst_path: Path) -> None:
     if dst_path.exists():
         raise OfficeError(
             code=EXIT_USER_ERROR,
@@ -476,13 +493,27 @@ def cmd_new(args: argparse.Namespace) -> int:
                 "(refusing to silently overwrite operator state)"
             ),
         )
-    synthetic_floor = Floor(
+
+
+def _synth_floor(floor_id: str, dst_path: Path, entry: dict) -> Floor:
+    return Floor(
         id=floor_id,
         svg=dst_path,
-        clusters=_synth_clusters(new_entry["clusters"]),
-        rooms=_synth_rooms(new_entry["rooms"]),
+        clusters=_synth_clusters(entry["clusters"]),
+        rooms=_synth_rooms(entry["rooms"]),
         status="draft",
     )
+
+
+def _render_and_validate(
+    synthetic_floor: Floor,
+    dst_path: Path,
+    pdf_path: Path,
+    page,
+    src_floor: Floor | None,
+    src_path: Path | None,
+) -> tuple[list[str], list]:
+    """Render scaffold + optional copy-layout + validate; roll back on failure."""
     actions = ["scaffolded SVG"]
     dst_path.parent.mkdir(parents=True, exist_ok=True)
     try:
@@ -498,8 +529,6 @@ def cmd_new(args: argparse.Namespace) -> int:
             actions.append(f"copied layout from {src_floor.id}")
         issues = validate_floor(parse_svg(dst_path), synthetic_floor)
     except Exception:
-        # Roll back the partial SVG so a re-run isn't blocked on
-        # stale-file detection.
         if dst_path.exists():
             dst_path.unlink()
         raise
@@ -507,25 +536,28 @@ def cmd_new(args: argparse.Namespace) -> int:
     errors = [i for i in issues if i.severity is Severity.ERROR]
     warnings = [i for i in issues if i.severity is Severity.WARNING]
     if errors:
-        # Validation failed — roll back the SVG and refuse to write the
-        # YAML entry. Operator fixes the underlying issue and re-runs.
         dst_path.unlink()
         for err in errors:
             emit_diagnostic(f"  error [{err.rule}]: {err.message}")
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=(
-                f"generated SVG for {floor_id!r} has {len(errors)} validation "
-                "error(s); rolled back, no YAML written"
+                f"generated SVG for {synthetic_floor.id!r} has {len(errors)} "
+                "validation error(s); rolled back, no YAML written"
             ),
             remediation="fix the source layout (or pick a different page) and re-run",
         )
+    return actions, warnings
 
-    # Only commit YAML now that we have a clean, validated SVG on disk.
-    yaml_path = data_dir / "data" / "offices.yaml"
-    append_floor_entry(yaml_path, office_id, new_entry)
-    actions.append(f"appended {floor_id} under office {office_id}")
 
+def _emit_new_result(
+    args: argparse.Namespace,
+    office_id: str,
+    floor_id: str,
+    dst_path: Path,
+    actions: list[str],
+    warnings: list,
+) -> None:
     payload = {
         "office": office_id,
         "floor": floor_id,
@@ -536,17 +568,16 @@ def cmd_new(args: argparse.Namespace) -> int:
     }
     if args.json:
         emit_result(payload, json_mode=True)
-    else:
-        emit_result(f"OK   {floor_id} ({dst_path})", json_mode=False)
-        for action in actions:
-            emit_diagnostic(f"  {action}")
-        for warn in warnings:
-            emit_diagnostic(f"  warn  [{warn.rule}]: {warn.message}")
-        emit_diagnostic(
-            "  next: trace seats in Inkscape, then `office floors doctor "
-            f"{floor_id}`, then upload to Drive."
-        )
-    return 0
+        return
+    emit_result(f"OK   {floor_id} ({dst_path})", json_mode=False)
+    for action in actions:
+        emit_diagnostic(f"  {action}")
+    for warn in warnings:
+        emit_diagnostic(f"  warn  [{warn.rule}]: {warn.message}")
+    emit_diagnostic(
+        "  next: trace seats in Inkscape, then `office floors doctor "
+        f"{floor_id}`, then upload to Drive."
+    )
 
 
 def _synth_clusters(spec: object) -> dict:

--- a/office_cli/cli/_commands/floors.py
+++ b/office_cli/cli/_commands/floors.py
@@ -10,8 +10,15 @@ from pathlib import Path
 from office_cli._config import add_data_dir_arg, drive_cache_root, resolve_data_dir
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 from office_cli.cli._output import emit_diagnostic, emit_result
-from office_cli.floors import Severity, doctor_svg, parse_svg, scaffold_svg, validate_floor
-from office_cli.offices import Floor, load_offices
+from office_cli.floors import (
+    Severity,
+    copy_layout,
+    doctor_svg,
+    parse_svg,
+    scaffold_svg,
+    validate_floor,
+)
+from office_cli.offices import Floor, append_floor_entry, load_offices
 
 _HELP_JSON = "Emit structured JSON."
 _DOCTOR_HINT_THRESHOLD = 3
@@ -409,6 +416,199 @@ def _scaffold_out_path(args: argparse.Namespace, existing: Path, data_dir: Path)
     return p.resolve()
 
 
+def cmd_copy_layout(args: argparse.Namespace) -> int:
+    """Copy seats + rooms (geometry only) from one floor's SVG into
+    another, renumbering ids per the dst's cluster spec."""
+    data_dir = resolve_data_dir(args)
+    floor_index = _index_floors(load_offices(data_dir))
+    src_floor, src_path = _resolve_scaffold_floor(args.src, floor_index)
+    dst_floor, dst_path = _resolve_scaffold_floor(args.dst, floor_index)
+    report = copy_layout(
+        src_path=src_path,
+        src_floor=src_floor,
+        dst_path=dst_path,
+        dst_floor=dst_floor,
+        overwrite=bool(args.overwrite),
+    )
+    if args.json:
+        emit_result(report.to_dict(), json_mode=True)
+    else:
+        emit_result(
+            f"OK   {src_floor.id} -> {dst_floor.id} "
+            f"(seats {report.seats_copied}/{report.seat_slots}, "
+            f"rooms {report.rooms_copied}/{report.room_slots})",
+            json_mode=False,
+        )
+        for action in report.actions:
+            emit_diagnostic(f"  {action}")
+        for warning in report.warnings:
+            emit_diagnostic(f"  warn: {warning}")
+    return 0
+
+
+def cmd_new(args: argparse.Namespace) -> int:
+    """Create a new floor end-to-end: append `offices.yaml` entry,
+    scaffold the SVG, optionally copy layout from an existing floor.
+    """
+    data_dir = resolve_data_dir(args)
+    offices = load_offices(data_dir)
+    office_id = _resolve_new_office(args, offices)
+    floor_id = args.floor_id
+    _ensure_floor_id_not_declared(floor_id, offices)
+
+    floor_index = _index_floors(offices)
+    src_floor, src_path = _resolve_optional_src(args, floor_index)
+    pdf_path = _require_pdf(args)
+    page = _coerce_page(args.page) if args.page else _require_page(args)
+
+    new_entry = _build_floor_entry(floor_id, src_floor)
+    yaml_path = data_dir / "data" / "offices.yaml"
+    append_floor_entry(yaml_path, office_id, new_entry)
+
+    # Reload to get a Floor object pointing at the on-disk path.
+    offices_after = load_offices(data_dir)
+    dst_floor = offices_after[office_id].floors[floor_id]
+    dst_path = dst_floor.svg
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+    svg_bytes = scaffold_svg(floor=dst_floor, pdf=pdf_path, page=page)
+    dst_path.write_bytes(svg_bytes)
+    actions = [f"appended {floor_id} under office {office_id}", "scaffolded SVG"]
+
+    if src_floor is not None and src_path is not None:
+        copy_layout(
+            src_path=src_path,
+            src_floor=src_floor,
+            dst_path=dst_path,
+            dst_floor=dst_floor,
+        )
+        actions.append(f"copied layout from {src_floor.id}")
+
+    issues = validate_floor(parse_svg(dst_path), dst_floor)
+    errors = [i for i in issues if i.severity is Severity.ERROR]
+    warnings = [i for i in issues if i.severity is Severity.WARNING]
+    payload = {
+        "office": office_id,
+        "floor": floor_id,
+        "svg": str(dst_path),
+        "actions": actions,
+        "errors": [i.to_dict() for i in errors],
+        "warnings": [i.to_dict() for i in warnings],
+    }
+    if args.json:
+        emit_result(payload, json_mode=True)
+    else:
+        emit_result(f"OK   {floor_id} ({dst_path})", json_mode=False)
+        for action in actions:
+            emit_diagnostic(f"  {action}")
+        for warn in warnings:
+            emit_diagnostic(f"  warn  [{warn.rule}]: {warn.message}")
+        for err in errors:
+            emit_diagnostic(f"  error [{err.rule}]: {err.message}")
+        emit_diagnostic(
+            "  next: trace seats in Inkscape, then `office floors doctor "
+            f"{floor_id}`, then upload to Drive."
+        )
+    return 0
+
+
+def _resolve_new_office(args: argparse.Namespace, offices: dict) -> str:
+    """Pick the office for a new floor.
+
+    Auto-detects when offices.yaml has exactly one office; required
+    otherwise.
+    """
+    if args.office:
+        if args.office not in offices:
+            known = ", ".join(sorted(offices.keys()))
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"unknown office: {args.office!r}",
+                remediation=f"known offices: {known or '(none)'}",
+            )
+        return args.office
+    if len(offices) == 1:
+        return next(iter(offices))
+    known = ", ".join(sorted(offices.keys()))
+    raise OfficeError(
+        code=EXIT_USER_ERROR,
+        message="multiple offices declared; --office is required",
+        remediation=f"pass --office <id> (known: {known})",
+    )
+
+
+def _ensure_floor_id_not_declared(floor_id: str, offices: dict) -> None:
+    for office in offices.values():
+        if floor_id in office.floors:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=(
+                    f"floor id {floor_id!r} is already declared under office " f"{office.id!r}"
+                ),
+                remediation=(
+                    "delete the existing entry first, or pick a different id "
+                    "(refusing to silently overwrite)"
+                ),
+            )
+
+
+def _resolve_optional_src(
+    args: argparse.Namespace, floor_index: dict[Path, Floor]
+) -> tuple[Floor | None, Path | None]:
+    src_id = getattr(args, "copy_from", None)
+    if not src_id:
+        return None, None
+    src_floor, src_path = _resolve_scaffold_floor(src_id, floor_index)
+    return src_floor, src_path
+
+
+def _require_pdf(args: argparse.Namespace) -> Path:
+    if not args.pdf:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="--pdf is required",
+            remediation="pass --pdf <path-to-architects.pdf>",
+        )
+    return Path(args.pdf).expanduser()
+
+
+def _require_page(args: argparse.Namespace) -> int | str:
+    if not args.page:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="--page is required",
+            remediation="pass --page <N> (1-based) or --page <label>",
+        )
+    return _coerce_page(args.page)
+
+
+def _build_floor_entry(floor_id: str, src_floor: Floor | None) -> dict:
+    """Shape the dict consumed by ``append_floor_entry``.
+
+    Inherits cluster + room spec from ``src_floor`` when given (so a
+    --copy-from creates an offices.yaml entry that fits the source's
+    layout). Without it, falls back to a placeholder T:1 cluster.
+    """
+    if src_floor is not None:
+        clusters = {
+            letter: {"capacity": cluster.capacity, "type": cluster.type}
+            for letter, cluster in src_floor.clusters.items()
+        }
+        rooms = {
+            rid: {"name": r.name, "type": r.type, "capacity": r.capacity}
+            for rid, r in src_floor.rooms.items()
+        }
+    else:
+        clusters = {"T": {"capacity": 1, "type": "open-space"}}
+        rooms = {}
+    return {
+        "id": floor_id,
+        "svg": f"floors/{floor_id}.svg",
+        "status": "draft",
+        "clusters": clusters,
+        "rooms": rooms,
+    }
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     """Diagnose-and-fix floor SVGs: drop off-page / duplicate shapes,
     renumber per ``offices.yaml`` cluster spec."""
@@ -664,6 +864,54 @@ def register(sub: argparse._SubParsersAction) -> None:
     p_scaff.add_argument("--json", action="store_true", help=_HELP_JSON)
     add_data_dir_arg(p_scaff)
     p_scaff.set_defaults(func=cmd_scaffold)
+
+    p_copy = inner.add_parser(
+        "copy-layout",
+        help="Copy seats+rooms geometry from one floor to another (renumbering ids).",
+        description=(
+            "Copy <rect class='seat'> and <polygon class='room'> elements "
+            "from a clean source floor's SVG into a destination scaffold. "
+            "The destination's embedded background and viewBox are preserved; "
+            "ids are renumbered per the dst floor's cluster spec in offices.yaml."
+        ),
+    )
+    p_copy.add_argument("src", help="Source floor id (e.g. 'tlv-floor-5').")
+    p_copy.add_argument("dst", help="Destination floor id (e.g. 'tlv-floor-3').")
+    p_copy.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow copying onto a non-draft (status: active) destination.",
+    )
+    p_copy.add_argument("--json", action="store_true", help=_HELP_JSON)
+    add_data_dir_arg(p_copy)
+    p_copy.set_defaults(func=cmd_copy_layout)
+
+    p_new = inner.add_parser(
+        "new",
+        help="Create a new floor: append offices.yaml entry + scaffold SVG.",
+        description=(
+            "End-to-end create for a new floor. Appends the offices.yaml entry "
+            "(status: draft), scaffolds the SVG from the chosen PDF page, and "
+            "optionally overlays seats+rooms from an existing floor."
+        ),
+    )
+    p_new.add_argument("floor_id", help="New floor id (e.g. 'tlv-floor-3').")
+    p_new.add_argument("--pdf", help="Path to the architect's PDF.")
+    p_new.add_argument(
+        "--page", help="1-based page number, or text label that appears on one page."
+    )
+    p_new.add_argument(
+        "--office",
+        help="Office id (required when offices.yaml declares multiple offices).",
+    )
+    p_new.add_argument(
+        "--copy-from",
+        dest="copy_from",
+        help="Existing floor id whose layout (and cluster spec) to inherit.",
+    )
+    p_new.add_argument("--json", action="store_true", help=_HELP_JSON)
+    add_data_dir_arg(p_new)
+    p_new.set_defaults(func=cmd_new)
 
     p_ref = inner.add_parser(
         "refresh",

--- a/office_cli/explain/catalog.py
+++ b/office_cli/explain/catalog.py
@@ -113,6 +113,9 @@ List configured offices/floors and validate floor SVGs against the
 - `office floors doctor [PATH] [--all] [--dry-run] [--json] [--data-dir DIR]`
 - `office floors scaffold [FLOOR_ID] [--pdf P --page N|--manifest M]
     [--force] [--out PATH] [--json] [--data-dir DIR]`
+- `office floors new FLOOR_ID --pdf P --page N [--office ID]
+    [--copy-from SRC] [--json] [--data-dir DIR]`
+- `office floors copy-layout SRC DST [--overwrite] [--json] [--data-dir DIR]`
 - `office floors refresh [--json]`
 
 ## Validation rules
@@ -275,6 +278,98 @@ The scaffold passes `office floors validate` with a single
 seats/rooms in Inkscape, run `office floors doctor <id>` to renumber
 per the cluster spec, then flip the floor's `status: draft` to
 `status: active` in offices.yaml.
+"""
+
+_FLOORS_NEW = """\
+# office floors new
+
+Create a new floor end-to-end without hand-editing `offices.yaml`.
+Appends a draft entry to `data/offices.yaml`, scaffolds the SVG from
+a PDF page, and optionally overlays seats + rooms from an existing
+floor's layout.
+
+## Usage
+
+    office floors new tlv-floor-3 --pdf <path> --page 8
+    office floors new tlv-floor-3 --pdf <path> --page 8 --copy-from tlv-floor-5
+    office floors new fc-floor-6 --pdf <path> --page 2 --office fc
+
+## Flags
+
+- `--pdf PATH` — required. Architect's PDF.
+- `--page N|LABEL` — required. 1-based page number or string label.
+- `--office ID` — required when offices.yaml has multiple offices;
+  auto-detected for single-office configurations.
+- `--copy-from SRC` — existing floor id whose cluster spec, room
+  declarations, and SVG layout get inherited. The new floor ends up
+  with the same number of seats and rooms as `SRC`, just renumbered
+  for the new floor (e.g. `5-T-01` -> `3-T-01`).
+
+## Output
+
+- offices.yaml gets a new `floors[]` entry under the chosen office,
+  with `status: draft`. The append is textual: comments and field
+  ordering of existing entries are preserved.
+- `floors/<floor-id>.svg` is created with an embedded PDF page as
+  background and either (a) one example seat + one example room
+  (without `--copy-from`) or (b) the full layout from `--copy-from`.
+
+## Refusals
+
+- Floor id already declared anywhere in offices.yaml.
+- Multiple offices declared and no `--office` flag.
+- PDF, page, or `--copy-from` source missing.
+
+## Next steps
+
+After this verb succeeds, the typical loop is:
+
+    office floors doctor <new-floor-id>      # tidy ids if needed
+    office floors validate <new-floor-id>    # confirm clean
+    # Upload SVG + mirror offices.yaml entry to Drive (manual)
+    office floors refresh
+    office floors validate <new-floor-id>    # via Drive
+
+Flip `status: draft` -> `status: active` once the trace is real.
+"""
+
+_FLOORS_COPY_LAYOUT = """\
+# office floors copy-layout
+
+Copy `<rect class="seat">` and `<polygon class="room">` geometry from
+one floor's SVG into another, renumbering ids per the destination's
+cluster spec. Use when many floors share a layout (e.g. floor 3 and
+floor 4 of the same building) and you want to bootstrap the second
+floor without re-tracing in Inkscape.
+
+## Usage
+
+    office floors copy-layout tlv-floor-5 tlv-floor-3
+    office floors copy-layout tlv-floor-5 tlv-floor-3 --overwrite
+
+## What it does
+
+1. Validate src — refuses to copy a layout with errors.
+2. Strip the dst's existing seats + rooms (the example placeholders
+   from `office floors scaffold`).
+3. Deep-copy src's seats + rooms into dst, preserving `x/y/w/h`
+   and `points` attributes.
+4. Renumber via the same logic the doctor verb uses: spatial sort,
+   slot assignment per dst's cluster spec, drop excess.
+5. Pretty-print and write back. Capacity warnings emitted if dst
+   has fewer seats than src.
+
+## Refusals
+
+- Either id ambiguous (same id under two offices) — same guard as
+  validate / doctor / scaffold.
+- src has validation errors.
+- dst is `status: active` and `--overwrite` was not passed.
+
+## Output
+
+Text: a status line plus indented action lines and any warnings.
+JSON (with `--json`): `{src_floor, dst_floor, seats_copied, rooms_copied, ...}`.
 """
 
 _FLOORS_REFRESH = """\
@@ -486,6 +581,8 @@ ENTRIES: dict[tuple[str, ...], str] = {
     ("floors", "validate"): _FLOORS_VALIDATE,
     ("floors", "doctor"): _FLOORS_DOCTOR,
     ("floors", "scaffold"): _FLOORS_SCAFFOLD,
+    ("floors", "new"): _FLOORS_NEW,
+    ("floors", "copy-layout"): _FLOORS_COPY_LAYOUT,
     ("floors", "refresh"): _FLOORS_REFRESH,
     ("seats",): _SEATS,
     ("seats", "assign"): _SEATS_ASSIGN,

--- a/office_cli/floors/__init__.py
+++ b/office_cli/floors/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from office_cli.floors._copy_layout import CopyReport, copy_layout
 from office_cli.floors._doctor import DoctorReport, doctor_svg
 from office_cli.floors._ids import (
     ROOM_RE,
@@ -15,12 +16,14 @@ from office_cli.floors._svg import FloorSvg, parse_svg
 from office_cli.floors._validate import Issue, Severity, validate_floor
 
 __all__ = [
+    "CopyReport",
     "DoctorReport",
     "FloorSvg",
     "Issue",
     "ROOM_RE",
     "SEAT_RE",
     "Severity",
+    "copy_layout",
     "doctor_svg",
     "is_room_id",
     "is_seat_id",

--- a/office_cli/floors/_copy_layout.py
+++ b/office_cli/floors/_copy_layout.py
@@ -101,10 +101,10 @@ def copy_layout(
 
     dst_tree = _parse(dst_path)
     dst_root = dst_tree.getroot()
-    _strip_existing_layout(dst_root)
+    seats_parent, rooms_parent = _strip_existing_layout(dst_root)
 
-    new_seats = _clone_into(src_seats, dst_root)
-    new_rooms = _clone_into(src_rooms, dst_root)
+    new_seats = _clone_into(src_seats, seats_parent or dst_root)
+    new_rooms = _clone_into(src_rooms, rooms_parent or dst_root)
 
     parents = {child: parent for parent in dst_root.iter() for child in parent}
     seat_slots = _seat_ids_for(dst_floor.number, dst_floor.clusters)
@@ -194,25 +194,36 @@ def _ensure_dst_writable(dst_floor: Floor, overwrite: bool) -> None:
 # -- tree manipulation ------------------------------------------------------
 
 
-def _strip_existing_layout(root: ET.Element) -> None:
-    """Remove every seat/room from the dst root.
+def _strip_existing_layout(
+    root: ET.Element,
+) -> tuple[ET.Element | None, ET.Element | None]:
+    """Remove every seat/room from the dst root; return their original parents.
 
     Preserves ``<image>``, layer groups, and anything else (so the
-    embedded background and the viewBox stay intact).
+    embedded background and the viewBox stay intact). Returns the
+    parent element of the first seat and first room respectively, so
+    callers can re-parent the copied shapes into the same Inkscape
+    ``<g id="seats">`` / ``<g id="rooms">`` group rather than
+    flattening everything to the SVG root. Qodo PR #57.
     """
     parents = {child: parent for parent in root.iter() for child in parent}
-    for el in _select(root, "rect", "seat") + _select(root, "polygon", "room"):
+    seats = _select(root, "rect", "seat")
+    rooms = _select(root, "polygon", "room")
+    seats_parent = parents.get(seats[0]) if seats else None
+    rooms_parent = parents.get(rooms[0]) if rooms else None
+    for el in seats + rooms:
         parent = parents.get(el)
         if parent is not None:
             parent.remove(el)
+    return seats_parent, rooms_parent
 
 
-def _clone_into(elements: list[ET.Element], dst_root: ET.Element) -> list[ET.Element]:
-    """Deep-copy ``elements`` into ``dst_root``; return the new copies."""
+def _clone_into(elements: list[ET.Element], target: ET.Element) -> list[ET.Element]:
+    """Deep-copy ``elements`` into ``target``; return the new copies."""
     out: list[ET.Element] = []
     for el in elements:
         new_el = _copy.deepcopy(el)
-        dst_root.append(new_el)
+        target.append(new_el)
         out.append(new_el)
     return out
 

--- a/office_cli/floors/_copy_layout.py
+++ b/office_cli/floors/_copy_layout.py
@@ -1,0 +1,239 @@
+"""Copy seats + rooms from one floor SVG into another.
+
+Many floors in a single building share a layout: floor 3 and floor 4
+have the same column grid, the same desk arrangement, the same room
+boundaries. Re-tracing each one in Inkscape is wasteful when we
+already have one clean trace to use as a stencil.
+
+:func:`copy_layout` reads ``src_path``'s ``<rect class="seat">`` and
+``<polygon class="room">`` elements verbatim — preserving every
+``x/y/width/height`` and ``points`` attribute — appends them into
+``dst_path`` (replacing any existing seats/rooms there), then
+renumbers the new ids per ``dst_floor.clusters`` and
+``dst_floor.rooms``. The dst's embedded ``<image>`` background and
+``viewBox`` are preserved unchanged, so the copy lands on top of
+dst's own architectural plan.
+
+Reuses the doctor verb's ``_assign_ids`` / ``_select`` /
+``_capacity_warnings`` / ``_seat_ids_for`` helpers — same renumbering
+contract, just sourcing the elements from another file instead of
+the dst's own pre-existing shapes.
+"""
+
+from __future__ import annotations
+
+import copy as _copy
+from dataclasses import dataclass, field
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+from office_cli.floors._doctor import (
+    _assign_ids,
+    _capacity_warnings,
+    _parse,
+    _seat_ids_for,
+    _select,
+)
+from office_cli.floors._svg import parse_svg
+from office_cli.floors._validate import Severity, validate_floor
+from office_cli.offices._models import Floor
+
+# Match doctor + scaffold: emit `<svg xmlns="...">`, not `<ns0:svg ...>`.
+ET.register_namespace("", "http://www.w3.org/2000/svg")
+
+
+@dataclass(frozen=True)
+class CopyReport:
+    """Outcome of one :func:`copy_layout` invocation."""
+
+    src_floor_id: str
+    dst_floor_id: str
+    src_path: Path
+    dst_path: Path
+    seats_copied: int
+    rooms_copied: int
+    seat_slots: int
+    room_slots: int
+    actions: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "src_floor": self.src_floor_id,
+            "dst_floor": self.dst_floor_id,
+            "src": str(self.src_path),
+            "dst": str(self.dst_path),
+            "seats_copied": self.seats_copied,
+            "rooms_copied": self.rooms_copied,
+            "seat_slots": self.seat_slots,
+            "room_slots": self.room_slots,
+            "actions": list(self.actions),
+            "warnings": list(self.warnings),
+        }
+
+
+def copy_layout(
+    *,
+    src_path: Path,
+    src_floor: Floor,
+    dst_path: Path,
+    dst_floor: Floor,
+    overwrite: bool = False,
+) -> CopyReport:
+    """Stencil src's seats + rooms onto dst, renumbered for dst.
+
+    Refuses to run if:
+
+    - either path is missing on disk;
+    - ``src`` has any validation errors (would propagate garbage);
+    - ``dst`` is not ``status: draft`` and ``overwrite`` is ``False``
+      (defends against clobbering a real trace).
+    """
+    _ensure_files_exist(src_path, dst_path)
+    _ensure_src_clean(src_path, src_floor)
+    _ensure_dst_writable(dst_floor, overwrite)
+
+    src_tree = _parse(src_path)
+    src_root = src_tree.getroot()
+    src_seats = _select(src_root, "rect", "seat")
+    src_rooms = _select(src_root, "polygon", "room")
+
+    dst_tree = _parse(dst_path)
+    dst_root = dst_tree.getroot()
+    _strip_existing_layout(dst_root)
+
+    new_seats = _clone_into(src_seats, dst_root)
+    new_rooms = _clone_into(src_rooms, dst_root)
+
+    parents = {child: parent for parent in dst_root.iter() for child in parent}
+    seat_slots = _seat_ids_for(dst_floor.number, dst_floor.clusters)
+    room_slots = list(dst_floor.rooms.keys())
+    seat_renamed, seat_excess = _assign_ids(new_seats, seat_slots, parents)
+    room_renamed, room_excess = _assign_ids(new_rooms, room_slots, parents)
+
+    actions = _format_actions(
+        src_seat_count=len(src_seats),
+        src_room_count=len(src_rooms),
+        src_floor_id=src_floor.id,
+        seat_renamed=seat_renamed,
+        seat_excess=seat_excess,
+        room_renamed=room_renamed,
+        room_excess=room_excess,
+    )
+    seats_after = min(len(new_seats) - seat_excess, len(seat_slots))
+    rooms_after = min(len(new_rooms) - room_excess, len(room_slots))
+    warnings = _capacity_warnings(seats_after, len(seat_slots), rooms_after, len(room_slots))
+
+    ET.indent(dst_tree, space="  ")
+    dst_tree.write(dst_path, encoding="utf-8", xml_declaration=True)
+
+    return CopyReport(
+        src_floor_id=src_floor.id,
+        dst_floor_id=dst_floor.id,
+        src_path=src_path,
+        dst_path=dst_path,
+        seats_copied=seats_after,
+        rooms_copied=rooms_after,
+        seat_slots=len(seat_slots),
+        room_slots=len(room_slots),
+        actions=actions,
+        warnings=warnings,
+    )
+
+
+# -- guards -----------------------------------------------------------------
+
+
+def _ensure_files_exist(src_path: Path, dst_path: Path) -> None:
+    if not src_path.is_file():
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"src SVG not found: {src_path}",
+            remediation="check the source floor's svg field in offices.yaml",
+        )
+    if not dst_path.is_file():
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"dst SVG not found: {dst_path}",
+            remediation="run `office floors scaffold <id>` first to create the dst",
+        )
+
+
+def _ensure_src_clean(src_path: Path, src_floor: Floor) -> None:
+    src_svg = parse_svg(src_path)
+    issues = validate_floor(src_svg, src_floor)
+    errors = [i for i in issues if i.severity is Severity.ERROR]
+    if errors:
+        rules = ", ".join(sorted({i.rule for i in errors}))
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"src floor {src_floor.id!r} has {len(errors)} validation "
+                f"error(s) ({rules}); refusing to copy a broken layout"
+            ),
+            remediation="fix the source floor first (try office floors doctor)",
+        )
+
+
+def _ensure_dst_writable(dst_floor: Floor, overwrite: bool) -> None:
+    if dst_floor.status != "draft" and not overwrite:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"dst floor {dst_floor.id!r} is status: {dst_floor.status!r}; "
+                "refusing to clobber a non-draft trace"
+            ),
+            remediation=(
+                "pass --overwrite to copy anyway, or change the dst's "
+                "status to draft in offices.yaml"
+            ),
+        )
+
+
+# -- tree manipulation ------------------------------------------------------
+
+
+def _strip_existing_layout(root: ET.Element) -> None:
+    """Remove every seat/room from the dst root.
+
+    Preserves ``<image>``, layer groups, and anything else (so the
+    embedded background and the viewBox stay intact).
+    """
+    parents = {child: parent for parent in root.iter() for child in parent}
+    for el in _select(root, "rect", "seat") + _select(root, "polygon", "room"):
+        parent = parents.get(el)
+        if parent is not None:
+            parent.remove(el)
+
+
+def _clone_into(elements: list[ET.Element], dst_root: ET.Element) -> list[ET.Element]:
+    """Deep-copy ``elements`` into ``dst_root``; return the new copies."""
+    out: list[ET.Element] = []
+    for el in elements:
+        new_el = _copy.deepcopy(el)
+        dst_root.append(new_el)
+        out.append(new_el)
+    return out
+
+
+def _format_actions(
+    *,
+    src_seat_count: int,
+    src_room_count: int,
+    src_floor_id: str,
+    seat_renamed: int,
+    seat_excess: int,
+    room_renamed: int,
+    room_excess: int,
+) -> list[str]:
+    actions = [f"copied {src_seat_count} seats and {src_room_count} rooms from {src_floor_id}"]
+    if seat_renamed:
+        actions.append(f"renumbered {seat_renamed} seats per dst spec")
+    if seat_excess:
+        actions.append(f"dropped {seat_excess} excess seats (over capacity)")
+    if room_renamed:
+        actions.append(f"renumbered {room_renamed} rooms per dst spec")
+    if room_excess:
+        actions.append(f"dropped {room_excess} excess rooms")
+    return actions

--- a/office_cli/offices/__init__.py
+++ b/office_cli/offices/__init__.py
@@ -9,6 +9,7 @@ without leaking tracebacks.
 from __future__ import annotations
 
 from office_cli.offices._models import Cluster, Floor, Office, Room
+from office_cli.offices._writer import append_floor_entry
 from office_cli.offices._yaml import load_offices
 
-__all__ = ["Cluster", "Floor", "Office", "Room", "load_offices"]
+__all__ = ["Cluster", "Floor", "Office", "Room", "append_floor_entry", "load_offices"]

--- a/office_cli/offices/_writer.py
+++ b/office_cli/offices/_writer.py
@@ -267,6 +267,6 @@ def _format_rooms_block(spec: object, nested: str) -> str:
             rtype = str(sub.get("type", "meeting"))
             cap = int(sub.get("capacity", 0))
             out.append(
-                f'{inner}"{room_id}": ' f'{{ name: "{name}", type: {rtype}, capacity: {cap} }}\n'
+                f'{inner}"{room_id}": {{ name: "{name}", type: {rtype}, capacity: {cap} }}\n'
             )
     return "".join(out)

--- a/office_cli/offices/_writer.py
+++ b/office_cli/offices/_writer.py
@@ -43,6 +43,17 @@ def append_floor_entry(
     The function preserves comments, trailing whitespace, and the
     rest of the file.
     """
+    # Defend against path traversal: the helper is only ever called for
+    # ``<data_dir>/data/offices.yaml`` (per `cmd_new` plumbing). Refuse
+    # if the caller passes anything else — keeps Sonar S2083's taint
+    # analysis happy and protects callers from accidentally pointing
+    # the writer at a system file.
+    if yaml_path.name != "offices.yaml":
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"refusing to write a non-offices.yaml file: {yaml_path}",
+            remediation="pass a path whose final component is `offices.yaml`",
+        )
     if not yaml_path.is_file():
         raise OfficeError(
             code=EXIT_USER_ERROR,
@@ -108,7 +119,7 @@ def _ensure_floor_id_unique(office: dict, floor_id: str, office_id: str) -> None
         if isinstance(entry, dict) and str(entry.get("id", "")).strip() == floor_id:
             raise OfficeError(
                 code=EXIT_USER_ERROR,
-                message=(f"floor id {floor_id!r} already declared under office " f"{office_id!r}"),
+                message=f"floor id {floor_id!r} already declared under office {office_id!r}",
                 remediation=(
                     "delete the existing entry first, or pick a different "
                     "floor id (refusing to silently overwrite)"
@@ -180,31 +191,33 @@ def _scan_to_block_end(lines: list[str], floors_line: int, item_prefix: str) -> 
     """Find the byte offset to insert at the end of a YAML list block."""
     last_item_end_line = floors_line  # if floors list is empty, insert right after
     for i in range(floors_line + 1, len(lines)):
-        line = lines[i]
-        if line.strip() == "":
-            continue  # blank lines inside the block are tolerated
-        if line.startswith(item_prefix):
+        if _line_belongs_to_block(lines[i], item_prefix):
             last_item_end_line = i
             continue
-        if line.startswith(item_prefix.rstrip()):
-            last_item_end_line = i
+        if lines[i].strip() == "":
             continue
-        # Continuation of a multi-line item (deeper indent than item_prefix)?
-        if (
-            line[: len(item_prefix)].isspace()
-            and line.lstrip()
-            and not line.startswith(item_prefix)
-        ):
-            # Same column as item_prefix or deeper → still inside the current item.
-            stripped_indent = len(line) - len(line.lstrip())
-            if stripped_indent >= len(item_prefix):
-                last_item_end_line = i
-                continue
         # Anything else = end of the floors list.
         break
-    # Insert at the end of last_item_end_line (after its trailing newline).
-    offset = sum(len(line) for line in lines[: last_item_end_line + 1])
-    return offset
+    return sum(len(line) for line in lines[: last_item_end_line + 1])
+
+
+def _line_belongs_to_block(line: str, item_prefix: str) -> bool:
+    """True if ``line`` is a list item or continuation under ``item_prefix``.
+
+    Matches three shapes: the exact prefix; the rstripped prefix
+    (handles short items like ``- foo``); and any line whose leading
+    whitespace is at least as deep as the prefix (multi-line continuation
+    of the previous item).
+    """
+    if not line.strip():
+        return False
+    if line.startswith(item_prefix) or line.startswith(item_prefix.rstrip()):
+        return True
+    leading = line[: len(item_prefix)]
+    if leading.isspace():
+        stripped_indent = len(line) - len(line.lstrip())
+        return stripped_indent >= len(item_prefix)
+    return False
 
 
 def _format_floor_block(floor: Mapping[str, object]) -> str:

--- a/office_cli/offices/_writer.py
+++ b/office_cli/offices/_writer.py
@@ -22,7 +22,7 @@ import yaml
 
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
 
-_INDENT = "      "  # 6 spaces — list items under offices[].floors
+_DEFAULT_INDENT = "      "  # 6 spaces — list items under offices[].floors
 
 
 def append_floor_entry(
@@ -73,9 +73,10 @@ def append_floor_entry(
     _ensure_floor_id_unique(office, fid, office_id)
 
     # Locate the matching `- id: <office_id>` block and the end of its
-    # `floors:` child list in the source text.
-    insertion_point = _find_insertion_point(text, office_id, yaml_path)
-    new_block = _format_floor_block(floor)
+    # `floors:` child list in the source text. The item indent is
+    # discovered from the file (Qodo PR #57: don't hardcode 6 spaces).
+    insertion_point, item_indent = _find_insertion_point(text, office_id, yaml_path)
+    new_block = _format_floor_block(floor, item_indent=item_indent)
     new_text = text[:insertion_point] + new_block + text[insertion_point:]
     yaml_path.write_text(new_text, encoding="utf-8")
 
@@ -127,27 +128,24 @@ def _ensure_floor_id_unique(office: dict, floor_id: str, office_id: str) -> None
             )
 
 
-def _find_insertion_point(text: str, office_id: str, path: Path) -> int:
-    """Return the byte offset in ``text`` where the new floor entry goes.
+def _find_insertion_point(text: str, office_id: str, path: Path) -> tuple[int, str]:
+    """Return ``(byte_offset, item_indent)`` for the new floor entry.
 
     Walks the source line-by-line:
 
     1. Find ``- id: <office_id>`` (start of the matching office block).
     2. Inside that block, find ``floors:``.
-    3. Scan forward to the last child entry of that floors list (lines
-       starting with the expected indent ``      - ``).
-    4. Insert at the end of that last entry.
-
-    Errors with a clear remediation if the file's indentation doesn't
-    match — let the operator hand-edit rather than guess.
+    3. Scan forward to the last child entry of that floors list.
+    4. Insert at the end of that last entry, and report the indent
+       used by existing list items so the caller can match it.
     """
     lines = text.splitlines(keepends=True)
     office_line, office_indent = _locate_office_block(lines, office_id, path)
     floors_line, floors_indent = _locate_floors_key(
         lines, office_line, office_indent, office_id, path
     )
-    expected_item_prefix = " " * (floors_indent + 2) + "- "
-    return _scan_to_block_end(lines, floors_line, expected_item_prefix)
+    item_indent = " " * (floors_indent + 2)
+    return _scan_to_block_end(lines, floors_line, item_indent + "- "), item_indent
 
 
 def _locate_office_block(lines: list[str], office_id: str, path: Path) -> tuple[int, int]:
@@ -220,41 +218,55 @@ def _line_belongs_to_block(line: str, item_prefix: str) -> bool:
     return False
 
 
-def _format_floor_block(floor: Mapping[str, object]) -> str:
-    """Render a floor mapping as a `      - id: ...\\n        ...` YAML block."""
+def _format_floor_block(floor: Mapping[str, object], item_indent: str = _DEFAULT_INDENT) -> str:
+    """Render a floor mapping as a YAML block matching the file's indent.
+
+    ``item_indent`` is the prefix for the leading ``- id:`` line; nested
+    keys get two additional spaces. Qodo PR #57: don't hardcode the
+    6-space convention — match whatever the existing `floors:` list uses.
+    """
     fid = str(floor["id"]).strip()
     svg = str(floor.get("svg", f"floors/{fid}.svg")).strip()
     status = str(floor.get("status", "draft")).strip()
-    out = [
-        f"{_INDENT}- id: {fid}\n",
-        f"{_INDENT}  svg: {svg}\n",
-        f"{_INDENT}  status: {status}\n",
+    nested = item_indent + "  "
+    parts = [
+        f"{item_indent}- id: {fid}\n",
+        f"{nested}svg: {svg}\n",
+        f"{nested}status: {status}\n",
     ]
-    clusters = floor.get("clusters")
-    if isinstance(clusters, dict) and clusters:
-        out.append(f"{_INDENT}  clusters:\n")
-        for letter in sorted(clusters.keys()):
-            spec = clusters[letter]
-            if isinstance(spec, dict):
-                cap = int(spec.get("capacity", 1))
-                ctype = str(spec.get("type", "open-space"))
-                out.append(f"{_INDENT}    {letter}: {{ capacity: {cap}, type: {ctype} }}\n")
-    else:
-        out.append(f"{_INDENT}  clusters:\n")
-        out.append(f"{_INDENT}    T: {{ capacity: 1, type: open-space }}\n")
-    rooms = floor.get("rooms")
-    if isinstance(rooms, dict) and rooms:
-        out.append(f"{_INDENT}  rooms:\n")
-        for room_id in sorted(rooms.keys()):
-            spec = rooms[room_id]
-            if isinstance(spec, dict):
-                name = str(spec.get("name", room_id))
-                rtype = str(spec.get("type", "meeting"))
-                cap = int(spec.get("capacity", 0))
-                out.append(
-                    f'{_INDENT}    "{room_id}": '
-                    f'{{ name: "{name}", type: {rtype}, capacity: {cap} }}\n'
-                )
-    else:
-        out.append(f"{_INDENT}  rooms: {{}}\n")
+    parts.append(_format_clusters_block(floor.get("clusters"), nested))
+    parts.append(_format_rooms_block(floor.get("rooms"), nested))
+    return "".join(parts)
+
+
+def _format_clusters_block(spec: object, nested: str) -> str:
+    """Render the ``clusters:`` sub-block with one line per cluster."""
+    inner = nested + "  "
+    if not (isinstance(spec, dict) and spec):
+        return f"{nested}clusters:\n{inner}T: {{ capacity: 1, type: open-space }}\n"
+    out = [f"{nested}clusters:\n"]
+    for letter in sorted(spec.keys()):
+        sub = spec[letter]
+        if isinstance(sub, dict):
+            cap = int(sub.get("capacity", 1))
+            ctype = str(sub.get("type", "open-space"))
+            out.append(f"{inner}{letter}: {{ capacity: {cap}, type: {ctype} }}\n")
+    return "".join(out)
+
+
+def _format_rooms_block(spec: object, nested: str) -> str:
+    """Render the ``rooms:`` sub-block; empty dict if no rooms declared."""
+    inner = nested + "  "
+    if not (isinstance(spec, dict) and spec):
+        return f"{nested}rooms: {{}}\n"
+    out = [f"{nested}rooms:\n"]
+    for room_id in sorted(spec.keys()):
+        sub = spec[room_id]
+        if isinstance(sub, dict):
+            name = str(sub.get("name", room_id))
+            rtype = str(sub.get("type", "meeting"))
+            cap = int(sub.get("capacity", 0))
+            out.append(
+                f'{inner}"{room_id}": ' f'{{ name: "{name}", type: {rtype}, capacity: {cap} }}\n'
+            )
     return "".join(out)

--- a/office_cli/offices/_writer.py
+++ b/office_cli/offices/_writer.py
@@ -1,0 +1,247 @@
+"""Append a new floor entry to ``data/offices.yaml`` without rewriting the file.
+
+PyYAML's :func:`yaml.safe_dump` strips comments and reorders fields,
+which would mangle the carefully-commented ``data/offices.yaml``. This
+module instead does a **textual splice**: parse the file once with
+PyYAML to validate structure, locate the target office's ``floors:``
+list in the source text, and insert a new entry while preserving
+everything else byte-for-byte.
+
+The verb ``office floors new`` (issue #54 follow-up) calls
+:func:`append_floor_entry` to add a draft floor without operators
+having to hand-edit the YAML.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Mapping
+
+import yaml
+
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+
+_INDENT = "      "  # 6 spaces — list items under offices[].floors
+
+
+def append_floor_entry(
+    yaml_path: Path,
+    office_id: str,
+    floor: Mapping[str, object],
+) -> None:
+    """Append a floor entry under ``offices[id=office_id].floors``.
+
+    ``floor`` is a mapping with at least ``id`` and ``svg`` keys, plus
+    optional ``status``, ``clusters``, ``rooms``. Validation rules:
+
+    - ``yaml_path`` must be valid YAML and have a top-level
+      ``offices:`` list.
+    - ``office_id`` must match an existing office.
+    - ``floor['id']`` must not already be declared under that office.
+
+    The function preserves comments, trailing whitespace, and the
+    rest of the file.
+    """
+    if not yaml_path.is_file():
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"offices.yaml not found: {yaml_path}",
+            remediation="check the --data-dir or run from the repo root",
+        )
+    fid = str(floor.get("id", "")).strip()
+    if not fid:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="floor entry is missing `id`",
+            remediation="pass a floor dict with at least `id` and `svg`",
+        )
+    text = yaml_path.read_text(encoding="utf-8")
+    parsed = _parse_offices(text, yaml_path)
+    office = _find_office(parsed, office_id, yaml_path)
+    _ensure_floor_id_unique(office, fid, office_id)
+
+    # Locate the matching `- id: <office_id>` block and the end of its
+    # `floors:` child list in the source text.
+    insertion_point = _find_insertion_point(text, office_id, yaml_path)
+    new_block = _format_floor_block(floor)
+    new_text = text[:insertion_point] + new_block + text[insertion_point:]
+    yaml_path.write_text(new_text, encoding="utf-8")
+
+
+def _parse_offices(text: str, path: Path) -> list[dict]:
+    try:
+        raw = yaml.safe_load(text) or {}
+    except yaml.YAMLError as err:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"offices.yaml is not valid YAML: {path}: {err}",
+            remediation="fix the syntax error and rerun",
+        ) from err
+    offices = raw.get("offices") if isinstance(raw, dict) else None
+    if not isinstance(offices, list):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"offices.yaml is missing top-level `offices:` list: {path}",
+            remediation="see data/offices.yaml.example for the expected shape",
+        )
+    return offices
+
+
+def _find_office(offices: list[dict], office_id: str, path: Path) -> dict:
+    for entry in offices:
+        if isinstance(entry, dict) and str(entry.get("id", "")).strip() == office_id:
+            return entry
+    known = ", ".join(sorted(str(e.get("id", "")) for e in offices if isinstance(e, dict)))
+    raise OfficeError(
+        code=EXIT_USER_ERROR,
+        message=f"unknown office {office_id!r} in {path}",
+        remediation=f"known offices: {known or '(none)'}",
+    )
+
+
+def _ensure_floor_id_unique(office: dict, floor_id: str, office_id: str) -> None:
+    floors = office.get("floors") or []
+    if not isinstance(floors, list):
+        return
+    for entry in floors:
+        if isinstance(entry, dict) and str(entry.get("id", "")).strip() == floor_id:
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=(f"floor id {floor_id!r} already declared under office " f"{office_id!r}"),
+                remediation=(
+                    "delete the existing entry first, or pick a different "
+                    "floor id (refusing to silently overwrite)"
+                ),
+            )
+
+
+def _find_insertion_point(text: str, office_id: str, path: Path) -> int:
+    """Return the byte offset in ``text`` where the new floor entry goes.
+
+    Walks the source line-by-line:
+
+    1. Find ``- id: <office_id>`` (start of the matching office block).
+    2. Inside that block, find ``floors:``.
+    3. Scan forward to the last child entry of that floors list (lines
+       starting with the expected indent ``      - ``).
+    4. Insert at the end of that last entry.
+
+    Errors with a clear remediation if the file's indentation doesn't
+    match — let the operator hand-edit rather than guess.
+    """
+    lines = text.splitlines(keepends=True)
+    office_line, office_indent = _locate_office_block(lines, office_id, path)
+    floors_line, floors_indent = _locate_floors_key(
+        lines, office_line, office_indent, office_id, path
+    )
+    expected_item_prefix = " " * (floors_indent + 2) + "- "
+    return _scan_to_block_end(lines, floors_line, expected_item_prefix)
+
+
+def _locate_office_block(lines: list[str], office_id: str, path: Path) -> tuple[int, int]:
+    needle = re.compile(r"^(\s*)- id:\s*" + re.escape(office_id) + r"\s*$")
+    for i, line in enumerate(lines):
+        m = needle.match(line)
+        if m:
+            return i, len(m.group(1))
+    raise OfficeError(
+        code=EXIT_USER_ERROR,
+        message=(
+            f"could not locate the `- id: {office_id}` line in {path}; " "structure is unusual"
+        ),
+        remediation="hand-edit data/offices.yaml or simplify its layout",
+    )
+
+
+def _locate_floors_key(
+    lines: list[str], start: int, office_indent: int, office_id: str, path: Path
+) -> tuple[int, int]:
+    inner_indent = office_indent + 2  # `- ` makes children indent 2 deeper
+    pattern = re.compile(r"^" + " " * inner_indent + r"floors:\s*$")
+    for i in range(start + 1, len(lines)):
+        line = lines[i]
+        if pattern.match(line):
+            return i, inner_indent
+        # If we hit another office at the same depth, give up.
+        if re.match(r"^" + " " * office_indent + r"- id:", line):
+            break
+    raise OfficeError(
+        code=EXIT_USER_ERROR,
+        message=(
+            f"office {office_id!r} has no `floors:` block in {path}; "
+            "add an empty `floors:` line first"
+        ),
+        remediation="hand-edit offices.yaml to declare `floors:`",
+    )
+
+
+def _scan_to_block_end(lines: list[str], floors_line: int, item_prefix: str) -> int:
+    """Find the byte offset to insert at the end of a YAML list block."""
+    last_item_end_line = floors_line  # if floors list is empty, insert right after
+    for i in range(floors_line + 1, len(lines)):
+        line = lines[i]
+        if line.strip() == "":
+            continue  # blank lines inside the block are tolerated
+        if line.startswith(item_prefix):
+            last_item_end_line = i
+            continue
+        if line.startswith(item_prefix.rstrip()):
+            last_item_end_line = i
+            continue
+        # Continuation of a multi-line item (deeper indent than item_prefix)?
+        if (
+            line[: len(item_prefix)].isspace()
+            and line.lstrip()
+            and not line.startswith(item_prefix)
+        ):
+            # Same column as item_prefix or deeper → still inside the current item.
+            stripped_indent = len(line) - len(line.lstrip())
+            if stripped_indent >= len(item_prefix):
+                last_item_end_line = i
+                continue
+        # Anything else = end of the floors list.
+        break
+    # Insert at the end of last_item_end_line (after its trailing newline).
+    offset = sum(len(line) for line in lines[: last_item_end_line + 1])
+    return offset
+
+
+def _format_floor_block(floor: Mapping[str, object]) -> str:
+    """Render a floor mapping as a `      - id: ...\\n        ...` YAML block."""
+    fid = str(floor["id"]).strip()
+    svg = str(floor.get("svg", f"floors/{fid}.svg")).strip()
+    status = str(floor.get("status", "draft")).strip()
+    out = [
+        f"{_INDENT}- id: {fid}\n",
+        f"{_INDENT}  svg: {svg}\n",
+        f"{_INDENT}  status: {status}\n",
+    ]
+    clusters = floor.get("clusters")
+    if isinstance(clusters, dict) and clusters:
+        out.append(f"{_INDENT}  clusters:\n")
+        for letter in sorted(clusters.keys()):
+            spec = clusters[letter]
+            if isinstance(spec, dict):
+                cap = int(spec.get("capacity", 1))
+                ctype = str(spec.get("type", "open-space"))
+                out.append(f"{_INDENT}    {letter}: {{ capacity: {cap}, type: {ctype} }}\n")
+    else:
+        out.append(f"{_INDENT}  clusters:\n")
+        out.append(f"{_INDENT}    T: {{ capacity: 1, type: open-space }}\n")
+    rooms = floor.get("rooms")
+    if isinstance(rooms, dict) and rooms:
+        out.append(f"{_INDENT}  rooms:\n")
+        for room_id in sorted(rooms.keys()):
+            spec = rooms[room_id]
+            if isinstance(spec, dict):
+                name = str(spec.get("name", room_id))
+                rtype = str(spec.get("type", "meeting"))
+                cap = int(spec.get("capacity", 0))
+                out.append(
+                    f'{_INDENT}    "{room_id}": '
+                    f'{{ name: "{name}", type: {rtype}, capacity: {cap} }}\n'
+                )
+    else:
+        out.append(f"{_INDENT}  rooms: {{}}\n")
+    return "".join(out)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.12.0"
+version = "0.13.0"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_floors.py
+++ b/tests/test_cli_floors.py
@@ -663,3 +663,187 @@ def test_floors_scaffold_manifest_atomicity(
     assert rc != 0
     # The valid entry must NOT have been written:
     assert (data_dir / "floors" / "tlv-floor-5.svg").read_bytes() == floor5_before
+
+
+def test_floors_copy_layout_happy_path(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Add a draft tlv-floor-3 in offices.yaml + an empty scaffold-shaped
+    SVG, then copy floor-5's layout into it."""
+    from office_cli.offices import append_floor_entry
+
+    # Append a draft floor-3 with the same cluster spec as floor-5.
+    append_floor_entry(
+        data_dir / "data" / "offices.yaml",
+        "tlv",
+        {
+            "id": "tlv-floor-3",
+            "svg": "floors/tlv-floor-3.svg",
+            "clusters": {
+                "T": {"capacity": 6, "type": "open-space"},
+                "Z": {"capacity": 2, "type": "phone-room"},
+            },
+            "rooms": {
+                "3.10": {"name": "Conf 3.10", "type": "meeting", "capacity": 8},
+            },
+        },
+    )
+    (data_dir / "floors" / "tlv-floor-3.svg").write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">\n'
+        '<image x="0" y="0" width="1920" height="1080" href="data:image/png;base64,X"/>\n'
+        '<rect id="3-T-01" class="seat" x="100" y="100" width="51" height="25"/>\n'
+        '<polygon id="placeholder" class="room" points="200,200 260,200 260,240 200,240"/>\n'
+        "</svg>\n",
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "floors",
+            "copy-layout",
+            "tlv-floor-5",
+            "tlv-floor-3",
+            "--json",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["src_floor"] == "tlv-floor-5"
+    assert payload["dst_floor"] == "tlv-floor-3"
+    assert payload["seats_copied"] == 8
+
+
+def test_floors_copy_layout_refuses_active_dst(
+    data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """floor-5 in the fixture is status: active. Copying onto it
+    without --overwrite must fail."""
+    from office_cli.offices import append_floor_entry
+
+    # Add an active second floor we'll use as src.
+    append_floor_entry(
+        data_dir / "data" / "offices.yaml",
+        "tlv",
+        {
+            "id": "tlv-floor-99",
+            "svg": "floors/tlv-floor-99.svg",
+            "status": "active",
+            "clusters": {"T": {"capacity": 6, "type": "open-space"}},
+            "rooms": {},
+        },
+    )
+    (data_dir / "floors" / "tlv-floor-99.svg").write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">\n'
+        '<rect id="99-T-01" class="seat" x="100" y="100" width="51" height="25"/>\n'
+        "</svg>\n",
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "floors",
+            "copy-layout",
+            "tlv-floor-5",
+            "tlv-floor-99",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "refusing to clobber" in err
+
+
+def test_floors_new_with_copy_from(
+    data_dir: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`floors new --copy-from` runs the full chain: append YAML,
+    scaffold, copy layout. The result must validate clean."""
+    from office_cli.floors import _scaffold as scaffold_mod
+
+    monkeypatch.setattr(scaffold_mod, "_render_pdf_page", lambda *a, **kw: b"\x89PNG")
+
+    pdf = data_dir / "fake.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+
+    rc = main(
+        [
+            "floors",
+            "new",
+            "tlv-floor-3",
+            "--pdf",
+            str(pdf),
+            "--page",
+            "1",
+            "--copy-from",
+            "tlv-floor-5",
+            "--json",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["floor"] == "tlv-floor-3"
+    assert payload["office"] == "tlv"
+    # 8 seats + 1 room from floor-5 carried over → no errors.
+    assert payload["errors"] == []
+    # offices.yaml updated.
+    yaml_text = (data_dir / "data" / "offices.yaml").read_text(encoding="utf-8")
+    assert "tlv-floor-3" in yaml_text
+    # SVG written.
+    assert (data_dir / "floors" / "tlv-floor-3.svg").is_file()
+
+
+def test_floors_new_without_copy_from_uses_placeholder_cluster(
+    data_dir: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without --copy-from, the new floor gets a placeholder T:1 cluster."""
+    from office_cli.floors import _scaffold as scaffold_mod
+
+    monkeypatch.setattr(scaffold_mod, "_render_pdf_page", lambda *a, **kw: b"\x89PNG")
+    pdf = data_dir / "fake.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+
+    rc = main(
+        [
+            "floors",
+            "new",
+            "tlv-floor-3",
+            "--pdf",
+            str(pdf),
+            "--page",
+            "1",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc == 0
+    yaml_text = (data_dir / "data" / "offices.yaml").read_text(encoding="utf-8")
+    assert "tlv-floor-3" in yaml_text
+    assert "T: { capacity: 1" in yaml_text
+
+
+def test_floors_new_refuses_existing_floor_id(
+    data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pdf = data_dir / "fake.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    rc = main(
+        [
+            "floors",
+            "new",
+            "tlv-floor-5",  # already exists
+            "--pdf",
+            str(pdf),
+            "--page",
+            "1",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "already declared" in err

--- a/tests/test_floors_copy_layout.py
+++ b/tests/test_floors_copy_layout.py
@@ -1,0 +1,288 @@
+"""Tests for ``office_cli.floors.copy_layout`` (the pure module)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+from office_cli.floors import copy_layout, parse_svg
+from office_cli.offices._models import Cluster, Floor, Room
+
+
+def _src_svg() -> str:
+    """A clean floor-5 stencil: 6 T-cluster seats + 2 Z-cluster seats + 1 room."""
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">\n'
+        # Six T seats arranged in two rows.
+        '<rect id="5-T-01" class="seat" x="100" y="100" width="51" height="25"/>\n'
+        '<rect id="5-T-02" class="seat" x="160" y="100" width="51" height="25"/>\n'
+        '<rect id="5-T-03" class="seat" x="220" y="100" width="51" height="25"/>\n'
+        '<rect id="5-T-04" class="seat" x="100" y="200" width="51" height="25"/>\n'
+        '<rect id="5-T-05" class="seat" x="160" y="200" width="51" height="25"/>\n'
+        '<rect id="5-T-06" class="seat" x="220" y="200" width="51" height="25"/>\n'
+        # Two Z phone-room seats.
+        '<rect id="5-Z-01" class="seat" x="500" y="500" width="51" height="25"/>\n'
+        '<rect id="5-Z-02" class="seat" x="560" y="500" width="51" height="25"/>\n'
+        # One named room.
+        '<polygon id="5.18" class="room" points="800,300 1000,300 1000,500 800,500"/>\n'
+        "</svg>\n"
+    )
+
+
+def _dst_scaffold(floor_num: str = "3") -> str:
+    """A scaffold-shaped SVG: embedded background + 1 example seat + 1 example room."""
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080"'
+        ' width="1920" height="1080">\n'
+        # Background image (preserved across copy).
+        '<image x="0" y="0" width="1920" height="1080" href="data:image/png;base64,FAKE"/>\n'
+        # Example placeholders (should be replaced).
+        f'<rect id="{floor_num}-T-01" class="seat" x="100" y="100" width="51" height="25"/>\n'
+        '<polygon id="placeholder-room" class="room" points="200,200 260,200 260,240 200,240"/>\n'
+        "</svg>\n"
+    )
+
+
+def _src_floor() -> Floor:
+    return Floor(
+        id="tlv-floor-5",
+        svg=Path("/dev/null"),
+        clusters={
+            "T": Cluster(letter="T", capacity=6),
+            "Z": Cluster(letter="Z", capacity=2, type="phone-room"),
+        },
+        rooms={"5.18": Room(id="5.18", name="MR")},
+        status="active",
+    )
+
+
+def _dst_floor(status: str = "draft") -> Floor:
+    return Floor(
+        id="tlv-floor-3",
+        svg=Path("/dev/null"),
+        clusters={
+            "T": Cluster(letter="T", capacity=6),
+            "Z": Cluster(letter="Z", capacity=2, type="phone-room"),
+        },
+        rooms={"3.10": Room(id="3.10", name="Conf 3.10")},
+        status=status,
+    )
+
+
+def test_copy_layout_renumbers_per_dst_spec(tmp_path: Path) -> None:
+    src = tmp_path / "src.svg"
+    src.write_text(_src_svg(), encoding="utf-8")
+    dst = tmp_path / "dst.svg"
+    dst.write_text(_dst_scaffold(), encoding="utf-8")
+
+    report = copy_layout(
+        src_path=src,
+        src_floor=_src_floor(),
+        dst_path=dst,
+        dst_floor=_dst_floor(),
+    )
+
+    assert report.seats_copied == 8  # 6 T + 2 Z
+    assert report.rooms_copied == 1
+    parsed = parse_svg(dst)
+    assert sorted(parsed.seat_ids) == [
+        "3-T-01",
+        "3-T-02",
+        "3-T-03",
+        "3-T-04",
+        "3-T-05",
+        "3-T-06",
+        "3-Z-01",
+        "3-Z-02",
+    ]
+    assert sorted(parsed.room_ids) == ["3.10"]
+
+
+def test_copy_layout_preserves_dst_background(tmp_path: Path) -> None:
+    """The embedded ``<image>`` must survive the copy untouched."""
+    src = tmp_path / "src.svg"
+    src.write_text(_src_svg(), encoding="utf-8")
+    dst = tmp_path / "dst.svg"
+    dst.write_text(_dst_scaffold(), encoding="utf-8")
+
+    copy_layout(
+        src_path=src,
+        src_floor=_src_floor(),
+        dst_path=dst,
+        dst_floor=_dst_floor(),
+    )
+
+    written = dst.read_text(encoding="utf-8")
+    assert 'href="data:image/png;base64,FAKE"' in written
+
+
+def test_copy_layout_preserves_seat_geometry(tmp_path: Path) -> None:
+    """Seat ``x/y/w/h`` come over verbatim — only the id changes."""
+    src = tmp_path / "src.svg"
+    src.write_text(_src_svg(), encoding="utf-8")
+    dst = tmp_path / "dst.svg"
+    dst.write_text(_dst_scaffold(), encoding="utf-8")
+
+    copy_layout(
+        src_path=src,
+        src_floor=_src_floor(),
+        dst_path=dst,
+        dst_floor=_dst_floor(),
+    )
+
+    written = dst.read_text(encoding="utf-8")
+    # First src seat was at (100, 100); after spatial sort + reassign it
+    # becomes 3-T-01 at the same x/y.
+    assert 'id="3-T-01"' in written
+    assert 'x="100"' in written
+    assert 'y="100"' in written
+
+
+def test_copy_layout_emits_browser_compatible_root(tmp_path: Path) -> None:
+    """No <ns0:svg> regression — same constraint as doctor + scaffold."""
+    src = tmp_path / "src.svg"
+    src.write_text(_src_svg(), encoding="utf-8")
+    dst = tmp_path / "dst.svg"
+    dst.write_text(_dst_scaffold(), encoding="utf-8")
+
+    copy_layout(
+        src_path=src,
+        src_floor=_src_floor(),
+        dst_path=dst,
+        dst_floor=_dst_floor(),
+    )
+
+    written = dst.read_text(encoding="utf-8")
+    assert "<ns0:svg" not in written
+    assert "<svg " in written
+
+
+def test_copy_layout_drops_existing_dst_seats(tmp_path: Path) -> None:
+    """The dst's example placeholders must be gone after the copy."""
+    src = tmp_path / "src.svg"
+    src.write_text(_src_svg(), encoding="utf-8")
+    dst = tmp_path / "dst.svg"
+    dst.write_text(_dst_scaffold(), encoding="utf-8")
+
+    copy_layout(
+        src_path=src,
+        src_floor=_src_floor(),
+        dst_path=dst,
+        dst_floor=_dst_floor(),
+    )
+
+    parsed = parse_svg(dst)
+    # `placeholder-room` from the scaffold must NOT survive — the room
+    # got either renamed (to 3.10) or dropped.
+    assert "placeholder-room" not in parsed.room_ids
+
+
+def test_copy_layout_capacity_warning_when_dst_smaller(tmp_path: Path) -> None:
+    """Dst declares fewer seats than src has → excess dropped + warning."""
+    src = tmp_path / "src.svg"
+    src.write_text(_src_svg(), encoding="utf-8")
+    dst = tmp_path / "dst.svg"
+    dst.write_text(_dst_scaffold(), encoding="utf-8")
+
+    small_dst = Floor(
+        id="tlv-floor-3",
+        svg=Path("/dev/null"),
+        clusters={"T": Cluster(letter="T", capacity=2)},
+        rooms={},
+        status="draft",
+    )
+    report = copy_layout(
+        src_path=src,
+        src_floor=_src_floor(),
+        dst_path=dst,
+        dst_floor=small_dst,
+    )
+
+    # 8 seats from src, dst has T:2 = 2 slots → 6 dropped
+    assert report.seats_copied == 2
+    assert any("dropped 6 excess seats" in a for a in report.actions)
+
+
+def test_copy_layout_refuses_active_dst_without_overwrite(tmp_path: Path) -> None:
+    src = tmp_path / "src.svg"
+    src.write_text(_src_svg(), encoding="utf-8")
+    dst = tmp_path / "dst.svg"
+    dst.write_text(_dst_scaffold(), encoding="utf-8")
+
+    with pytest.raises(OfficeError) as exc:
+        copy_layout(
+            src_path=src,
+            src_floor=_src_floor(),
+            dst_path=dst,
+            dst_floor=_dst_floor(status="active"),
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "refusing to clobber" in exc.value.message
+
+
+def test_copy_layout_overwrite_flag_allows_active_dst(tmp_path: Path) -> None:
+    src = tmp_path / "src.svg"
+    src.write_text(_src_svg(), encoding="utf-8")
+    dst = tmp_path / "dst.svg"
+    dst.write_text(_dst_scaffold(), encoding="utf-8")
+
+    report = copy_layout(
+        src_path=src,
+        src_floor=_src_floor(),
+        dst_path=dst,
+        dst_floor=_dst_floor(status="active"),
+        overwrite=True,
+    )
+    assert report.seats_copied == 8
+
+
+def test_copy_layout_refuses_src_with_validation_errors(tmp_path: Path) -> None:
+    """Don't propagate broken layouts."""
+    bad_src = tmp_path / "src.svg"
+    bad_src.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">\n'
+        # Garbled id — will fail seat-id-format
+        '<rect id="garbage-seat" class="seat" x="100" y="100" width="51" height="25"/>\n'
+        "</svg>\n",
+        encoding="utf-8",
+    )
+    dst = tmp_path / "dst.svg"
+    dst.write_text(_dst_scaffold(), encoding="utf-8")
+
+    with pytest.raises(OfficeError) as exc:
+        copy_layout(
+            src_path=bad_src,
+            src_floor=_src_floor(),
+            dst_path=dst,
+            dst_floor=_dst_floor(),
+        )
+    assert "validation" in exc.value.message
+
+
+def test_copy_layout_missing_paths_raise(tmp_path: Path) -> None:
+    bogus = tmp_path / "missing.svg"
+    real = tmp_path / "real.svg"
+    real.write_text(_src_svg(), encoding="utf-8")
+
+    with pytest.raises(OfficeError) as exc1:
+        copy_layout(
+            src_path=bogus,
+            src_floor=_src_floor(),
+            dst_path=real,
+            dst_floor=_dst_floor(),
+        )
+    assert "src SVG not found" in exc1.value.message
+
+    with pytest.raises(OfficeError) as exc2:
+        copy_layout(
+            src_path=real,
+            src_floor=_src_floor(),
+            dst_path=bogus,
+            dst_floor=_dst_floor(),
+        )
+    assert "dst SVG not found" in exc2.value.message

--- a/tests/test_offices_writer.py
+++ b/tests/test_offices_writer.py
@@ -132,10 +132,23 @@ def test_append_refuses_missing_id(tmp_path: Path) -> None:
 
 
 def test_append_refuses_missing_file(tmp_path: Path) -> None:
-    bogus = tmp_path / "no-such.yaml"
+    bogus = tmp_path / "data" / "offices.yaml"
     with pytest.raises(OfficeError) as exc:
         append_floor_entry(bogus, "tlv", {"id": "x", "svg": "y.svg"})
     assert "not found" in exc.value.message
+
+
+def test_append_refuses_non_offices_yaml_filename(tmp_path: Path) -> None:
+    """Sonar PR #57 review (S2083): the path must end with
+    `offices.yaml`. Defends against the writer being pointed at a
+    system file via a mis-set --data-dir."""
+    danger = tmp_path / "passwd"
+    danger.write_text("not yaml", encoding="utf-8")
+    with pytest.raises(OfficeError) as exc:
+        append_floor_entry(danger, "tlv", {"id": "x", "svg": "y.svg"})
+    assert "non-offices.yaml" in exc.value.message
+    # File untouched.
+    assert danger.read_text(encoding="utf-8") == "not yaml"
 
 
 def test_append_refuses_malformed_yaml(tmp_path: Path) -> None:
@@ -178,7 +191,7 @@ def test_append_drops_into_empty_floors_list(tmp_path: Path) -> None:
     yaml_path = tmp_path / "data" / "offices.yaml"
     yaml_path.parent.mkdir(parents=True)
     yaml_path.write_text(
-        "offices:\n" "  - id: tlv\n" '    name: "Tel Aviv"\n' "    floors:\n",
+        'offices:\n  - id: tlv\n    name: "Tel Aviv"\n    floors:\n',
         encoding="utf-8",
     )
     append_floor_entry(

--- a/tests/test_offices_writer.py
+++ b/tests/test_offices_writer.py
@@ -1,0 +1,190 @@
+"""Tests for ``append_floor_entry`` (the textual YAML splice)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
+from office_cli.offices import append_floor_entry, load_offices
+
+_TWO_OFFICE_YAML = """\
+# This top-level comment must survive any append.
+
+# Stage 7 — SSO + roles. Comment block to preserve.
+
+offices:
+  - id: tlv
+    name: "Tel Aviv"
+    address: "Tel Aviv, Israel"
+    floors:
+      - id: tlv-floor-5
+        svg: floors/tlv-floor-5.svg
+        status: active
+        clusters:
+          T: { capacity: 6, type: open-space }
+        rooms:
+          "5.18": { name: "Conf 5.18", type: meeting, capacity: 8 }
+  - id: nyc
+    name: "New York"
+    floors:
+      - id: nyc-floor-12
+        svg: floors/nyc-floor-12.svg
+        status: active
+        clusters:
+          A: { capacity: 4, type: open-space }
+        rooms: {}
+"""
+
+
+def _write(tmp_path: Path) -> Path:
+    yaml_path = tmp_path / "data" / "offices.yaml"
+    yaml_path.parent.mkdir(parents=True)
+    yaml_path.write_text(_TWO_OFFICE_YAML, encoding="utf-8")
+    return yaml_path
+
+
+def test_append_appends_under_correct_office(tmp_path: Path) -> None:
+    yaml_path = _write(tmp_path)
+    append_floor_entry(
+        yaml_path,
+        "tlv",
+        {
+            "id": "tlv-floor-3",
+            "svg": "floors/tlv-floor-3.svg",
+            "clusters": {"T": {"capacity": 6, "type": "open-space"}},
+            "rooms": {},
+        },
+    )
+    offices = load_offices(tmp_path)
+    floors = offices["tlv"].floors
+    assert "tlv-floor-3" in floors
+    assert "tlv-floor-5" in floors
+    assert floors["tlv-floor-3"].status == "draft"
+    assert floors["tlv-floor-3"].clusters["T"].capacity == 6
+    # NYC untouched.
+    assert list(offices["nyc"].floors) == ["nyc-floor-12"]
+
+
+def test_append_preserves_top_level_comments(tmp_path: Path) -> None:
+    yaml_path = _write(tmp_path)
+    append_floor_entry(
+        yaml_path,
+        "tlv",
+        {"id": "tlv-floor-7", "svg": "floors/tlv-floor-7.svg"},
+    )
+    text = yaml_path.read_text(encoding="utf-8")
+    assert "# This top-level comment must survive any append." in text
+    assert "# Stage 7 — SSO + roles." in text
+
+
+def test_append_preserves_existing_floor_block(tmp_path: Path) -> None:
+    """All lines from the original file must survive (they may be
+    bisected by the new entry, but each line still appears in order)."""
+    yaml_path = _write(tmp_path)
+    before = yaml_path.read_text(encoding="utf-8")
+    append_floor_entry(
+        yaml_path,
+        "tlv",
+        {"id": "tlv-floor-7", "svg": "floors/tlv-floor-7.svg"},
+    )
+    after = yaml_path.read_text(encoding="utf-8")
+    # Every original line still appears (in original order — no reorder).
+    for line in before.splitlines():
+        assert line in after
+    # New entry landed.
+    assert "tlv-floor-7" in after
+    # And the new entry is under the tlv block, not nyc — it appears
+    # before `- id: nyc` in the file.
+    assert after.index("tlv-floor-7") < after.index("- id: nyc")
+
+
+def test_append_refuses_duplicate_floor_id(tmp_path: Path) -> None:
+    yaml_path = _write(tmp_path)
+    with pytest.raises(OfficeError) as exc:
+        append_floor_entry(
+            yaml_path,
+            "tlv",
+            {"id": "tlv-floor-5", "svg": "floors/tlv-floor-5.svg"},
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "already declared" in exc.value.message
+
+
+def test_append_refuses_unknown_office(tmp_path: Path) -> None:
+    yaml_path = _write(tmp_path)
+    with pytest.raises(OfficeError) as exc:
+        append_floor_entry(
+            yaml_path,
+            "no-such",
+            {"id": "no-floor", "svg": "floors/no.svg"},
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "unknown office" in exc.value.message
+
+
+def test_append_refuses_missing_id(tmp_path: Path) -> None:
+    yaml_path = _write(tmp_path)
+    with pytest.raises(OfficeError) as exc:
+        append_floor_entry(yaml_path, "tlv", {"svg": "floors/x.svg"})
+    assert "missing `id`" in exc.value.message
+
+
+def test_append_refuses_missing_file(tmp_path: Path) -> None:
+    bogus = tmp_path / "no-such.yaml"
+    with pytest.raises(OfficeError) as exc:
+        append_floor_entry(bogus, "tlv", {"id": "x", "svg": "y.svg"})
+    assert "not found" in exc.value.message
+
+
+def test_append_refuses_malformed_yaml(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "data" / "offices.yaml"
+    yaml_path.parent.mkdir(parents=True)
+    yaml_path.write_text("offices: not: valid: yaml: : :\n  - [\n", encoding="utf-8")
+    with pytest.raises(OfficeError) as exc:
+        append_floor_entry(yaml_path, "tlv", {"id": "x", "svg": "y.svg"})
+    assert "not valid YAML" in exc.value.message
+
+
+def test_append_inherited_clusters_and_rooms(tmp_path: Path) -> None:
+    """A new floor may carry the full cluster + room spec inherited
+    from a `--copy-from` source."""
+    yaml_path = _write(tmp_path)
+    append_floor_entry(
+        yaml_path,
+        "tlv",
+        {
+            "id": "tlv-floor-3",
+            "svg": "floors/tlv-floor-3.svg",
+            "clusters": {
+                "T": {"capacity": 6, "type": "open-space"},
+                "Z": {"capacity": 2, "type": "phone-room"},
+            },
+            "rooms": {
+                "3.10": {"name": "Conf 3.10", "type": "meeting", "capacity": 8},
+            },
+        },
+    )
+    offices = load_offices(tmp_path)
+    floor = offices["tlv"].floors["tlv-floor-3"]
+    assert sorted(floor.clusters.keys()) == ["T", "Z"]
+    assert floor.clusters["Z"].capacity == 2
+    assert floor.rooms["3.10"].name == "Conf 3.10"
+
+
+def test_append_drops_into_empty_floors_list(tmp_path: Path) -> None:
+    """If an office declares `floors: []`, the append still works."""
+    yaml_path = tmp_path / "data" / "offices.yaml"
+    yaml_path.parent.mkdir(parents=True)
+    yaml_path.write_text(
+        "offices:\n" "  - id: tlv\n" '    name: "Tel Aviv"\n' "    floors:\n",
+        encoding="utf-8",
+    )
+    append_floor_entry(
+        yaml_path,
+        "tlv",
+        {"id": "tlv-floor-1", "svg": "floors/tlv-floor-1.svg"},
+    )
+    offices = load_offices(tmp_path)
+    assert "tlv-floor-1" in offices["tlv"].floors

--- a/tests/test_offices_writer.py
+++ b/tests/test_offices_writer.py
@@ -201,3 +201,36 @@ def test_append_drops_into_empty_floors_list(tmp_path: Path) -> None:
     )
     offices = load_offices(tmp_path)
     assert "tlv-floor-1" in offices["tlv"].floors
+
+
+def test_append_matches_existing_indentation(tmp_path: Path) -> None:
+    """Qodo PR #57 review: writer must use the file's existing list-item
+    indentation, not a hardcoded 6 spaces."""
+    yaml_path = tmp_path / "data" / "offices.yaml"
+    yaml_path.parent.mkdir(parents=True)
+    # 2-space-deeper indentation (8 spaces for floor items).
+    yaml_path.write_text(
+        "offices:\n"
+        "    - id: tlv\n"
+        '      name: "Tel Aviv"\n'
+        "      floors:\n"
+        "        - id: tlv-floor-5\n"
+        "          svg: floors/tlv-floor-5.svg\n"
+        "          status: active\n"
+        "          clusters:\n"
+        "            T: { capacity: 1, type: open-space }\n"
+        "          rooms: {}\n",
+        encoding="utf-8",
+    )
+    append_floor_entry(
+        yaml_path,
+        "tlv",
+        {"id": "tlv-floor-3", "svg": "floors/tlv-floor-3.svg"},
+    )
+    text = yaml_path.read_text(encoding="utf-8")
+    # The new entry's `- id:` line must have the same 8-space prefix as
+    # the existing one.
+    assert "        - id: tlv-floor-3" in text
+    # And load_offices must still succeed (well-formed YAML).
+    offices = load_offices(tmp_path)
+    assert "tlv-floor-3" in offices["tlv"].floors

--- a/uv.lock
+++ b/uv.lock
@@ -713,7 +713,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
Operational follow-up to #54. Two new verbs that close the last two manual steps in the trace-to-render loop.

## Why

After #54 closed, two friction points remained on every new floor:

1. **Re-tracing identical layouts.** Many floors in a building share
   a layout (same column grid, same desk arrangement, same room
   boundaries). Today we trace each one separately in Inkscape.
2. **Hand-editing `offices.yaml`.** Adding a new floor required a
   manual YAML edit: pick the right office block, find the
   `floors:` list, indent everything correctly. The user explicitly
   asked for this not to be a hand-edit.

This PR ships two verbs that turn both into one-liners.

## New verbs

```bash
# Copy seats + rooms (geometry only) from one floor's SVG into
# another, renumbering ids per the dst's cluster spec.
office floors copy-layout tlv-floor-5 tlv-floor-3
office floors copy-layout tlv-floor-5 tlv-floor-3 --overwrite   # active dst

# End-to-end: append offices.yaml entry + scaffold + (optional)
# copy layout from an existing floor.
office floors new tlv-floor-3 --pdf <pdf> --page 8 --copy-from tlv-floor-5
office floors new fc-floor-6 --pdf <pdf> --page 2 --office fc
```

`floors new` with `--copy-from` collapses the previous five-step
"add floor" flow (edit YAML, scaffold, copy-paste in Inkscape,
renumber, validate) into one command.

## YAML preservation

`office_cli.offices.append_floor_entry` does a **textual splice**
into `data/offices.yaml`: parse for validation, locate the right
`floors:` list, insert a new YAML block at the end of that list as
raw text. PyYAML's `safe_dump` would reorder fields and strip
comments — that would mangle the carefully-commented file. The
helper errors with a clear remediation if the file's indentation
doesn't match (operator hand-edits rather than risk a guess).

## What's reused

`copy-layout` leans on the doctor verb's renumbering primitives:

- `_assign_ids` — spatial sort + slot assignment + drop excess.
- `_select` — extract `<rect class="seat">` / `<polygon class="room">`.
- `_capacity_warnings` — same warning shape.
- `_seat_ids_for` — produce target slot list from a cluster spec.

Same contract as doctor, just with elements sourced from another file.

## Refusals

- `copy-layout`: refuses if either id is ambiguous across offices
  (mirrors validate/doctor/scaffold), if src has validation errors
  (no propagating broken layouts), or if dst is `status: active` and
  `--overwrite` was not passed.
- `new`: refuses if the floor id is already declared anywhere in
  offices.yaml; errors when multiple offices are declared and
  `--office` is missing.

## Test plan

- [x] `uv run pytest -n auto` — 485 → 510 (+25: 10 copy-layout pure,
  10 YAML writer, 5 CLI).
- [x] `uv run office floors copy-layout tlv-floor-5 <new-id>` —
  preserves embedded background, drops example placeholders, ids
  match dst's cluster spec.
- [x] `uv run office floors new <id> --pdf <p> --page N --copy-from
  tlv-floor-5` — full chain runs and result validates clean.
- [x] `uv run office floors new <id>` without `--copy-from` — placeholder
  T:1 cluster + scaffold defaults; validates with one `floor-draft`
  warning.
- [x] `uv run office floors new tlv-floor-5` — refuses with "already
  declared".
- [x] `append_floor_entry` preserves top-level comments and the
  exact text of existing floor blocks; refuses on duplicate id and
  unknown office id.
- [x] black, isort, flake8, bandit, markdownlint — all clean.
- [x] Version bumped 0.12.0 → 0.13.0.

## Out of scope (filed as follow-ups)

- **Drive write** for `offices.yaml` + SVG — biggest remaining
  manual step. After running `floors new` locally, the operator
  still mirrors the changes to Drive by hand.
- Manifest mode for `floors new` (batch-create N floors at once)
  — YAGNI for now.
- Foster City office (`fc`, Levels 6 + 7) — separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)