### PR TITLE
feat(floors): retarget room ids on --copy-from + add floors new --manifest batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-05-08
+
+### Added
+
+- `office floors new --manifest <yaml>` — batch mode. One invocation creates many floors from a single manifest, each independently transactional. Manifest fields: `pdf` (required), `office` (optional, auto-detected for single-office), `copy_from` (optional default applied to every entry), and a `floors[{id, page, copy_from?}]` list. Per-entry `copy_from` overrides the manifest top-level. Successfully created floors become candidate copy-from sources for later entries in the same run (offices.yaml is reloaded per entry). Exit code is non-zero if any entry failed; the report distinguishes per-entry success vs failure.
+- `data/floor-bootstrap.yaml.example` — extended with an illustrative `office floors new --manifest` example block alongside the existing scaffold-mode block.
+
+### Changed
+
+- `office floors new --copy-from <src>` now **retargets room ids** to the destination floor's number when inheriting from the source. `5.18` (floor-5) becomes `3.18` on floor-3, `12.18` on floor-12, etc. Seats already retargeted (cluster letter + sequence preserved, only the floor number swapped); rooms now follow the same pattern. Non-conforming room ids (custom strings, legacy formats) pass through unchanged. The polygon `points`, room `name` / `type` / `capacity` are unchanged — only the id rewrites.
+
+### Fixed
+
+- `office_cli/floors/_copy_layout.py` — replace `seats_parent or dst_root` with explicit `is not None` checks. Avoids a Python deprecation warning ("Testing an element's truth value will raise an exception in future versions") on every call.
+
 ## [0.13.0] - 2026-05-08
 
 ### Added

--- a/data/floor-bootstrap.yaml.example
+++ b/data/floor-bootstrap.yaml.example
@@ -1,24 +1,28 @@
-# Manifest for `office floors scaffold --manifest` (issue #54).
+# Manifest for batch floor creation. Two verbs accept this file:
 #
-# Maps PDF pages to floor ids declared in offices.yaml. The verb runs
-# once per entry, producing floors/<id>.svg with the chosen PDF page
-# embedded as a raster background plus one example seat + room for the
-# operator to Ctrl+D-duplicate in Inkscape.
+#   office floors scaffold --manifest data/floor-bootstrap.yaml
+#       Requires each id to already be declared in offices.yaml with
+#       at least one cluster. Produces floors/<id>.svg with the
+#       chosen PDF page embedded as a raster background plus one
+#       example seat + room for the operator to Ctrl+D-duplicate
+#       in Inkscape.
 #
-# All floor ids referenced here must already be declared in
-# `data/offices.yaml` with at least one cluster. Use `status: draft`
-# on the offices.yaml entries — the validator skips the cluster-
-# capacity check for drafts and emits a `floor-draft` warning instead.
+#   office floors new --manifest data/floor-bootstrap.yaml
+#       Adds the offices.yaml entry AND scaffolds, for each entry.
+#       Recognises additional fields:
+#         office:     top-level — pick the office (auto-detected
+#                     when offices.yaml has only one).
+#         copy_from:  top-level — applied to every entry; can be
+#                     overridden per-entry. The new floor inherits
+#                     src's cluster + room spec, retargeted to the
+#                     new floor's number (5.18 -> 3.18 etc.).
+#       Per-entry atomicity: if entry N fails, entries 1..N-1 stay.
 #
 # Copy this file to `data/floor-bootstrap.yaml` (git-ignored), point
 # `pdf:` at your architect's PDF, and adjust the `floors:` list to
-# match. Then:
-#
-#     office floors scaffold --manifest data/floor-bootstrap.yaml
-#
-# `pdf:` may be relative to this manifest file. Use ~ for $HOME.
-# `page:` is either a 1-based int or a string label that appears
-# verbatim on exactly one page (resolved via pdftotext).
+# match. `pdf:` may be relative to this manifest file. `page:` is
+# either a 1-based int or a string label that appears verbatim on
+# exactly one page (resolved via pdftotext).
 
 pdf: <path-to-architects.pdf>
 
@@ -31,3 +35,15 @@ floors:
   # on exactly one page, otherwise the verb errors with a candidate
   # listing.
   - { id: <office>-floor-12, page: "12th Floor" }
+
+# --- Example for `office floors new --manifest` ---
+# Uncomment + adapt; this section is illustrative only.
+#
+# pdf: ~/Downloads/architects-plan.pdf
+# office: tlv
+# copy_from: tlv-floor-5      # stencil for every entry
+# floors:
+#   - { id: tlv-floor-2,  page: 7  }
+#   - { id: tlv-floor-3,  page: 8  }
+#   - { id: tlv-floor-4,  page: 9  }
+#   - { id: tlv-floor-12, page: 14, copy_from: tlv-floor-3 }

