### PR TITLE
feat(floors): doctor preserves shapes by default; auto-grows offices.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-05-09
+
+### Added
+
+- `office floors doctor --prune` flag — opt-in for the original aggressive cleanup (drop off-page shapes + dedupe near-duplicates + drop excess beyond declared capacity). The previous default behavior is now behind this flag.
+- `DoctorReport` exposes `new_clusters` (letter → capacity) and `new_rooms` (id list) so callers can preview the post-doctor spec without mutating the file (e.g. via `--dry-run`).
+- `office_cli.offices.update_floor_entry` — textually replace a floor's `clusters:` and/or `rooms:` blocks while preserving the rest of the YAML byte-for-byte. Used by doctor's auto-grow.
+
+### Changed
+
+- **`office floors doctor` default behavior is now keep-all.** No off-page drop, no dedupe, no excess-drop — the verb just renumbers ids per cluster (auto-detecting the letter from existing ids) and writes the cleaned SVG back. After write, it auto-grows `data/offices.yaml`: bumps cluster capacities to match actual counts, replaces the rooms block with the new sequential id list (default `name: "Room <id>"`, `type: meeting`, `capacity: 4` for newly-added rooms). Operators no longer lose traced shapes when doctor's heuristics are over-aggressive. Pass `--prune` to restore the previous behavior. Issue #54 follow-up.
+
+### Fixed
+
 ## [0.14.0] - 2026-05-08
 
 ### Added

--- a/office_cli/cli/_commands/floors.py
+++ b/office_cli/cli/_commands/floors.py
@@ -19,7 +19,7 @@ from office_cli.floors import (
     scaffold_svg,
     validate_floor,
 )
-from office_cli.offices import Floor, append_floor_entry, load_offices
+from office_cli.offices import Floor, append_floor_entry, load_offices, update_floor_entry
 
 _HELP_JSON = "Emit structured JSON."
 _DOCTOR_HINT_THRESHOLD = 3
@@ -967,11 +967,21 @@ def _build_floor_entry(floor_id: str, src_floor: Floor | None) -> dict:
 
 
 def cmd_doctor(args: argparse.Namespace) -> int:
-    """Diagnose-and-fix floor SVGs: drop off-page / duplicate shapes,
-    renumber per ``offices.yaml`` cluster spec."""
+    """Diagnose-and-fix floor SVGs.
+
+    Default (keep-all): just renumber the ids — preserves every traced
+    shape, auto-grows offices.yaml's cluster capacities and rooms list
+    to match.
+
+    ``--prune``: drop off-page shapes + dedupe near-duplicates +
+    renumber per the existing cluster spec (drops excess). Original
+    PR-A behavior, opt-in.
+    """
     data_dir = resolve_data_dir(args)
-    floor_index = _index_floors(load_offices(data_dir))
+    offices = load_offices(data_dir)
+    floor_index = _index_floors(offices)
     targets = _resolve_targets(args, floor_index, data_dir)
+    prune = bool(getattr(args, "prune", False))
     payload: list[dict[str, object]] = []
     for target in targets:
         floor = floor_index.get(target)
@@ -981,13 +991,69 @@ def cmd_doctor(args: argparse.Namespace) -> int:
                 message=f"SVG {target} is not declared in offices.yaml",
                 remediation="add a floors entry pointing at this SVG, or pass an SVG that is",
             )
-        report = doctor_svg(target, floor, dry_run=bool(args.dry_run))
+        report = doctor_svg(target, floor, dry_run=bool(args.dry_run), prune=prune)
+        # Auto-grow offices.yaml when keep-all mode produced more
+        # shapes than the declared spec covers. Skipped on dry-run and
+        # in prune mode (where nothing grew).
+        if not args.dry_run and not prune:
+            _maybe_autogrow_yaml(data_dir, offices, floor, report)
         payload.append(report.to_dict())
     if args.json:
         emit_result({"results": payload}, json_mode=True)
     else:
         _print_doctor_text(payload)
     return 0
+
+
+def _maybe_autogrow_yaml(
+    data_dir: Path,
+    offices: dict,
+    floor: Floor,
+    report,
+) -> None:
+    """Update offices.yaml if the doctor's new spec differs from declared.
+
+    Issue #54 follow-up. Bumps cluster capacities and expands the rooms
+    list when keep-all mode produced shapes beyond declared capacity.
+    Default room metadata (`name`, `type`, `capacity`) is filled in for
+    newly-added rooms; existing rooms keep their declared metadata.
+    """
+    declared_caps = {letter: c.capacity for letter, c in floor.clusters.items()}
+    declared_rooms = list(floor.rooms.keys())
+    if report.new_clusters == declared_caps and report.new_rooms == declared_rooms:
+        return
+    # Find which office this floor belongs to.
+    office_id = next((oid for oid, o in offices.items() if floor.id in o.floors), None)
+    if office_id is None:
+        return  # shouldn't happen if floor came from offices
+    yaml_path = data_dir / "data" / "offices.yaml"
+    new_clusters_spec = {
+        letter: {
+            "capacity": cap,
+            "type": (floor.clusters[letter].type if letter in floor.clusters else "open-space"),
+        }
+        for letter, cap in report.new_clusters.items()
+    }
+    new_rooms_spec = {
+        rid: (
+            {
+                "name": floor.rooms[rid].name,
+                "type": floor.rooms[rid].type,
+                "capacity": floor.rooms[rid].capacity,
+            }
+            if rid in floor.rooms
+            else {"name": f"Room {rid}", "type": "meeting", "capacity": 4}
+        )
+        for rid in report.new_rooms
+    }
+    update_floor_entry(
+        yaml_path,
+        office_id,
+        floor.id,
+        clusters=new_clusters_spec,
+        rooms=new_rooms_spec,
+    )
+    report.actions.append(f"updated offices.yaml: {floor.id} clusters/rooms auto-grown")
 
 
 def _print_doctor_text(payload: list[dict[str, object]]) -> None:
@@ -1177,6 +1243,15 @@ def register(sub: argparse._SubParsersAction) -> None:
         help="Path to a floor SVG, or a floor id (e.g. 'tlv-floor-5').",
     )
     p_doc.add_argument("--all", action="store_true", help="Doctor every declared SVG.")