--- a/office_cli/cli/_commands/floors.py
+++ b/office_cli/cli/_commands/floors.py
@@ -14,6 +14,7 @@ from office_cli.floors import (
     Severity,
     copy_layout,
     doctor_svg,
+    is_room_id,
     parse_svg,
     scaffold_svg,
     validate_floor,
@@ -447,40 +448,242 @@ def cmd_copy_layout(args: argparse.Namespace) -> int:
 
 
 def cmd_new(args: argparse.Namespace) -> int:
-    """Create a new floor end-to-end: append `offices.yaml` entry,
-    scaffold the SVG, optionally copy layout from an existing floor.
+    """Create a new floor (or many) end-to-end.
 
-    Atomic flow (Qodo PR #57 review): scaffold + copy + validate all
-    happen BEFORE we touch offices.yaml. If anything fails, the only
-    side-effect is a partial SVG at dst_path (rolled back below); the
-    YAML stays untouched so a fresh `floors new` works.
-
-    Decomposed into helpers so cognitive complexity stays under
-    Sonar's S3776 threshold.
+    Single-floor mode: ``floors new <id> --pdf <p> --page <N> [--copy-from SRC]``.
+    Batch mode: ``floors new --manifest <yaml>`` — manifest declares pdf
+    + a list of {id, page} entries, each independently created with
+    per-floor atomicity. Failure of one batch entry doesn't roll back
+    successful entries.
     """
     data_dir = resolve_data_dir(args)
+    if args.manifest:
+        return _run_new_batch(args, data_dir)
+    return _run_new_single(args, data_dir)
+
+
+def _run_new_single(args: argparse.Namespace, data_dir: Path) -> int:
+    if not args.floor_id:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message="pass a floor id or --manifest <yaml>",
+            remediation="example: office floors new tlv-floor-3 --pdf <p> --page 8",
+        )
     offices = load_offices(data_dir)
     office_id = _resolve_new_office(args, offices)
-    _ensure_floor_id_not_declared(args.floor_id, offices)
-
-    floor_index = _index_floors(offices)
-    src_floor, src_path = _resolve_optional_src(args, floor_index)
     pdf_path = _require_pdf(args)
     page = _coerce_page(args.page) if args.page else _require_page(args)
+    src_id = getattr(args, "copy_from", None) or None
 
-    new_entry = _build_floor_entry(args.floor_id, src_floor)
+    actions, warnings, dst_path = _run_one_new(
+        data_dir=data_dir,
+        office_id=office_id,
+        floor_id=args.floor_id,
+        pdf_path=pdf_path,
+        page=page,
+        src_id=src_id,
+    )
+    _emit_new_result(args, office_id, args.floor_id, dst_path, actions, warnings)
+    return 0
+
+
+def _run_new_batch(args: argparse.Namespace, data_dir: Path) -> int:
+    """Create N floors from a manifest. Per-entry atomicity."""
+    jobs = _new_jobs_from_manifest(args, data_dir)
+    results: list[dict] = []
+    any_failed = False
+    for job in jobs:
+        try:
+            actions, warnings, dst_path = _run_one_new(**job)
+            results.append(
+                {
+                    "floor": job["floor_id"],
+                    "office": job["office_id"],
+                    "svg": str(dst_path),
+                    "ok": True,
+                    "actions": actions,
+                    "warnings": [w.to_dict() for w in warnings],
+                }
+            )
+        except OfficeError as err:
+            any_failed = True
+            results.append(
+                {
+                    "floor": job["floor_id"],
+                    "office": job["office_id"],
+                    "ok": False,
+                    "error": err.message,
+                    "remediation": err.remediation,
+                }
+            )
+            # Re-fetch offices.yaml for the next iteration so duplicate-id
+            # checks see entries we successfully appended above.
+            # (load_offices is called inside _run_one_new -> implicit reload.)
+    _emit_batch_result(args, results)
+    return EXIT_USER_ERROR if any_failed else 0
+
+
+def _run_one_new(
+    *,
+    data_dir: Path,
+    office_id: str,
+    floor_id: str,
+    pdf_path: Path,
+    page,
+    src_id: str | None,
+) -> tuple[list[str], list, Path]:
+    """Single-floor create: build entry, render, copy, validate, append YAML.
+
+    Refuses up front if the floor id is already declared anywhere in
+    offices.yaml. Resolves ``src_id`` (if any) from the current
+    offices state — re-loaded on every call so batch mode sees
+    floors created earlier in the same run as candidate copy
+    sources. Uses the PR-C `_render_and_validate` flow for full
+    per-floor atomicity.
+    """
+    offices = load_offices(data_dir)
+    _ensure_floor_id_not_declared(floor_id, offices)
+    src_floor, src_path = _resolve_src_id(src_id, offices)
+    new_entry = _build_floor_entry(floor_id, src_floor)
     dst_path = data_dir / new_entry["svg"]
     _ensure_dst_unused(dst_path)
-    synthetic_floor = _synth_floor(args.floor_id, dst_path, new_entry)
-
+    synthetic_floor = _synth_floor(floor_id, dst_path, new_entry)
     actions, warnings = _render_and_validate(
         synthetic_floor, dst_path, pdf_path, page, src_floor, src_path
     )
     yaml_path = data_dir / "data" / "offices.yaml"
     append_floor_entry(yaml_path, office_id, new_entry)
-    actions.append(f"appended {args.floor_id} under office {office_id}")
-    _emit_new_result(args, office_id, args.floor_id, dst_path, actions, warnings)
-    return 0
+    actions.append(f"appended {floor_id} under office {office_id}")
+    return actions, warnings, dst_path
+
+
+def _resolve_src_id(src_id: str | None, offices: dict) -> tuple[Floor | None, Path | None]:
+    """Resolve a copy-from floor id against the current offices state."""
+    if not src_id:
+        return None, None
+    return _resolve_scaffold_floor(src_id, _index_floors(offices))
+
+
+def _new_jobs_from_manifest(args: argparse.Namespace, data_dir: Path) -> list[dict]:
+    """Parse a manifest into a list of `_run_one_new` kwargs dicts."""
+    manifest_path = Path(args.manifest).expanduser()
+    raw = _load_manifest(manifest_path)
+    pdf_path = _manifest_pdf_path(raw, manifest_path)
+    offices = load_offices(data_dir)
+    floor_index = _index_floors(offices)
+    office_id = _resolve_manifest_office(args, raw, offices)
+    default_copy_from = (
+        getattr(args, "copy_from", None) or str(raw.get("copy_from", "")).strip() or None
+    )
+    floors = raw.get("floors") or []
+    if not isinstance(floors, list) or not floors:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"manifest must declare a non-empty `floors:` list: {manifest_path}",
+            remediation="see data/floor-bootstrap.yaml.example",
+        )
+    return [
+        _build_new_job(entry, idx, pdf_path, office_id, default_copy_from, floor_index, data_dir)
+        for idx, entry in enumerate(floors)
+    ]
+
+
+def _build_new_job(
+    entry: object,
+    idx: int,
+    pdf_path: Path,
+    office_id: str,
+    default_copy_from: str | None,
+    floor_index: dict[Path, Floor],
+    data_dir: Path,
+) -> dict:
+    """Validate one manifest entry; return kwargs for `_run_one_new`.
+
+    Note: ``copy_from`` is stored as the source floor id (string),
+    NOT resolved to a Floor here. Resolution is deferred to
+    `_run_one_new` so a bad copy_from in entry N fails just that
+    entry, not the whole batch.
+    """
+    _ = floor_index  # reserved; per-entry code re-resolves from fresh offices
+    if not isinstance(entry, dict):
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"manifest floors[{idx}] is not a mapping",
+            remediation="each entry needs `id:` and `page:`",
+        )
+    fid = str(entry.get("id", "")).strip()
+    if not fid:
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"manifest floors[{idx}] is missing `id:`",
+            remediation="add `id: <floor-id>`",
+        )
+    page_raw = entry.get("page")
+    if page_raw is None or page_raw == "":
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"manifest floors[{idx}] (id={fid!r}) is missing `page:`",
+            remediation="add `page: <N>` or `page: '<label>'`",
+        )
+    src_id = str(entry.get("copy_from", default_copy_from or "")).strip() or None
+    return {
+        "data_dir": data_dir,
+        "office_id": office_id,
+        "floor_id": fid,
+        "pdf_path": pdf_path,
+        "page": _coerce_page(page_raw),
+        "src_id": src_id,
+    }
+
+
+def _resolve_manifest_office(args: argparse.Namespace, raw: dict, offices: dict) -> str:
+    """CLI flag > manifest field > single-office auto-detect."""
+    if args.office:
+        if args.office not in offices:
+            known = ", ".join(sorted(offices.keys()))
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"unknown office: {args.office!r}",
+                remediation=f"known offices: {known or '(none)'}",
+            )
+        return args.office
+    yaml_office = str(raw.get("office", "")).strip()
+    if yaml_office:
+        if yaml_office not in offices:
+            known = ", ".join(sorted(offices.keys()))
+            raise OfficeError(
+                code=EXIT_USER_ERROR,
+                message=f"manifest references unknown office: {yaml_office!r}",
+                remediation=f"known offices: {known or '(none)'}",
+            )
+        return yaml_office
+    if len(offices) == 1:
+        return next(iter(offices))
+    known = ", ".join(sorted(offices.keys()))
+    raise OfficeError(
+        code=EXIT_USER_ERROR,
+        message="multiple offices declared; manifest needs `office:` or pass --office",
+        remediation=f"add `office: <id>` to the manifest top-level (known: {known})",
+    )
+
+
+def _emit_batch_result(args: argparse.Namespace, results: list[dict]) -> None:
+    if args.json:
+        emit_result({"results": results}, json_mode=True)
+        return
+    ok_count = sum(1 for r in results if r["ok"])
+    fail_count = len(results) - ok_count
+    emit_result(
+        f"batch: {ok_count} ok, {fail_count} failed (of {len(results)})",
+        json_mode=False,
+    )
+    for r in results:
+        if r["ok"]:
+            emit_diagnostic(f"  OK   {r['floor']} ({r['svg']})")
+        else:
+            emit_diagnostic(f"  FAIL {r['floor']}: {r['error']}")
+            if r.get("remediation"):
+                emit_diagnostic(f"       hint: {r['remediation']}")
 
 
 def _ensure_dst_unused(dst_path: Path) -> None:
@@ -681,20 +884,44 @@ def _require_page(args: argparse.Namespace) -> int | str:
     return _coerce_page(args.page)
 
 
+def _retarget_room_id(rid: str, dst_floor_num: str) -> str:
+    """Replace the floor prefix in a `<floor>.<NN>` room id.
+
+    ``5.18`` (floor-5 stencil) → ``3.18`` (floor-3 destination).
+    Non-conforming ids (custom strings, legacy formats) pass through
+    unchanged so we never mangle data we don't recognize.
+    """
+    if not is_room_id(rid):
+        return rid
+    suffix = rid.split(".", 1)[1]
+    return f"{dst_floor_num}.{suffix}"
+
+
 def _build_floor_entry(floor_id: str, src_floor: Floor | None) -> dict:
     """Shape the dict consumed by ``append_floor_entry``.
 
     Inherits cluster + room spec from ``src_floor`` when given (so a
     --copy-from creates an offices.yaml entry that fits the source's
     layout). Without it, falls back to a placeholder T:1 cluster.
+
+    Room ids are **retargeted** to the destination floor's number so
+    that copying floor-5's ``5.18`` produces floor-3's ``3.18``,
+    matching the architect's per-floor numbering convention. Seats
+    don't need this here — they're renumbered later by ``copy_layout``
+    via ``_seat_ids_for(dst_floor.number, ...)``.
     """
+    dst_num = floor_id.rsplit("-", 1)[-1]
     if src_floor is not None:
         clusters = {
             letter: {"capacity": cluster.capacity, "type": cluster.type}
             for letter, cluster in src_floor.clusters.items()
         }
         rooms = {
-            rid: {"name": r.name, "type": r.type, "capacity": r.capacity}
+            _retarget_room_id(rid, dst_num): {
+                "name": r.name,
+                "type": r.type,
+                "capacity": r.capacity,
+            }
             for rid, r in src_floor.rooms.items()
         }
     else:
@@ -995,7 +1222,15 @@ def register(sub: argparse._SubParsersAction) -> None:
             "optionally overlays seats+rooms from an existing floor."
         ),
     )
-    p_new.add_argument("floor_id", help="New floor id (e.g. 'tlv-floor-3').")
+    p_new.add_argument(
+        "floor_id",
+        nargs="?",
+        help="New floor id (e.g. 'tlv-floor-3'). Required unless --manifest is passed.",
+    )
+    p_new.add_argument(
+        "--manifest",
+        help="Batch mode: YAML manifest with pdf + floors[{id, page}] + optional copy_from.",
+    )
     p_new.add_argument("--pdf", help="Path to the architect's PDF.")
     p_new.add_argument(
         "--page", help="1-based page number, or text label that appears on one page."

--- a/office_cli/cli/_commands/floors.py
+++ b/office_cli/cli/_commands/floors.py
@@ -23,6 +23,7 @@ from office_cli.offices import Floor, append_floor_entry, load_offices
 
 _HELP_JSON = "Emit structured JSON."
 _DOCTOR_HINT_THRESHOLD = 3
+_BOOTSTRAP_HINT = "see data/floor-bootstrap.yaml.example"
 
 
 def cmd_list(args: argparse.Namespace) -> int:
@@ -272,7 +273,7 @@ def _scaffold_jobs_from_manifest(
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=f"manifest must declare a non-empty `floors:` list: {manifest_path}",
-            remediation="see data/floor-bootstrap.yaml.example",
+            remediation=_BOOTSTRAP_HINT,
         )
     _ = data_dir  # currently unused; reserved for relative resolution
     return [_manifest_floor_entry(entry, idx, pdf_path) for idx, entry in enumerate(floors)]
@@ -286,7 +287,7 @@ def _load_manifest(manifest_path: Path) -> dict:
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=f"manifest not found: {manifest_path}",
-            remediation="check the --manifest path; see data/floor-bootstrap.yaml.example",
+            remediation=f"check the --manifest path; {_BOOTSTRAP_HINT}",
         )
     try:
         raw = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
@@ -294,20 +295,20 @@ def _load_manifest(manifest_path: Path) -> dict:
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=f"manifest is not valid YAML: {manifest_path}: {err}",
-            remediation="see data/floor-bootstrap.yaml.example for the expected shape",
+            remediation=f"{_BOOTSTRAP_HINT} for the expected shape",
         ) from err
     if not isinstance(raw, dict):
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=f"manifest must be a mapping at top-level: {manifest_path}",
-            remediation="see data/floor-bootstrap.yaml.example",
+            remediation=_BOOTSTRAP_HINT,
         )
     return raw
 
 
 def _manifest_pdf_path(raw: dict, manifest_path: Path) -> Path:
     """Pull `pdf:` out of the manifest, resolving relative against the manifest dir."""
-    pdf_field = str(raw.get("pdf", "")).strip()
+    pdf_field = _yaml_str(raw.get("pdf"))
     if not pdf_field:
         raise OfficeError(
             code=EXIT_USER_ERROR,
@@ -328,7 +329,7 @@ def _manifest_floor_entry(entry: object, idx: int, pdf_path: Path) -> tuple[str,
             message=f"manifest floors[{idx}] is not a mapping",
             remediation="each entry needs `id:` and `page:`",
         )
-    fid = str(entry.get("id", "")).strip()
+    fid = _yaml_str(entry.get("id"))
     if not fid:
         raise OfficeError(
             code=EXIT_USER_ERROR,
@@ -516,6 +517,21 @@ def _run_new_batch(args: argparse.Namespace, data_dir: Path) -> int:
                     "remediation": err.remediation,
                 }
             )
+        except Exception as err:  # noqa: BLE001 — Qodo PR #58: keep per-entry isolation
+            # Catch unexpected errors (OSError on write, ET.ParseError on
+            # corrupt PDF, KeyError from a malformed manifest field, etc.)
+            # so a single bad entry doesn't terminate the whole batch
+            # with a traceback.
+            any_failed = True
+            results.append(
+                {
+                    "floor": job["floor_id"],
+                    "office": job["office_id"],
+                    "ok": False,
+                    "error": f"{type(err).__name__}: {err}",
+                    "remediation": "(unexpected error — see traceback in stderr if needed)",
+                }
+            )
             # Re-fetch offices.yaml for the next iteration so duplicate-id
             # checks see entries we successfully appended above.
             # (load_offices is called inside _run_one_new -> implicit reload.)
@@ -572,15 +588,13 @@ def _new_jobs_from_manifest(args: argparse.Namespace, data_dir: Path) -> list[di
     offices = load_offices(data_dir)
     floor_index = _index_floors(offices)
     office_id = _resolve_manifest_office(args, raw, offices)
-    default_copy_from = (
-        getattr(args, "copy_from", None) or str(raw.get("copy_from", "")).strip() or None
-    )
+    default_copy_from = getattr(args, "copy_from", None) or _yaml_str(raw.get("copy_from")) or None
     floors = raw.get("floors") or []
     if not isinstance(floors, list) or not floors:
         raise OfficeError(
             code=EXIT_USER_ERROR,
             message=f"manifest must declare a non-empty `floors:` list: {manifest_path}",
-            remediation="see data/floor-bootstrap.yaml.example",
+            remediation=_BOOTSTRAP_HINT,
         )
     return [
         _build_new_job(entry, idx, pdf_path, office_id, default_copy_from, floor_index, data_dir)
@@ -611,7 +625,7 @@ def _build_new_job(
             message=f"manifest floors[{idx}] is not a mapping",
             remediation="each entry needs `id:` and `page:`",
         )
-    fid = str(entry.get("id", "")).strip()
+    fid = _yaml_str(entry.get("id"))
     if not fid:
         raise OfficeError(
             code=EXIT_USER_ERROR,
@@ -625,7 +639,8 @@ def _build_new_job(
             message=f"manifest floors[{idx}] (id={fid!r}) is missing `page:`",
             remediation="add `page: <N>` or `page: '<label>'`",
         )
-    src_id = str(entry.get("copy_from", default_copy_from or "")).strip() or None
+    per_entry_src = _yaml_str(entry.get("copy_from")) if "copy_from" in entry else ""
+    src_id = per_entry_src or default_copy_from or None
     return {
         "data_dir": data_dir,
         "office_id": office_id,
@@ -647,7 +662,7 @@ def _resolve_manifest_office(args: argparse.Namespace, raw: dict, offices: dict)
                 remediation=f"known offices: {known or '(none)'}",
             )
         return args.office
-    yaml_office = str(raw.get("office", "")).strip()
+    yaml_office = _yaml_str(raw.get("office"))
     if yaml_office:
         if yaml_office not in offices:
             known = ", ".join(sorted(offices.keys()))
@@ -882,6 +897,21 @@ def _require_page(args: argparse.Namespace) -> int | str:
             remediation="pass --page <N> (1-based) or --page <label>",
         )
     return _coerce_page(args.page)
+
+
+def _yaml_str(value: object) -> str:
+    """Coerce a YAML-loaded value to a stripped string.
+
+    Critical detail: YAML's ``null`` (or a missing key with a ``None``
+    fallback) loads as Python ``None`` — and ``str(None) == 'None'``,
+    which is truthy. Without this helper, ``copy_from: null`` /
+    ``office: null`` / ``pdf: null`` would each silently become the
+    literal string ``"None"`` and produce confusing downstream errors
+    ("unknown office: 'None'" rather than "missing field"). Qodo PR #58.
+    """
+    if value is None:
+        return ""
+    return str(value).strip()
 
 
 def _retarget_room_id(rid: str, dst_floor_num: str) -> str:

--- a/office_cli/explain/catalog.py
+++ b/office_cli/explain/catalog.py
@@ -290,20 +290,46 @@ floor's layout.
 
 ## Usage
 
+    # Single-floor
     office floors new tlv-floor-3 --pdf <path> --page 8
     office floors new tlv-floor-3 --pdf <path> --page 8 --copy-from tlv-floor-5
     office floors new fc-floor-6 --pdf <path> --page 2 --office fc
 
+    # Batch (one PDF, many floors, optional shared copy-from stencil)
+    office floors new --manifest data/floor-bootstrap.yaml
+
 ## Flags
 
-- `--pdf PATH` — required. Architect's PDF.
-- `--page N|LABEL` — required. 1-based page number or string label.
+- `--pdf PATH` — required in single-floor mode. Architect's PDF.
+- `--page N|LABEL` — required in single-floor mode. 1-based page
+  number or string label.
 - `--office ID` — required when offices.yaml has multiple offices;
   auto-detected for single-office configurations.
 - `--copy-from SRC` — existing floor id whose cluster spec, room
   declarations, and SVG layout get inherited. The new floor ends up
-  with the same number of seats and rooms as `SRC`, just renumbered
-  for the new floor (e.g. `5-T-01` -> `3-T-01`).
+  with the same number of seats and rooms as `SRC`, just retargeted
+  for the new floor: seat ids `5-T-01` -> `3-T-01`, room ids
+  `5.18` -> `3.18`. Geometry (positions, sizes) carries over verbatim.
+- `--manifest PATH` — batch mode. See "Manifest shape" below.
+
+## Manifest shape (batch mode)
+
+    pdf: <path-to-architects.pdf>
+    office: tlv                  # optional, auto-detected if single
+    copy_from: tlv-floor-5       # optional default, applied to every entry
+    floors:
+      - { id: tlv-floor-2,  page: 7  }
+      - { id: tlv-floor-3,  page: 8  }
+      - { id: tlv-floor-12, page: 14 }
+      - { id: tlv-floor-14, page: 15, copy_from: tlv-floor-12 }   # per-entry override
+
+Each entry is its own transaction (per-floor atomicity): if entry N
+fails (poppler error, unknown copy_from, validation error), the
+verb rolls back any partial SVG for that entry but **leaves earlier
+successful entries intact**. Final exit is non-zero if any entry
+failed; the report (text + JSON) lists per-entry status. Successful
+entries become candidate copy-from sources for later entries in
+the same run, since `offices.yaml` is reloaded per entry.
 
 ## Output
 
@@ -317,7 +343,7 @@ floor's layout.
 ## Refusals
 
 - Floor id already declared anywhere in offices.yaml.
-- Multiple offices declared and no `--office` flag.
+- Multiple offices declared and no `--office` (CLI or manifest).
 - PDF, page, or `--copy-from` source missing.
 
 ## Next steps

--- a/office_cli/floors/_copy_layout.py
+++ b/office_cli/floors/_copy_layout.py
@@ -103,8 +103,8 @@ def copy_layout(
     dst_root = dst_tree.getroot()
     seats_parent, rooms_parent = _strip_existing_layout(dst_root)
 
-    new_seats = _clone_into(src_seats, seats_parent or dst_root)
-    new_rooms = _clone_into(src_rooms, rooms_parent or dst_root)
+    new_seats = _clone_into(src_seats, seats_parent if seats_parent is not None else dst_root)
+    new_rooms = _clone_into(src_rooms, rooms_parent if rooms_parent is not None else dst_root)
 
     parents = {child: parent for parent in dst_root.iter() for child in parent}
     seat_slots = _seat_ids_for(dst_floor.number, dst_floor.clusters)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.13.0"
+version = "0.14.0"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_floors.py
+++ b/tests/test_cli_floors.py
@@ -1058,3 +1058,89 @@ def test_floors_new_no_floor_id_no_manifest(
     assert rc != 0
     err = capsys.readouterr().err
     assert "floor id" in err or "manifest" in err
+
+
+def test_floors_new_manifest_handles_yaml_nulls(
+    data_dir: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Qodo PR #58: YAML nulls (`copy_from: null`, `office: null`) must
+    be treated as unset, not coerced to the literal string "None"."""
+    from office_cli.floors import _scaffold as scaffold_mod
+
+    monkeypatch.setattr(scaffold_mod, "_render_pdf_page", lambda *a, **kw: b"\x89PNG")
+    pdf = data_dir / "fake.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    manifest = data_dir / "boot.yaml"
+    # Explicit YAML nulls — copy_from null at top, office null at top.
+    manifest.write_text(
+        f"pdf: {pdf}\n"
+        "copy_from: null\n"
+        "office: null\n"
+        "floors:\n"
+        "  - { id: tlv-floor-2, page: 7, copy_from: null }\n",
+        encoding="utf-8",
+    )
+    rc = main(
+        [
+            "floors",
+            "new",
+            "--manifest",
+            str(manifest),
+            "--data-dir",
+            str(data_dir),
+            "--json",
+        ]
+    )
+    # Should succeed: no copy_from means use the placeholder T:1 cluster.
+    # No office means single-office auto-detect (tlv).
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["results"][0]["ok"] is True
+    assert payload["results"][0]["office"] == "tlv"
+
+
+def test_floors_new_manifest_isolates_unexpected_exceptions(
+    data_dir: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Qodo PR #58: a non-OfficeError exception (e.g. OSError) in one
+    entry must not abort the batch. Other entries continue; the
+    failure is captured per-entry."""
+    from office_cli.floors import _scaffold as scaffold_mod
+
+    pdf = data_dir / "fake.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+
+    call_count = {"n": 0}
+
+    def fake_render(*a, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return b"\x89PNG"
+        raise OSError("simulated disk error")
+
+    monkeypatch.setattr(scaffold_mod, "_render_pdf_page", fake_render)
+    manifest = data_dir / "boot.yaml"
+    manifest.write_text(
+        f"pdf: {pdf}\n"
+        "floors:\n"
+        "  - { id: tlv-floor-2, page: 7 }\n"
+        "  - { id: tlv-floor-3, page: 8 }\n",
+        encoding="utf-8",
+    )
+    rc = main(
+        [
+            "floors",
+            "new",
+            "--manifest",
+            str(manifest),
+            "--data-dir",
+            str(data_dir),
+            "--json",
+        ]
+    )
+    assert rc != 0
+    payload = json.loads(capsys.readouterr().out)
+    by_id = {r["floor"]: r for r in payload["results"]}
+    assert by_id["tlv-floor-2"]["ok"] is True
+    assert by_id["tlv-floor-3"]["ok"] is False
+    assert "OSError" in by_id["tlv-floor-3"]["error"]

--- a/tests/test_cli_floors.py
+++ b/tests/test_cli_floors.py
@@ -847,3 +847,214 @@ def test_floors_new_refuses_existing_floor_id(
     assert rc != 0
     err = capsys.readouterr().err
     assert "already declared" in err
+
+
+def test_floors_new_retargets_room_ids(
+    data_dir: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--copy-from` must retarget room ids to the destination floor's
+    number — `5.18` (floor-5) becomes `3.18` (floor-3). Both the
+    offices.yaml entry and the SVG polygon id must reflect the new id."""
+    from office_cli.floors import _scaffold as scaffold_mod
+
+    monkeypatch.setattr(scaffold_mod, "_render_pdf_page", lambda *a, **kw: b"\x89PNG")
+    pdf = data_dir / "fake.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+
+    rc = main(
+        [
+            "floors",
+            "new",
+            "tlv-floor-3",
+            "--pdf",
+            str(pdf),
+            "--page",
+            "1",
+            "--copy-from",
+            "tlv-floor-5",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc == 0
+    yaml_text = (data_dir / "data" / "offices.yaml").read_text(encoding="utf-8")
+    # offices.yaml must have the retargeted room id, not the source's.
+    assert '"3.18"' in yaml_text
+    assert '"5.18"' not in yaml_text.split("tlv-floor-3")[1]  # not in floor-3's block
+    # SVG polygon id must also be retargeted (copy_layout uses dst_floor.rooms keys).
+    svg_text = (data_dir / "floors" / "tlv-floor-3.svg").read_text(encoding="utf-8")
+    assert 'id="3.18"' in svg_text
+    assert 'id="5.18"' not in svg_text
+
+
+def test_retarget_room_id_passes_through_non_conforming(data_dir: Path) -> None:
+    """Direct unit test: a custom-format room id (no `<floor>.<NN>`)
+    is left alone rather than being mangled into something invalid."""
+    from office_cli.cli._commands.floors import _retarget_room_id
+
+    assert _retarget_room_id("5.18", "3") == "3.18"
+    assert _retarget_room_id("12.18", "14") == "14.18"
+    # Non-conforming forms pass through:
+    assert _retarget_room_id("legacy-MR-A", "3") == "legacy-MR-A"
+    assert _retarget_room_id("Conf 5.18", "3") == "Conf 5.18"
+
+
+def test_floors_new_manifest_creates_multiple_floors(
+    data_dir: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Manifest mode: one PDF, multiple {id, page} entries, all created
+    with retargeted ids."""
+    from office_cli.floors import _scaffold as scaffold_mod
+
+    monkeypatch.setattr(scaffold_mod, "_render_pdf_page", lambda *a, **kw: b"\x89PNG")
+    pdf = data_dir / "fake.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    manifest = data_dir / "boot.yaml"
+    manifest.write_text(
+        f"pdf: {pdf}\n"
+        "copy_from: tlv-floor-5\n"
+        "floors:\n"
+        "  - { id: tlv-floor-2, page: 7 }\n"
+        "  - { id: tlv-floor-3, page: 8 }\n"
+        "  - { id: tlv-floor-4, page: 9 }\n",
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "floors",
+            "new",
+            "--manifest",
+            str(manifest),
+            "--data-dir",
+            str(data_dir),
+            "--json",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["results"]) == 3
+    assert all(r["ok"] for r in payload["results"])
+    yaml_text = (data_dir / "data" / "offices.yaml").read_text(encoding="utf-8")
+    # Each new floor's room id is retargeted to its own floor number.
+    assert '"2.18"' in yaml_text
+    assert '"3.18"' in yaml_text
+    assert '"4.18"' in yaml_text
+    # Three SVGs written.
+    for fid in ("tlv-floor-2", "tlv-floor-3", "tlv-floor-4"):
+        assert (data_dir / "floors" / f"{fid}.svg").is_file()
+
+
+def test_floors_new_manifest_per_entry_copy_from_override(
+    data_dir: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Per-entry `copy_from` overrides the manifest top-level default."""
+    from office_cli.floors import _scaffold as scaffold_mod
+
+    monkeypatch.setattr(scaffold_mod, "_render_pdf_page", lambda *a, **kw: b"\x89PNG")
+    pdf = data_dir / "fake.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+
+    # First create floor-3 with floor-5's layout — that becomes a
+    # candidate stencil for further copies.
+    rc = main(
+        [
+            "floors",
+            "new",
+            "tlv-floor-3",
+            "--pdf",
+            str(pdf),
+            "--page",
+            "1",
+            "--copy-from",
+            "tlv-floor-5",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc == 0
+    capsys.readouterr()  # drop output
+
+    # Now manifest-create floor-4 (default copy_from = floor-5) and
+    # floor-2 (override to floor-3).
+    manifest = data_dir / "boot.yaml"
+    manifest.write_text(
+        f"pdf: {pdf}\n"
+        "copy_from: tlv-floor-5\n"
+        "floors:\n"
+        "  - { id: tlv-floor-4, page: 9 }\n"
+        "  - { id: tlv-floor-2, page: 7, copy_from: tlv-floor-3 }\n",
+        encoding="utf-8",
+    )
+    rc = main(
+        [
+            "floors",
+            "new",
+            "--manifest",
+            str(manifest),
+            "--data-dir",
+            str(data_dir),
+            "--json",
+        ]
+    )
+    assert rc == 0
+    capsys.readouterr()  # drain
+    # Floor-2 used floor-3 (which itself derived from floor-5), so its
+    # room id is `2.18` (retargeted from floor-3's `3.18`).
+    yaml_text = (data_dir / "data" / "offices.yaml").read_text(encoding="utf-8")
+    assert '"2.18"' in yaml_text
+
+
+def test_floors_new_manifest_partial_failure(
+    data_dir: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One bad entry must not block the others. Exit code is non-zero
+    when any entry failed; the report distinguishes ok vs fail per entry."""
+    from office_cli.floors import _scaffold as scaffold_mod
+
+    monkeypatch.setattr(scaffold_mod, "_render_pdf_page", lambda *a, **kw: b"\x89PNG")
+    pdf = data_dir / "fake.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    manifest = data_dir / "boot.yaml"
+    # Second entry references an unknown copy_from id.
+    manifest.write_text(
+        f"pdf: {pdf}\n"
+        "floors:\n"
+        "  - { id: tlv-floor-2, page: 7, copy_from: tlv-floor-5 }\n"
+        "  - { id: tlv-floor-3, page: 8, copy_from: no-such-floor }\n",
+        encoding="utf-8",
+    )
+
+    rc = main(
+        [
+            "floors",
+            "new",
+            "--manifest",
+            str(manifest),
+            "--data-dir",
+            str(data_dir),
+            "--json",
+        ]
+    )
+    assert rc != 0
+    payload = json.loads(capsys.readouterr().out)
+    by_id = {r["floor"]: r for r in payload["results"]}
+    assert by_id["tlv-floor-2"]["ok"] is True
+    assert by_id["tlv-floor-3"]["ok"] is False
+    assert "no-such-floor" in by_id["tlv-floor-3"]["error"]
+    # Successful entry IS persisted (per-entry atomicity, not batch).
+    yaml_text = (data_dir / "data" / "offices.yaml").read_text(encoding="utf-8")
+    assert "tlv-floor-2" in yaml_text
+    # Failed entry is NOT persisted.
+    assert "tlv-floor-3" not in yaml_text or "id: tlv-floor-3" not in yaml_text
+
+
+def test_floors_new_no_floor_id_no_manifest(
+    data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pdf = data_dir / "fake.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    rc = main(["floors", "new", "--pdf", str(pdf), "--page", "1", "--data-dir", str(data_dir)])
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "floor id" in err or "manifest" in err

--- a/uv.lock
+++ b/uv.lock
@@ -713,7 +713,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
Operational follow-up surfaced by the tlv-floor-3 e2e demo after PR #57.

## Why

Two problems became visible once PR-C (`floors new --copy-from`)
ran end-to-end:

1. **Room ids didn't retarget.** Copying floor-5 to floor-3 left
   the new room as `5.18` instead of `3.18`. Seats already
   retargeted (cluster letter + sequence preserved, floor number
   swapped); rooms didn't.
2. **One floor at a time was too slow.** Once one floor is traced
   properly, scaffolding the others is purely mechanical — should
   be one command.

This PR fixes both.

## What

```bash
# Fix 1: --copy-from now retargets room ids
office floors new tlv-floor-3 --pdf <p> --page 8 --copy-from tlv-floor-5
# offices.yaml: rooms keyed `3.18` (not `5.18`)
# SVG: <polygon id="3.18" ...>

# Fix 2: batch mode
office floors new --manifest data/tlv-batch.yaml
# manifest declares pdf + a list of floors with optional shared copy-from
```

Manifest schema (extends the existing scaffold-manifest format):

```yaml
pdf: <path>
office: tlv                # optional; auto-detected if single
copy_from: tlv-floor-5     # optional default for every entry
floors:
  - { id: tlv-floor-2,  page: 7  }
  - { id: tlv-floor-3,  page: 8  }
  - { id: tlv-floor-12, page: 14, copy_from: tlv-floor-3 }   # per-entry override
```

Per-entry atomicity: each entry is its own transaction. If entry N
fails, the partial SVG is rolled back, but already-succeeded
entries 1..N-1 stay (they're valid completions). Exit code is
non-zero if any entry failed.

Successful entries become candidate copy-from sources for later
entries in the same run, since `offices.yaml` is reloaded between
entries.

## Test plan

- [x] `uv run pytest -n auto` — 512 → 518 (+6).
- [x] `uv run office floors new tlv-floor-99 --pdf <p> --page 8 --copy-from tlv-floor-5` — confirms `99.18` in YAML and SVG, no `5.18`.
- [x] Manifest mode with 3 entries — all created, all retargeted.
- [x] Manifest with one bad `copy_from` — other entries succeed; exit non-zero; report distinguishes ok/fail.
- [x] black, isort, flake8, bandit, markdownlint — all clean.
- [x] Version 0.13.0 → 0.14.0.

## Out of scope

- Drive write — biggest remaining manual step (mirroring offices.yaml + uploading SVGs is still operator-side).
- Foster City office (`fc`, Levels 6 + 7) — separate.
- Per-floor cluster overrides in the manifest — speculative; current model assumes all batch entries share the source's cluster spec via `copy_from`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)