+    p_doc.add_argument(
+        "--prune",
+        action="store_true",
+        help=(
+            "Aggressive cleanup: drop off-page shapes + dedupe near-duplicates "
+            "+ drop excess beyond declared capacity. Default keeps everything "
+            "and just fixes the ids (auto-growing offices.yaml to match)."
+        ),
+    )
     p_doc.add_argument(
         "--dry-run",
         action="store_true",

--- a/office_cli/explain/catalog.py
+++ b/office_cli/explain/catalog.py
@@ -173,10 +173,10 @@ Text: one line per floor (`OK` / `FAIL`) plus indented `error [rule]:` /
 _FLOORS_DOCTOR = """\
 # office floors doctor
 
-Diagnose and fix common Inkscape pitfalls in a traced floor SVG.
-Inkscape's `Ctrl+D` duplication generates ids like `5-T-06-7-4-0-8`
-and often leaves shapes off-page; this verb cleans the noise so the
-file passes `office floors validate`.
+Fix the ids in a traced floor SVG. By default the verb keeps every
+shape (just renumbers them per cluster) and auto-grows
+`offices.yaml` to match. Pass `--prune` for the original aggressive
+cleanup that drops off-page + near-duplicate shapes.
 
 ## Usage
 
@@ -184,41 +184,59 @@ file passes `office floors validate`.
     office floors doctor tlv-floor-5 --dry-run
     office floors doctor floors/tlv-floor-5.svg
     office floors doctor --all
+    office floors doctor tlv-floor-5 --prune          # aggressive cleanup
     office floors doctor tlv-floor-5 --json
 
 A bare argument is tried first as a floor id (matched against
 `offices.yaml`), then falls back to a path resolved against the
 data dir.
 
-## What it does (in order)
+## Default mode (keep-all)
 
-1. Drops `<rect class="seat">` and `<polygon class="room">` whose
-   bounding-box center is outside the 1920x1080 viewBox.
-2. Drops near-duplicate elements (centers within ~6 px of an
-   already-kept element of the same class).
-3. Sorts surviving elements row-major (y bucketed by ~30 px, then x).
-4. Renumbers seats per the floor's `offices.yaml` cluster spec
-   (clusters walked in alphabetical order, capacities filled in
-   sequence). Excess seats are dropped.
-5. Renumbers rooms per the floor's declared room ids in
-   `offices.yaml`. Excess rooms are dropped.
+1. Detect cluster letter from each seat's existing id (regex
+   `<floor>-([A-Z])-`); seats without a recognized prefix go to
+   the first declared cluster letter.
+2. Within each cluster, sort row-major (y bucketed by ~30 px,
+   then x); mint sequential `<floor>-<LETTER>-<NN>` ids.
+3. For rooms: pull the numeric suffix from existing
+   `<floor>.<NN>` ids; sort spatially; mint sequential
+   `<floor>.<NN>` ids starting at the minimum suffix found
+   (defaults to 18).
+4. Auto-grow `offices.yaml`: bump cluster capacities to the actual
+   counts; replace the `rooms:` block with the new sequential id
+   list. Newly-added rooms get default `name: "Room <id>"`,
+   `type: meeting`, `capacity: 4` — operator can edit later.
+
+The new SVG passes `office floors validate` cleanly.
+
+## Prune mode (`--prune`)
+
+1. Drop `<rect class="seat">` / `<polygon class="room">` whose
+   center is outside the 1920×1080 viewBox.
+2. Drop near-duplicates (centers within ~6 px).
+3. Renumber per the existing `offices.yaml` cluster spec; drop
+   excess. Used when an Inkscape `Ctrl+D` cascade left many true
+   overlapping copies and the operator wants them flattened.
+
+`offices.yaml` is **not** mutated in prune mode.
 
 ## Output
 
 Text: a status line plus indented action lines and any warnings:
 
-    OK    tlv-floor-5 (floors/tlv-floor-5.svg) seats 21->5 rooms 14->1
-      dropped 16 off-page seats
-      dropped 13 near-duplicate rooms
-      renamed 5 seats
-      renamed 1 room
-      warn: 5 seats traced; offices.yaml declares 8 ...
+    OK    tlv-floor-5 (floors/tlv-floor-5.svg) seats 21->21 rooms 14->14
+      renamed 21 seats
+      clusters: T: 6 -> 21
+      renamed 14 rooms
+      + 13 rooms (5.19..5.31)
+      updated offices.yaml: tlv-floor-5 clusters/rooms auto-grown
 
-JSON: `{"results": [{<fields>}]}` where `<fields>` includes
-`floor`, `svg`, `dry_run`, `seats_before`, `seats_after`,
-`rooms_before`, `rooms_after`, `actions`, `warnings`.
+JSON: `{"results": [{...}]}` with the same fields plus
+`new_clusters` (letter → capacity) and `new_rooms` (id list)
+reflecting the post-doctor spec.
 
-`--dry-run` reports what would change without writing the SVG.
+`--dry-run` reports what would change without writing either the
+SVG or `offices.yaml`.
 """
 
 _FLOORS_SCAFFOLD = """\

--- a/office_cli/floors/_doctor.py
+++ b/office_cli/floors/_doctor.py
@@ -287,7 +287,7 @@ def _renumber_rooms_keep_all(
 def _default_cluster_letter(floor: Floor) -> str:
     """First declared cluster letter, or 'T' if none."""
     if floor.clusters:
-        return sorted(floor.clusters.keys())[0]
+        return min(floor.clusters.keys())
     return "T"
 
 

--- a/office_cli/floors/_doctor.py
+++ b/office_cli/floors/_doctor.py
@@ -1,10 +1,21 @@
 """Diagnose-and-fix for floor SVGs.
 
-Cleans up the most common Inkscape pitfall: ``Ctrl+D`` duplication
-generates ids like ``5-T-06-7-4-0-8`` and leaves shapes scattered
-off-page. :func:`doctor_svg` parses the SVG, drops elements outside
-the viewBox, deduplicates near-overlapping shapes, then renumbers
-the survivors per the floor's ``offices.yaml`` cluster spec.
+Two modes:
+
+- **Default (keep-all)**: just fix the ids. Walks every traced
+  ``<rect class="seat">`` and ``<polygon class="room">``, detects
+  the cluster letter / floor prefix, sorts spatially, mints
+  sequential valid ids. Auto-grows the slot list to accommodate
+  every shape — operators don't lose any traced geometry. The
+  caller (CLI verb) then auto-grows ``offices.yaml`` to match the
+  new cluster capacity / room list.
+
+- **Prune mode** (``prune=True``): the original aggressive cleanup.
+  Drops shapes outside the ``1920x1080`` viewBox, drops near-
+  duplicate shapes within ``_DEDUP_PX`` of each other, then
+  renumbers per the floor's ``offices.yaml`` cluster spec (drops
+  excess). Useful when an Inkscape ``Ctrl+D`` cascade has produced
+  many overlapping copies the operator wants flattened.
 
 The function is pure on the file-system: pass ``dry_run=True`` to
 get a report without writing changes.
@@ -26,6 +37,13 @@ _VIEW_W = 1920
 _VIEW_H = 1080
 _DEDUP_PX = 6.0  # bounding-box centers within this distance treated as duplicates
 _ROW_TOL = 30.0  # y-pixel grouping tolerance for row-major spatial sort
+
+# Detect a cluster letter prefix in an existing seat id, e.g.
+# ``5-T-06`` or ``5-T-06-7-2`` (Ctrl+D cascade) → letter ``T``.
+_CLUSTER_LETTER_RE = re.compile(r"^\d+-([A-Z])-")
+# Detect floor.<NN> in an existing room id (or its ``5.18-1-3``
+# Ctrl+D-cascade descendants). Captures the first numeric suffix.
+_ROOM_NUM_RE = re.compile(r"^\d+\.(\d+)")
 
 # Register the SVG namespace as the default so writes emit
 # <svg xmlns="..."> instead of <ns0:svg xmlns:ns0="...">. Browsers
@@ -49,6 +67,11 @@ class DoctorReport:
     rooms_after: int
     actions: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    # Post-doctor cluster spec: letter → capacity. The CLI uses this
+    # to auto-grow offices.yaml when shapes exceed declared capacity.
+    new_clusters: dict[str, int] = field(default_factory=dict)
+    # Post-doctor room id list, in spatial order. Ditto auto-grow.
+    new_rooms: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -61,29 +84,42 @@ class DoctorReport:
             "rooms_after": self.rooms_after,
             "actions": list(self.actions),
             "warnings": list(self.warnings),
+            "new_clusters": dict(self.new_clusters),
+            "new_rooms": list(self.new_rooms),
         }
 
 
-def doctor_svg(svg_path: Path, floor: Floor, *, dry_run: bool = False) -> DoctorReport:
-    """Clean up duplicate / off-page noise in ``svg_path`` for ``floor``.
+def doctor_svg(
+    svg_path: Path,
+    floor: Floor,
+    *,
+    dry_run: bool = False,
+    prune: bool = False,
+) -> DoctorReport:
+    """Fix the ids in ``svg_path`` for ``floor``; optionally prune.
 
-    Steps (in order):
+    Default behavior (``prune=False``):
 
-    1. Drop ``<rect class="seat">`` and ``<polygon class="room">``
-       elements whose bounding-box center is outside the 1920x1080
-       viewBox.
-    2. Drop near-duplicate elements (centers within ``_DEDUP_PX`` of
-       an already-kept element of the same class).
-    3. Sort survivors row-major (y bucketed by ``_ROW_TOL``, then x).
-    4. Renumber:
-       - seats: walk ``floor.clusters`` in alphabetical order; assign
-         ``<floor>-<LETTER>-<NN>`` ids until each cluster's capacity
-         is filled. Excess seats beyond the total capacity are dropped.
-       - rooms: assign ids from ``floor.rooms`` keys (architect ids)
-         in spatial order. Excess rooms are dropped.
+    1. Detect the cluster letter for each seat from its existing id.
+       Seats whose ids don't match ``<floor>-<LETTER>-`` are bucketed
+       into the first declared cluster letter.
+    2. Within each cluster, spatial-sort row-major, mint sequential
+       ``<floor>-<LETTER>-<NN>`` ids.
+    3. For rooms: detect numeric suffix from existing ``<floor>.<NN>``
+       ids; spatial-sort; mint sequential ``<floor>.<NN>`` starting
+       at ``min(existing)`` (or ``18`` if no existing valid suffix).
+    4. **Keep all traced shapes** — the slot list extends to fit.
 
-    Returns a :class:`DoctorReport` describing what changed. With
-    ``dry_run=True`` the file is not written.
+    With ``prune=True``:
+
+    1. Drop ``<rect class="seat">`` / ``<polygon class="room">``
+       whose center is outside ``1920x1080``.
+    2. Drop near-duplicate elements (centers within ``_DEDUP_PX``).
+    3. Renumber per the floor's declared cluster spec; drop excess.
+
+    Returns a :class:`DoctorReport`. With ``dry_run=True`` the file
+    is not written; the caller can still inspect the report's
+    ``new_clusters`` / ``new_rooms`` to preview the effect.
     """
     if not svg_path.is_file():
         raise OfficeError(
@@ -102,16 +138,20 @@ def doctor_svg(svg_path: Path, floor: Floor, *, dry_run: bool = False) -> Doctor
     rooms_before = len(rooms)
 
     actions: list[str] = []
-    seat_slots = _seat_ids_for(floor.number, floor.clusters)
-    room_slots = list(floor.rooms.keys())
-
-    seats, seat_excess = _clean_category(seats, seat_slots, parents, "seats", actions)
-    rooms, room_excess = _clean_category(rooms, room_slots, parents, "rooms", actions)
-
-    seats_after = min(len(seats) - seat_excess, len(seat_slots))
-    rooms_after = min(len(rooms) - room_excess, len(room_slots))
-
-    warnings = _capacity_warnings(seats_after, len(seat_slots), rooms_after, len(room_slots))
+    if prune:
+        seats_after, rooms_after, new_clusters, new_rooms = _prune_and_renumber(
+            seats, rooms, floor, parents, actions
+        )
+    else:
+        seats_after, rooms_after, new_clusters, new_rooms = _keep_all_renumber(
+            seats, rooms, floor, actions
+        )
+    warnings = _capacity_warnings(
+        seats_after,
+        sum(c.capacity for c in floor.clusters.values()),
+        rooms_after,
+        len(floor.rooms),
+    )
 
     if not dry_run and actions:
         # Pretty-print before write so floor SVGs in the repo produce a
@@ -129,7 +169,158 @@ def doctor_svg(svg_path: Path, floor: Floor, *, dry_run: bool = False) -> Doctor
         rooms_after=rooms_after,
         actions=actions,
         warnings=warnings,
+        new_clusters=new_clusters,
+        new_rooms=new_rooms,
     )
+
+
+# -- modes ------------------------------------------------------------------
+
+
+def _prune_and_renumber(
+    seats: list[ET.Element],
+    rooms: list[ET.Element],
+    floor: Floor,
+    parents: dict[ET.Element, ET.Element],
+    actions: list[str],
+) -> tuple[int, int, dict[str, int], list[str]]:
+    """Prune mode (existing aggressive behavior). Returns the post-counts."""
+    seat_slots = _seat_ids_for(floor.number, floor.clusters)
+    room_slots = list(floor.rooms.keys())
+    seats, seat_excess = _clean_category(seats, seat_slots, parents, "seats", actions)
+    rooms, room_excess = _clean_category(rooms, room_slots, parents, "rooms", actions)
+    seats_after = min(len(seats) - seat_excess, len(seat_slots))
+    rooms_after = min(len(rooms) - room_excess, len(room_slots))
+    # Post-doctor spec is unchanged from the declared one (we dropped to fit).
+    new_clusters = {letter: c.capacity for letter, c in floor.clusters.items()}
+    new_rooms = list(floor.rooms.keys())
+    return seats_after, rooms_after, new_clusters, new_rooms
+
+
+def _keep_all_renumber(
+    seats: list[ET.Element],
+    rooms: list[ET.Element],
+    floor: Floor,
+    actions: list[str],
+) -> tuple[int, int, dict[str, int], list[str]]:
+    """Keep-all mode: just fix ids; auto-grow slot list to fit every shape."""
+    new_clusters = _renumber_seats_keep_all(seats, floor, actions)
+    new_rooms = _renumber_rooms_keep_all(rooms, floor, actions)
+    return len(seats), len(rooms), new_clusters, new_rooms
+
+
+def _renumber_seats_keep_all(
+    seats: list[ET.Element],
+    floor: Floor,
+    actions: list[str],
+) -> dict[str, int]:
+    """Renumber all seats, auto-growing each cluster letter's capacity.
+
+    Returns the post-doctor cluster spec (letter → count).
+    """
+    default_letter = _default_cluster_letter(floor)
+    by_letter: dict[str, list[ET.Element]] = {}
+    for el in seats:
+        letter = _detect_cluster_letter(el.get("id") or "", default_letter)
+        by_letter.setdefault(letter, []).append(el)
+
+    new_caps: dict[str, int] = {}
+    renamed_total = 0
+    for letter in sorted(by_letter.keys()):
+        items = by_letter[letter]
+        items.sort(key=_spatial_key)
+        for n, el in enumerate(items, start=1):
+            new_id = f"{floor.number}-{letter}-{n:02d}"
+            if (el.get("id") or "") != new_id:
+                el.set("id", new_id)
+                renamed_total += 1
+        new_caps[letter] = len(items)
+
+    # Preserve declared cluster letters with capacity 0 if no shapes
+    # mapped to them (operator may add later — keeps offices.yaml stable).
+    for letter in floor.clusters:
+        new_caps.setdefault(letter, 0)
+
+    if renamed_total:
+        actions.append(f"renamed {renamed_total} seats")
+    grown = [
+        f"{letter}: {floor.clusters[letter].capacity} -> {cap}"
+        for letter, cap in new_caps.items()
+        if letter in floor.clusters and cap != floor.clusters[letter].capacity
+    ]
+    new_letters = sorted(set(new_caps) - set(floor.clusters))
+    if new_letters:
+        grown.extend(f"+ {letter}: {new_caps[letter]}" for letter in new_letters)
+    if grown:
+        actions.append(f"clusters: {', '.join(grown)}")
+    return new_caps
+
+
+def _renumber_rooms_keep_all(
+    rooms: list[ET.Element],
+    floor: Floor,
+    actions: list[str],
+) -> list[str]:
+    """Renumber all rooms, auto-growing the rooms list to fit every shape."""
+    if not rooms:
+        return list(floor.rooms.keys())
+    rooms_sorted = sorted(rooms, key=_spatial_key)
+    start = _room_number_start(rooms_sorted, floor)
+    new_ids: list[str] = []
+    renamed = 0
+    for offset, el in enumerate(rooms_sorted):
+        new_id = f"{floor.number}.{start + offset}"
+        new_ids.append(new_id)
+        if (el.get("id") or "") != new_id:
+            el.set("id", new_id)
+            renamed += 1
+    if renamed:
+        actions.append(f"renamed {renamed} rooms")
+    declared = list(floor.rooms.keys())
+    if new_ids != declared:
+        added = [r for r in new_ids if r not in floor.rooms]
+        if added:
+            actions.append(f"+ {len(added)} rooms ({added[0]}..{added[-1]})")
+    return new_ids
+
+
+def _default_cluster_letter(floor: Floor) -> str:
+    """First declared cluster letter, or 'T' if none."""
+    if floor.clusters:
+        return sorted(floor.clusters.keys())[0]
+    return "T"
+
+
+def _detect_cluster_letter(seat_id: str, default_letter: str) -> str:
+    m = _CLUSTER_LETTER_RE.match(seat_id)
+    return m.group(1) if m else default_letter
+
+
+def _room_number_start(rooms_sorted: list[ET.Element], floor: Floor) -> int:
+    """Pick the starting NN for room renumbering.
+
+    Uses the smallest valid existing NN (e.g. 18 from ``5.18``) so
+    the architect's own first-room number is preserved. Falls back
+    to the floor's smallest declared room number, or 18 by default.
+    """
+    found: list[int] = []
+    for el in rooms_sorted:
+        m = _ROOM_NUM_RE.match(el.get("id") or "")
+        if m:
+            found.append(int(m.group(1)))
+    if found:
+        return min(found)
+    declared = [
+        int(rid.split(".", 1)[1])
+        for rid in floor.rooms
+        if "." in rid and rid.split(".", 1)[1].isdigit()
+    ]
+    if declared:
+        return min(declared)
+    return 18
+
+
+# -- prune-mode helpers -----------------------------------------------------
 
 
 def _parse(svg_path: Path) -> ET.ElementTree:
@@ -192,9 +383,6 @@ def _capacity_warnings(
             "(trace more in Inkscape and re-run)"
         )
     return out
-
-
-# -- helpers ----------------------------------------------------------------
 
 
 def _assign_ids(

--- a/office_cli/floors/_doctor.py
+++ b/office_cli/floors/_doctor.py
@@ -219,9 +219,10 @@ def _renumber_seats_keep_all(
     Returns the post-doctor cluster spec (letter → count).
     """
     default_letter = _default_cluster_letter(floor)
+    declared = set(floor.clusters)
     by_letter: dict[str, list[ET.Element]] = {}
     for el in seats:
-        letter = _detect_cluster_letter(el.get("id") or "", default_letter)
+        letter = _detect_cluster_letter(el.get("id") or "", default_letter, declared=declared)
         by_letter.setdefault(letter, []).append(el)
 
     new_caps: dict[str, int] = {}
@@ -285,15 +286,39 @@ def _renumber_rooms_keep_all(
 
 
 def _default_cluster_letter(floor: Floor) -> str:
-    """First declared cluster letter, or 'T' if none."""
+    """First **declared** cluster letter, or 'T' if none.
+
+    Uses ``next(iter(...))`` rather than alphabetical sort so the
+    docstring matches the behavior — a floor declared as
+    ``Z: 5, T: 3`` defaults to ``Z`` (declaration order), not ``T``
+    (alphabetical). YAML loaders preserve insertion order. Qodo PR #59.
+    """
     if floor.clusters:
-        return min(floor.clusters.keys())
+        return next(iter(floor.clusters))
     return "T"
 
 
-def _detect_cluster_letter(seat_id: str, default_letter: str) -> str:
+def _detect_cluster_letter(
+    seat_id: str,
+    default_letter: str,
+    *,
+    declared: set[str] | None = None,
+) -> str:
+    """Pull a cluster letter out of an existing seat id; fall back to default.
+
+    When ``declared`` is given, a regex-detected letter is only
+    accepted if it's in the declared set — this prevents Ctrl+D
+    cascade ids like ``5-X-06-7-2`` (where X isn't a declared
+    cluster) from spuriously creating a new cluster X via auto-grow.
+    Qodo PR #59.
+    """
     m = _CLUSTER_LETTER_RE.match(seat_id)
-    return m.group(1) if m else default_letter
+    if not m:
+        return default_letter
+    letter = m.group(1)
+    if declared is not None and letter not in declared:
+        return default_letter
+    return letter
 
 
 def _room_number_start(rooms_sorted: list[ET.Element], floor: Floor) -> int:

--- a/office_cli/offices/__init__.py
+++ b/office_cli/offices/__init__.py
@@ -9,7 +9,15 @@ without leaking tracebacks.
 from __future__ import annotations
 
 from office_cli.offices._models import Cluster, Floor, Office, Room
-from office_cli.offices._writer import append_floor_entry
+from office_cli.offices._writer import append_floor_entry, update_floor_entry
 from office_cli.offices._yaml import load_offices
 
-__all__ = ["Cluster", "Floor", "Office", "Room", "append_floor_entry", "load_offices"]
+__all__ = [
+    "Cluster",
+    "Floor",
+    "Office",
+    "Room",
+    "append_floor_entry",
+    "load_offices",
+    "update_floor_entry",
+]

--- a/office_cli/offices/_writer.py
+++ b/office_cli/offices/_writer.py
@@ -218,6 +218,141 @@ def _line_belongs_to_block(line: str, item_prefix: str) -> bool:
     return False
 
 
+def update_floor_entry(
+    yaml_path: Path,
+    office_id: str,
+    floor_id: str,
+    *,
+    clusters: Mapping[str, Mapping[str, object]] | None = None,
+    rooms: Mapping[str, Mapping[str, object]] | None = None,
+) -> None:
+    """Replace the ``clusters:`` and/or ``rooms:`` blocks of a floor entry.
+
+    Used by ``office floors doctor`` (issue #54 follow-up) to auto-grow
+    the YAML when the SVG has more shapes than declared. Locates the
+    matching ``- id: <floor_id>`` block under ``office_id`` and replaces
+    its child ``clusters:`` / ``rooms:`` subtrees textually, preserving
+    everything else byte-for-byte.
+
+    ``clusters`` is a mapping ``letter -> {"capacity": int, "type": str}``.
+    ``rooms`` is a mapping ``room_id -> {"name": str, "type": str,
+    "capacity": int}``. Pass ``None`` to leave that subtree unchanged.
+    """
+    if yaml_path.name != "offices.yaml":
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"refusing to write a non-offices.yaml file: {yaml_path}",
+            remediation="pass a path whose final component is `offices.yaml`",
+        )
+    if not yaml_path.is_file():
+        raise OfficeError(
+            code=EXIT_USER_ERROR,
+            message=f"offices.yaml not found: {yaml_path}",
+            remediation="check the --data-dir or run from the repo root",
+        )
+    text = yaml_path.read_text(encoding="utf-8")
+    parsed = _parse_offices(text, yaml_path)
+    _find_office(parsed, office_id, yaml_path)  # validates existence
+    lines = text.splitlines(keepends=True)
+    floor_line, floor_indent = _locate_floor_in_office(lines, office_id, floor_id, yaml_path)
+    nested = " " * (floor_indent + 2)
+    new_text = text
+    new_lines = new_text.splitlines(keepends=True)
+    # Re-locate inside new_lines after each replacement (offsets shift).
+    if clusters is not None:
+        new_block = _format_clusters_block(dict(clusters), nested)
+        new_lines = _replace_subtree(new_lines, floor_line, floor_indent, "clusters:", new_block)
+        # Recompute floor_line in case clusters block size changed.
+        floor_line, floor_indent = _locate_floor_in_office(
+            new_lines, office_id, floor_id, yaml_path
+        )
+        nested = " " * (floor_indent + 2)
+    if rooms is not None:
+        new_block = _format_rooms_block(dict(rooms), nested)
+        new_lines = _replace_subtree(new_lines, floor_line, floor_indent, "rooms:", new_block)
+    yaml_path.write_text("".join(new_lines), encoding="utf-8")
+
+
+def _locate_floor_in_office(
+    lines: list[str], office_id: str, floor_id: str, path: Path
+) -> tuple[int, int]:
+    """Return ``(line_index, indent)`` for the floor's ``- id:`` line."""
+    office_line, office_indent = _locate_office_block(lines, office_id, path)
+    floors_line, _ = _locate_floors_key(lines, office_line, office_indent, office_id, path)
+    needle = re.compile(r"^(\s*)- id:\s*" + re.escape(floor_id) + r"\s*$")
+    for i in range(floors_line + 1, len(lines)):
+        m = needle.match(lines[i])
+        if m:
+            return i, len(m.group(1))
+        # If we walked past the office's floors list, the floor isn't there.
+        if re.match(r"^" + " " * office_indent + r"- id:", lines[i]):
+            break
+    raise OfficeError(
+        code=EXIT_USER_ERROR,
+        message=(f"floor {floor_id!r} not found under office {office_id!r} in {path}"),
+        remediation="check the floor id matches the offices.yaml entry",
+    )
+
+
+def _replace_subtree(
+    lines: list[str],
+    floor_line: int,
+    floor_indent: int,
+    key_name: str,
+    new_block: str,
+) -> list[str]:
+    """Replace the ``<nested>key_name:`` block under ``floor_line``.
+
+    The block runs from the ``key_name:`` line through every following
+    line whose indent is deeper than ``floor_indent + 2`` (i.e. inside
+    the floor's mapping). Stops at any line at floor-level or shallower,
+    or at the next ``- id:`` of the same depth.
+    """
+    nested = " " * (floor_indent + 2)
+    pattern = re.compile(r"^" + re.escape(nested) + re.escape(key_name) + r"\s*$")
+    block_start = -1
+    for i in range(floor_line + 1, len(lines)):
+        if pattern.match(lines[i]):
+            block_start = i
+            break
+        # Walked off the floor's mapping into the next sibling.
+        if lines[i].startswith(" " * floor_indent + "- ") or (
+            lines[i].strip() and not lines[i].startswith(nested)
+        ):
+            break
+    if block_start < 0:
+        # Key didn't exist; insert a new block at the end of the floor's mapping.
+        insert_at = _find_floor_block_end(lines, floor_line, floor_indent)
+        return lines[:insert_at] + [new_block] + lines[insert_at:]
+    block_end = _find_subtree_end(lines, block_start, len(nested))
+    return lines[:block_start] + [new_block] + lines[block_end:]
+
+
+def _find_subtree_end(lines: list[str], block_start: int, key_indent: int) -> int:
+    """End-line (exclusive) of a YAML key's value block."""
+    for i in range(block_start + 1, len(lines)):
+        line = lines[i]
+        if not line.strip():
+            continue
+        # First line at or shallower than key_indent ends the subtree.
+        leading = len(line) - len(line.lstrip())
+        if leading <= key_indent:
+            return i
+    return len(lines)
+
+
+def _find_floor_block_end(lines: list[str], floor_line: int, floor_indent: int) -> int:
+    """End-line (exclusive) of a floor's mapping body."""
+    nested = " " * (floor_indent + 2)
+    for i in range(floor_line + 1, len(lines)):
+        line = lines[i]
+        if not line.strip():
+            continue
+        if not line.startswith(nested):
+            return i
+    return len(lines)
+
+
 def _format_floor_block(floor: Mapping[str, object], item_indent: str = _DEFAULT_INDENT) -> str:
     """Render a floor mapping as a YAML block matching the file's indent.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.14.0"
+version = "0.15.0"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_floors.py
+++ b/tests/test_cli_floors.py
@@ -71,8 +71,10 @@ def test_floors_validate_relative_path_from_other_cwd(
     assert payload["results"][0]["ok"] is True
 
 
-def test_floors_doctor_dry_run_reports(data_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    """Polluted SVG → dry-run reports actions but doesn't write."""
+def test_floors_doctor_prune_dry_run_reports(
+    data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Polluted SVG with --prune --dry-run → reports drops without writing."""
     svg = data_dir / "floors" / "tlv-floor-5.svg"
     polluted = (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
@@ -92,6 +94,7 @@ def test_floors_doctor_dry_run_reports(data_dir: Path, capsys: pytest.CaptureFix
             "floors",
             "doctor",
             str(svg),
+            "--prune",
             "--dry-run",
             "--json",
             "--data-dir",
@@ -108,6 +111,74 @@ def test_floors_doctor_dry_run_reports(data_dir: Path, capsys: pytest.CaptureFix
     assert result["rooms_after"] == 1
     # No write happened.
     assert svg.read_text(encoding="utf-8") == before
+
+
+def test_floors_doctor_default_keep_all_autogrows_yaml(
+    data_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The new default: keep all 21 seats, fix ids, mutate offices.yaml.
+
+    This is the headline e2e for PR-E. The fixture has T:6 + Z:2; after
+    doctor on a polluted 21-seat SVG, offices.yaml should show T:21.
+    """
+    svg = data_dir / "floors" / "tlv-floor-5.svg"
+    # 21 garbled seats + 14 garbled rooms (mirrors test_floors_doctor.py's
+    # _polluted_svg fixture).
+    on_page_seats = [
+        ("5-T-06-7-2", 92.99, 73.25),
+        ("5-T-06-7-0", 145.04, 75.10),
+        ("5-T-06", 41.80, 102.08),
+        ("5-T-06-7", 93.05, 101.54),
+        ("5-T-06-7-4", 143.73, 102.45),
+    ]
+    seat_lines = [
+        f'<rect id="{sid}" class="seat" x="{x}" y="{y}" width="51" height="25"/>'
+        for sid, x, y in on_page_seats
+    ]
+    seat_lines += [
+        f'<rect id="5-T-06-extra-{i}" class="seat" '
+        f'x="{50 + (i * 3 % 100)}" y="{-300 - i * 8}" width="51" height="25"/>'
+        for i in range(16)
+    ]
+    room_lines = []
+    for i in range(14):
+        offset = i * 0.5
+        rid = "5.18" if i == 0 else f"5.18-{'-'.join(str(d) for d in range(1, i + 1))}"
+        pts = (
+            f"{1400 + offset},{300 + offset} {1700 + offset},{300 + offset} "
+            f"{1700 + offset},{500 + offset} {1400 + offset},{500 + offset}"
+        )
+        room_lines.append(f'<polygon id="{rid}" class="room" points="{pts}"/>')
+    polluted = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">\n'
+        + "\n".join(seat_lines)
+        + "\n"
+        + "\n".join(room_lines)
+        + "\n"
+        + "</svg>\n"
+    )
+    svg.write_text(polluted, encoding="utf-8")
+
+    rc = main(
+        [
+            "floors",
+            "doctor",
+            str(svg),
+            "--json",
+            "--data-dir",
+            str(data_dir),
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    result = payload["results"][0]
+    assert result["seats_before"] == 21
+    assert result["seats_after"] == 21
+    assert result["new_clusters"]["T"] == 21
+    # offices.yaml mutated.
+    yaml_text = (data_dir / "data" / "offices.yaml").read_text(encoding="utf-8")
+    assert "T: { capacity: 21" in yaml_text
 
 
 def test_floors_doctor_writes_and_validate_passes(

--- a/tests/test_floors_doctor.py
+++ b/tests/test_floors_doctor.py
@@ -59,11 +59,12 @@ def _polluted_svg(view_box: str = "0 0 1920 1080") -> str:
     )
 
 
-def test_doctor_drops_off_page_and_dedupes_rooms(data_dir: Path) -> None:
+def test_doctor_prune_drops_off_page_and_dedupes_rooms(data_dir: Path) -> None:
+    """`--prune` mode: the original aggressive cleanup."""
     svg_path = data_dir / "floors" / "tlv-floor-5.svg"
     svg_path.write_text(_polluted_svg(), encoding="utf-8")
 
-    report = doctor_svg(svg_path, _floor(data_dir))
+    report = doctor_svg(svg_path, _floor(data_dir), prune=True)
 
     assert report.seats_before == 21
     assert report.rooms_before == 14
@@ -73,11 +74,11 @@ def test_doctor_drops_off_page_and_dedupes_rooms(data_dir: Path) -> None:
     assert any("near-duplicate rooms" in a for a in report.actions)
 
 
-def test_doctor_renumbers_in_spatial_order(data_dir: Path) -> None:
+def test_doctor_prune_renumbers_in_spatial_order(data_dir: Path) -> None:
     svg_path = data_dir / "floors" / "tlv-floor-5.svg"
     svg_path.write_text(_polluted_svg(), encoding="utf-8")
 
-    doctor_svg(svg_path, _floor(data_dir))
+    doctor_svg(svg_path, _floor(data_dir), prune=True)
 
     # The five survivors get cluster T slots. One of the polluted
     # ids (`5-T-06`) was already a valid slot, so the doctor preserves
@@ -87,11 +88,11 @@ def test_doctor_renumbers_in_spatial_order(data_dir: Path) -> None:
     assert sorted(svg.room_ids) == ["5.18"]
 
 
-def test_doctor_makes_validate_clean(data_dir: Path) -> None:
+def test_doctor_prune_makes_validate_clean(data_dir: Path) -> None:
     svg_path = data_dir / "floors" / "tlv-floor-5.svg"
     svg_path.write_text(_polluted_svg(), encoding="utf-8")
 
-    doctor_svg(svg_path, _floor(data_dir))
+    doctor_svg(svg_path, _floor(data_dir), prune=True)
 
     svg = parse_svg(svg_path)
     issues = validate_floor(svg, _floor(data_dir))
@@ -99,12 +100,12 @@ def test_doctor_makes_validate_clean(data_dir: Path) -> None:
     assert errors == []
 
 
-def test_doctor_dry_run_reports_without_writing(data_dir: Path) -> None:
+def test_doctor_prune_dry_run_reports_without_writing(data_dir: Path) -> None:
     svg_path = data_dir / "floors" / "tlv-floor-5.svg"
     polluted = _polluted_svg()
     svg_path.write_text(polluted, encoding="utf-8")
 
-    report = doctor_svg(svg_path, _floor(data_dir), dry_run=True)
+    report = doctor_svg(svg_path, _floor(data_dir), dry_run=True, prune=True)
 
     assert report.dry_run is True
     assert report.seats_after == 5
@@ -112,22 +113,22 @@ def test_doctor_dry_run_reports_without_writing(data_dir: Path) -> None:
     assert svg_path.read_text(encoding="utf-8") == polluted
 
 
-def test_doctor_warns_when_capacity_short(data_dir: Path) -> None:
+def test_doctor_prune_warns_when_capacity_short(data_dir: Path) -> None:
     """offices.yaml declares 6+2=8 seats; polluted fixture has 5
-    on-page survivors. Doctor should still succeed but emit a warning
-    so the operator knows to trace more in Inkscape."""
+    on-page survivors after prune. Doctor still succeeds but emits a
+    warning so the operator knows to trace more."""
     svg_path = data_dir / "floors" / "tlv-floor-5.svg"
     svg_path.write_text(_polluted_svg(), encoding="utf-8")
 
-    report = doctor_svg(svg_path, _floor(data_dir))
+    report = doctor_svg(svg_path, _floor(data_dir), prune=True)
 
     assert any("5 seats traced" in w for w in report.warnings)
     assert any("declares 8" in w for w in report.warnings)
 
 
-def test_doctor_drops_excess_seats_beyond_capacity(data_dir: Path) -> None:
-    """An SVG with more on-page seats than the cluster total should
-    have the excess deleted, not left to fail validation later."""
+def test_doctor_prune_drops_excess_seats_beyond_capacity(data_dir: Path) -> None:
+    """Prune mode: SVG with more on-page seats than total capacity has
+    the excess deleted."""
     extras = "".join(
         f'<rect id="extra-{i}" class="seat" x="{200 + i * 60}" y="800" width="40" height="20"/>'
         for i in range(15)  # 15 extra seats > total capacity 8
@@ -142,11 +143,82 @@ def test_doctor_drops_excess_seats_beyond_capacity(data_dir: Path) -> None:
     svg_path = data_dir / "floors" / "tlv-floor-5.svg"
     svg_path.write_text(svg_text, encoding="utf-8")
 
-    report = doctor_svg(svg_path, _floor(data_dir))
+    report = doctor_svg(svg_path, _floor(data_dir), prune=True)
 
     assert report.seats_before == 15
     assert report.seats_after == 8  # T:6 + Z:2
     assert any("excess seats" in a for a in report.actions)
+
+
+def test_doctor_default_keep_all_preserves_21_seats(data_dir: Path) -> None:
+    """The new default: keep all 21 seats, just fix the garbled ids.
+
+    All garbled ``5-T-06-...`` cascade ids get renumbered to sequential
+    ``5-T-01..21``. Off-page shapes are kept; near-duplicates kept.
+    """
+    svg_path = data_dir / "floors" / "tlv-floor-5.svg"
+    svg_path.write_text(_polluted_svg(), encoding="utf-8")
+
+    report = doctor_svg(svg_path, _floor(data_dir))
+
+    assert report.seats_before == 21
+    assert report.rooms_before == 14
+    assert report.seats_after == 21
+    assert report.rooms_after == 14
+    # All seats live in cluster T (their original cluster letter).
+    assert report.new_clusters["T"] == 21
+    # Z cluster preserved with capacity 0 (was declared, no shapes).
+    assert report.new_clusters.get("Z") == 0
+    parsed = parse_svg(svg_path)
+    assert sorted(parsed.seat_ids) == [f"5-T-{n:02d}" for n in range(1, 22)]
+    # Rooms get sequential ids starting at 18 (the first valid suffix
+    # found in the polluted ``5.18-1-3``-style cascade).
+    assert sorted(parsed.room_ids) == [f"5.{n}" for n in range(18, 32)]
+
+
+def test_doctor_default_dry_run_returns_new_spec_without_writing(data_dir: Path) -> None:
+    """The CLI auto-grow path needs to preview the new spec without
+    mutating the file. Dry-run must return ``new_clusters`` /
+    ``new_rooms`` populated."""
+    svg_path = data_dir / "floors" / "tlv-floor-5.svg"
+    polluted = _polluted_svg()
+    svg_path.write_text(polluted, encoding="utf-8")
+
+    report = doctor_svg(svg_path, _floor(data_dir), dry_run=True)
+
+    assert report.dry_run is True
+    assert report.new_clusters["T"] == 21
+    assert len(report.new_rooms) == 14
+    # File untouched.
+    assert svg_path.read_text(encoding="utf-8") == polluted
+
+
+def test_doctor_default_seat_with_unknown_letter_falls_back_to_first(
+    data_dir: Path,
+) -> None:
+    """A seat id with no cluster-letter prefix (or an unknown one) gets
+    bucketed into the first declared cluster letter so it doesn't get
+    lost. Ensures keep-all mode doesn't drop shapes silently."""
+    svg_text = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">\n'
+        # No cluster prefix at all:
+        '<rect id="orphan-1" class="seat" x="100" y="100" width="40" height="20"/>\n'
+        # Existing T-cluster seats:
+        '<rect id="5-T-99" class="seat" x="200" y="100" width="40" height="20"/>\n'
+        '<polygon id="r" class="room" points="1400,300 1700,300 1700,500 1400,500"/>\n'
+        "</svg>\n"
+    )
+    svg_path = data_dir / "floors" / "tlv-floor-5.svg"
+    svg_path.write_text(svg_text, encoding="utf-8")
+
+    report = doctor_svg(svg_path, _floor(data_dir))
+
+    assert report.seats_after == 2
+    parsed = parse_svg(svg_path)
+    # Both seats should land in cluster T (T is alphabetically first
+    # in the fixture's `T, Z` declarations).
+    assert sorted(parsed.seat_ids) == ["5-T-01", "5-T-02"]
 
 
 def test_doctor_idempotent_on_clean_file(data_dir: Path) -> None:
@@ -244,6 +316,13 @@ def test_doctor_polygon_with_malformed_points_does_not_crash(
     svg_path = data_dir / "floors" / "tlv-floor-5.svg"
     svg_path.write_text(svg_text, encoding="utf-8")
 
+    # Default (keep-all): malformed polygons survive, just renumbered.
+    # Test only asserts no crash — the polygons are kept verbatim with
+    # new ids; their bad ``points`` is the renderer's problem to deal with.
     report = doctor_svg(svg_path, _floor(data_dir))
-    # Doctor completed; the valid room got the slot.
+    assert report.rooms_after == 3
+    # Prune-mode: the bad polygons (whose center is (0, 0)) are dropped
+    # as off-page outliers; only the valid room survives.
+    svg_path.write_text(svg_text, encoding="utf-8")  # restore
+    report = doctor_svg(svg_path, _floor(data_dir), prune=True)
     assert report.rooms_after == 1

--- a/tests/test_floors_doctor.py
+++ b/tests/test_floors_doctor.py
@@ -326,3 +326,63 @@ def test_doctor_polygon_with_malformed_points_does_not_crash(
     svg_path.write_text(svg_text, encoding="utf-8")  # restore
     report = doctor_svg(svg_path, _floor(data_dir), prune=True)
     assert report.rooms_after == 1
+
+
+def test_doctor_default_letter_uses_declaration_order_not_alphabetical(
+    data_dir: Path,
+) -> None:
+    """Qodo PR #59: orphan seats fall back to the **first declared**
+    cluster letter, not the alphabetically-first. A floor declared
+    `Z: ..., T: ...` (Z first in YAML) defaults orphans to Z."""
+    from office_cli.cli._commands.floors import _build_floor_entry  # noqa: F401
+    from office_cli.offices._models import Cluster, Floor
+
+    # Synthesize a floor whose declaration order is Z, T (alphabetically T < Z).
+    floor = Floor(
+        id="tlv-floor-7",
+        svg=data_dir / "floors" / "tlv-floor-7.svg",
+        clusters={
+            "Z": Cluster(letter="Z", capacity=2, type="phone-room"),
+            "T": Cluster(letter="T", capacity=4, type="open-space"),
+        },
+        rooms={},
+        status="draft",
+    )
+    svg_path = data_dir / "floors" / "tlv-floor-7.svg"
+    svg_path.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">\n'
+        # Orphan seat (no cluster prefix).
+        '<rect id="orphan" class="seat" x="100" y="100" width="40" height="20"/>\n' "</svg>\n",
+        encoding="utf-8",
+    )
+
+    report = doctor_svg(svg_path, floor)
+    parsed = parse_svg(svg_path)
+    # Orphan went to Z (declaration-first), not T (alphabetical-first).
+    assert parsed.seat_ids == ("7-Z-01",)
+    assert report.new_clusters["Z"] == 1
+    assert report.new_clusters["T"] == 0
+
+
+def test_doctor_default_undeclared_letter_falls_back(data_dir: Path) -> None:
+    """Qodo PR #59: a seat id like ``5-X-...`` where X isn't a declared
+    cluster must not silently create a new X cluster — it falls back to
+    the default letter."""
+    svg_path = data_dir / "floors" / "tlv-floor-5.svg"
+    svg_path.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">\n'
+        # Spurious cluster letter X (not declared in fixture; clusters are T,Z).
+        '<rect id="5-X-99" class="seat" x="100" y="100" width="40" height="20"/>\n'
+        '<polygon id="r" class="room" points="1400,300 1700,300 1700,500 1400,500"/>\n'
+        "</svg>\n",
+        encoding="utf-8",
+    )
+
+    report = doctor_svg(svg_path, _floor(data_dir))
+    # No spurious X cluster appears.
+    assert "X" not in report.new_clusters
+    # The orphan-X seat goes to the first declared letter (T, since
+    # the fixture declares T then Z).
+    assert report.new_clusters["T"] == 1

--- a/tests/test_offices_writer.py
+++ b/tests/test_offices_writer.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from office_cli.cli._errors import EXIT_USER_ERROR, OfficeError
-from office_cli.offices import append_floor_entry, load_offices
+from office_cli.offices import append_floor_entry, load_offices, update_floor_entry
 
 _TWO_OFFICE_YAML = """\
 # This top-level comment must survive any append.
@@ -234,3 +234,92 @@ def test_append_matches_existing_indentation(tmp_path: Path) -> None:
     # And load_offices must still succeed (well-formed YAML).
     offices = load_offices(tmp_path)
     assert "tlv-floor-3" in offices["tlv"].floors
+
+
+def test_update_floor_entry_replaces_clusters(tmp_path: Path) -> None:
+    """Doctor's auto-grow path: bump T's capacity from 6 to 21 in-place."""
+    yaml_path = _write(tmp_path)
+    update_floor_entry(
+        yaml_path,
+        "tlv",
+        "tlv-floor-5",
+        clusters={"T": {"capacity": 21, "type": "open-space"}},
+    )
+    offices = load_offices(tmp_path)
+    floor = offices["tlv"].floors["tlv-floor-5"]
+    assert floor.clusters["T"].capacity == 21
+    # Other floors untouched.
+    assert offices["nyc"].floors["nyc-floor-12"].clusters["A"].capacity == 4
+
+
+def test_update_floor_entry_replaces_rooms(tmp_path: Path) -> None:
+    """Replace the rooms block with a new sequential list."""
+    yaml_path = _write(tmp_path)
+    new_rooms = {
+        f"5.{n}": {"name": f"Room 5.{n}", "type": "meeting", "capacity": 4} for n in range(18, 32)
+    }
+    update_floor_entry(yaml_path, "tlv", "tlv-floor-5", rooms=new_rooms)
+    offices = load_offices(tmp_path)
+    floor = offices["tlv"].floors["tlv-floor-5"]
+    assert sorted(floor.rooms.keys()) == [f"5.{n}" for n in range(18, 32)]
+
+
+def test_update_floor_entry_preserves_top_level_comments(tmp_path: Path) -> None:
+    yaml_path = _write(tmp_path)
+    update_floor_entry(
+        yaml_path,
+        "tlv",
+        "tlv-floor-5",
+        clusters={"T": {"capacity": 21, "type": "open-space"}},
+    )
+    text = yaml_path.read_text(encoding="utf-8")
+    assert "# This top-level comment must survive any append." in text
+    assert "# Stage 7 — SSO + roles." in text
+
+
+def test_update_floor_entry_replaces_both_clusters_and_rooms(tmp_path: Path) -> None:
+    yaml_path = _write(tmp_path)
+    update_floor_entry(
+        yaml_path,
+        "tlv",
+        "tlv-floor-5",
+        clusters={
+            "T": {"capacity": 21, "type": "open-space"},
+            "Z": {"capacity": 0, "type": "phone-room"},
+        },
+        rooms={
+            f"5.{n}": {"name": f"Room 5.{n}", "type": "meeting", "capacity": 4}
+            for n in range(18, 25)
+        },
+    )
+    offices = load_offices(tmp_path)
+    floor = offices["tlv"].floors["tlv-floor-5"]
+    assert floor.clusters["T"].capacity == 21
+    assert floor.clusters["Z"].capacity == 0
+    assert len(floor.rooms) == 7
+
+
+def test_update_floor_entry_refuses_unknown_floor(tmp_path: Path) -> None:
+    yaml_path = _write(tmp_path)
+    with pytest.raises(OfficeError) as exc:
+        update_floor_entry(
+            yaml_path,
+            "tlv",
+            "no-such-floor",
+            clusters={"T": {"capacity": 6, "type": "open-space"}},
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "not found" in exc.value.message
+
+
+def test_update_floor_entry_refuses_unknown_office(tmp_path: Path) -> None:
+    yaml_path = _write(tmp_path)
+    with pytest.raises(OfficeError) as exc:
+        update_floor_entry(
+            yaml_path,
+            "no-such-office",
+            "tlv-floor-5",
+            clusters={"T": {"capacity": 6, "type": "open-space"}},
+        )
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "unknown office" in exc.value.message

--- a/uv.lock
+++ b/uv.lock
@@ -713,7 +713,7 @@ wheels = [
 
 [[package]]
 name = "office-cli"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Why

PR-A's `office floors doctor` was too aggressive on real-world
Inkscape traces. On Tipalti's tlv-floor-5 backup (21 seats + 14 rooms
with garbled `Ctrl+D` cascade ids), the off-page detector + dedupe
dropped 16 seats and 13 rooms — most of the operator's actual trace.
Operators kept either rebuilding by hand or running one-off scripts
to keep all shapes.

This PR flips the default and adds an auto-grow path so the verb
matches the operator's mental model: "fix my ids, keep my shapes".

## What

```bash
# Default (new): keep all 21 seats, fix ids, auto-grow offices.yaml
office floors doctor tlv-floor-5
# offices.yaml: T: 6 → 21, rooms 5.18..5.31

# Aggressive cleanup (original behavior, opt-in)
office floors doctor tlv-floor-5 --prune
```

### Default (keep-all)

- Detect cluster letter from each seat's existing id (`<floor>-([A-Z])-`); orphans → first declared cluster.
- Spatial-sort within each cluster; mint sequential `<floor>-<LETTER>-<NN>`.
- For rooms: detect floor prefix; spatial-sort; mint sequential `<floor>.<NN>` starting at smallest existing suffix (default 18).
- **All traced shapes are kept** — the slot list extends to fit.
- After write, mutate `offices.yaml`: bump cluster capacities, replace the rooms block. Newly-added rooms get default `name: "Room <id>"`, `type: meeting`, `capacity: 4`; existing rooms keep their declared metadata.

### `--prune` (opt-in, old default)

- Drop shapes outside `1920×1080` viewBox.
- Drop near-duplicates (centers within 6 px).
- Renumber per declared cluster spec; drop excess. `offices.yaml` is **not** mutated.

### Auto-grow plumbing

New helper `office_cli.offices.update_floor_entry` does a textual
splice on `data/offices.yaml`: locates the floor block by id,
replaces its `clusters:` / `rooms:` subtrees, preserves everything
else byte-for-byte (comments, indentation, sibling floor blocks).

`DoctorReport` gains `new_clusters` (letter → capacity) and
`new_rooms` (id list) so dry-run callers can preview the post-doctor
spec without writing.

## Smoke test (the user's actual backup)

```text
$ uv run office floors doctor tlv-floor-5 --json --data-dir <tmp>
seats: 21 -> 21
rooms: 14 -> 14
new_clusters: {'T': 21, 'Z': 0}
new_rooms: ['5.18', '5.19', '5.20'] ... ['5.30', '5.31']
actions:
  - renamed 21 seats
  - clusters: T: 6 -> 21, Z: 2 -> 0
  - renamed 14 rooms
  - + 13 rooms (5.19..5.31)
  - updated offices.yaml: tlv-floor-5 clusters/rooms auto-grown
$ uv run office floors validate tlv-floor-5
ok=True seats=21 rooms=14 errors=0 warnings=0
```

## Test plan

- [x] `uv run pytest -n auto` — 518 → 530 (+12).
- [x] Migrated all PR-A aggressive-mode tests to `prune=True`.
- [x] New tests for keep-all default + auto-grow YAML.
- [x] `update_floor_entry` tests cover replace clusters, replace rooms, replace both, refuse unknown floor/office, preserve comments.
- [x] Lint clean. Version 0.14.0 → 0.15.0.

## Out of scope (filed as follow-ups)

- Drive-side `offices.yaml` mirror — operator still copies the updated YAML to Drive manually after doctor runs.
- Multi-cluster-letter spatial layouts (e.g. some seats `T-`, some `Z-`) — supported by the cluster-letter regex, but if the source ids are unrecognized they all bucket into the first declared letter. Not a regression; speculative improvement deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)