### PR TITLE
feat(server): cascading office/floor pickers + scope-aware seat search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,6 +238,7 @@ floors/*-[0-9]*-[0-9]*.svg
 # Operator-local scaffold manifest. The committed `.example` is the
 # template; the real one points at the operator's local PDF.
 data/floor-bootstrap.yaml
+data/floor-bootstrap-*.yaml
 
 # Google Sheets service-account key — never commit credentials.
 data/sheets-service-account.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/). This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-05-10
+
+### Added
+
+- Cascading office + floor pickers in the seat-map web UI. The flat "Office / floor" dropdown is replaced with a separate office picker that narrows the floor picker to that office's floors. Floors render with a `(draft)` suffix when `status: draft`.
+- Search-scope selector under the search bar (in the results panel) — toggles between `This floor`, `This office`, and `All offices`. Office and all-offices Fuse indexes are built lazily and invalidated on office switch / `asOf` change.
+- `GET /api/seats[?office=][&asOf=]` endpoint backing the new scope picker. Reuses `SeatService.list_seats` and the existing `_redact` helper so role-aware redaction stays consistent with `/api/floors/{id}`.
+- Tests for `GET /api/seats` (all offices, single-office filter, 404 for unknown office).
+
+### Changed
+
+- `.gitignore`: extend the operator-local manifest pattern to ignore per-office `data/floor-bootstrap-<office>.yaml` manifests.
+
 ## [0.16.0] - 2026-05-10
 
 ### Added

--- a/office_cli/server/_routes.py
+++ b/office_cli/server/_routes.py
@@ -63,6 +63,16 @@ def register_routes(
         user = current_user(request, oidc=oidc)
         return _build_floor_response(service, floor_id, as_of or as_of_camel, HTTPException, user)
 
+    @app.get("/api/seats")
+    def get_seats(
+        request: Request,
+        office: str = "",
+        as_of: str = "",
+        as_of_camel: str = Query("", alias="asOf"),
+    ) -> dict:
+        user = current_user(request, oidc=oidc)
+        return _build_seats_response(service, office, as_of or as_of_camel, HTTPException, user)
+
     @app.get("/", response_class=RedirectResponse)
     def root() -> str:
         first = _first_floor_path(service)
@@ -183,6 +193,49 @@ def _build_floor_response(
         "seats": seats,
         # Echo the date back only when the caller asked for one — this is
         # what the frontend uses to decide whether to surface the banner.
+        "as_of": as_of_value if explicit else None,
+        "user": user,
+    }
+
+
+def _build_seats_response(
+    service: SeatService,
+    office_id: str,
+    raw_as_of: str,
+    http_exception: Any,
+    user: dict[str, str] | None,
+) -> dict[str, Any]:
+    """Pure builder for the ``/api/seats`` JSON body.
+
+    Returns every seat across the topology (or just the requested
+    office) so the seat-map SPA can run cross-floor / cross-office
+    fuzzy search without round-tripping per floor. ``as_of`` is honored
+    so date-aware redaction stays consistent with ``/api/floors/{id}``.
+    """
+    if raw_as_of:
+        as_of_value: str | None = parse_iso_date(
+            raw_as_of, field="as_of", example="?as_of=2026-07-01"
+        )
+        explicit = True
+    else:
+        as_of_value = today_iso_date(service._clock)
+        explicit = False
+    if office_id and office_id not in service.offices:
+        raise http_exception(
+            status_code=404,
+            detail={
+                "error": f"unknown office: {office_id}",
+                "remediation": "GET /api/offices to see available office ids",
+            },
+        )
+    role = role_from_user(user)
+    seats = service.list_seats(as_of=as_of_value, role=role)
+    if office_id:
+        floor_ids = {f.id for f in service.offices[office_id].floors.values()}
+        seats = [s for s in seats if s.floor in floor_ids]
+    return {
+        "office": office_id or None,
+        "seats": [_redact(a) for a in seats],
         "as_of": as_of_value if explicit else None,
         "user": user,
     }

--- a/office_cli/server/static/app.css
+++ b/office_cli/server/static/app.css
@@ -57,7 +57,9 @@ body {
   outline-offset: -1px;
 }
 
-#floor-picker {
+#floor-picker,
+#office-picker,
+#search-scope {
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--border);
   border-radius: 0.375rem;
@@ -82,6 +84,29 @@ body {
 .results {
   background: var(--panel);
   border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.results-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.85rem;
+}
+
+.results-header label {
+  color: var(--muted);
+}
+
+.results-header #search-scope {
+  flex: 1;
+}
+
+.results-list {
   overflow-y: auto;
   padding: 0.5rem 0;
 }

--- a/office_cli/server/static/app.js
+++ b/office_cli/server/static/app.js
@@ -339,42 +339,47 @@ function debounce(fn, ms) {
   };
 }
 
-async function ensureFuseFor(scope) {
-  // Capture (officeId, asOf) at entry so the post-await write only lands
-  // when the SPA's view of the world hasn't moved on. Otherwise a slow
-  // /api/seats fetch could repopulate a cache that loadFloor() invalidated
-  // mid-flight, producing stale search results for the new context.
-  if (!globalThis.Fuse) return null;
-  if (scope === "floor") {
-    return state.fuses.floor;
+function buildFuse(seats) {
+  return new globalThis.Fuse(seats.map(searchableSeat), FUSE_OPTIONS);
+}
+
+async function ensureOfficeFuse(officeAtStart, asOfAtStart) {
+  if (!officeAtStart) return null;
+  if (state.fuses.office && state.fuseOfficeKey === officeAtStart) {
+    return state.fuses.office;
   }
+  const data = await fetchSeats(officeAtStart, asOfAtStart);
+  const fuse = buildFuse(data.seats);
+  // Only cache if the SPA's view of the world hasn't moved on during the
+  // await — otherwise a slow fetch could repopulate a cache that
+  // loadFloor() invalidated for a new context.
+  if (
+    state.currentOfficeId === officeAtStart
+    && state.currentAsOf === asOfAtStart
+  ) {
+    state.fuses.office = fuse;
+    state.fuseOfficeKey = officeAtStart;
+  }
+  return fuse;
+}
+
+async function ensureAllFuse(asOfAtStart) {
+  if (state.fuses.all) return state.fuses.all;
+  const data = await fetchSeats("", asOfAtStart);
+  const fuse = buildFuse(data.seats);
+  if (state.currentAsOf === asOfAtStart) {
+    state.fuses.all = fuse;
+  }
+  return fuse;
+}
+
+async function ensureFuseFor(scope) {
+  if (!globalThis.Fuse) return null;
+  if (scope === "floor") return state.fuses.floor;
   const officeAtStart = state.currentOfficeId;
   const asOfAtStart = state.currentAsOf;
-  if (scope === "office") {
-    if (!officeAtStart) return null;
-    if (state.fuses.office && state.fuseOfficeKey === officeAtStart) {
-      return state.fuses.office;
-    }
-    const data = await fetchSeats(officeAtStart, asOfAtStart);
-    const fuse = new globalThis.Fuse(data.seats.map(searchableSeat), FUSE_OPTIONS);
-    if (
-      state.currentOfficeId === officeAtStart
-      && state.currentAsOf === asOfAtStart
-    ) {
-      state.fuses.office = fuse;
-      state.fuseOfficeKey = officeAtStart;
-    }
-    return fuse;
-  }
-  if (scope === "all") {
-    if (state.fuses.all) return state.fuses.all;
-    const data = await fetchSeats("", asOfAtStart);
-    const fuse = new globalThis.Fuse(data.seats.map(searchableSeat), FUSE_OPTIONS);
-    if (state.currentAsOf === asOfAtStart) {
-      state.fuses.all = fuse;
-    }
-    return fuse;
-  }
+  if (scope === "office") return ensureOfficeFuse(officeAtStart, asOfAtStart);
+  if (scope === "all") return ensureAllFuse(asOfAtStart);
   return null;
 }
 

--- a/office_cli/server/static/app.js
+++ b/office_cli/server/static/app.js
@@ -487,7 +487,7 @@ async function loadOffices() {
     const officeId = els.officePicker.value;
     populateFloorPicker(officeId);
     const office = state.officesById.get(officeId);
-    if (!office || !office.floors.length) return;
+    if (!office?.floors.length) return;
     const floorId = office.floors[0].id;
     try {
       await loadFloor(officeId, floorId, urlState().asOf);

--- a/office_cli/server/static/app.js
+++ b/office_cli/server/static/app.js
@@ -24,22 +24,31 @@ const URL_PATH_RE = /^\/offices\/([^/]+)\/floors\/([^/]+)\/?$/;
 
 const els = {
   search: document.getElementById("search"),
+  searchScope: document.getElementById("search-scope"),
   results: document.getElementById("results"),
+  resultsList: document.getElementById("results-list"),
   map: document.getElementById("map"),
   detail: document.getElementById("detail"),
   banner: document.getElementById("banner"),
+  officePicker: document.getElementById("office-picker"),
   floorPicker: document.getElementById("floor-picker"),
   userInfo: document.getElementById("user-info"),
 };
 
 const state = {
   offices: [],
+  officesById: new Map(),
+  floorToOffice: new Map(),
   knownFloorIds: new Set(),
   currentFloorId: null,
   currentOfficeId: null,
   currentAsOf: null,
   seats: [],
-  fuse: null,
+  // Fuse indexes keyed by scope. "floor" rebuilds on every loadFloor;
+  // "office" / "all" are built lazily and invalidated on as_of change
+  // or office switch (for "office" only).
+  fuses: { floor: null, office: null, all: null },
+  fuseOfficeKey: null,
 };
 
 function urlState() {
@@ -88,6 +97,28 @@ function checkResponse(r, label) {
 async function fetchOffices() {
   const r = await fetch("/api/offices");
   return (await checkResponse(r, "/api/offices")).json();
+}
+
+const OFFICE_ID_RE = /^[A-Za-z0-9._-]+$/;
+
+async function fetchSeats(officeId, asOf) {
+  const params = new URLSearchParams();
+  if (officeId) {
+    if (!OFFICE_ID_RE.test(officeId)) {
+      throw new Error(`invalid office id: ${officeId}`);
+    }
+    params.set("office", officeId);
+  }
+  if (asOf) {
+    if (!ISO_DATE_RE.test(asOf)) {
+      throw new Error(`invalid asOf: ${asOf}`);
+    }
+    params.set("asOf", asOf);
+  }
+  const qs = params.toString();
+  const url = `/api/seats${qs ? "?" + qs : ""}`;
+  const r = await fetch(url);
+  return (await checkResponse(r, "/api/seats")).json();
 }
 
 async function fetchFloor(floorId, asOf) {
@@ -176,9 +207,9 @@ function el(tag, attrs, ...children) {
 }
 
 function renderResults(matches) {
-  els.results.replaceChildren();
+  els.resultsList.replaceChildren();
   if (!matches.length) {
-    els.results.appendChild(el("p", { className: "empty" }, "No matches."));
+    els.resultsList.appendChild(el("p", { className: "empty" }, "No matches."));
     return;
   }
   for (const m of matches) {
@@ -196,15 +227,35 @@ function renderResults(matches) {
       el("div", { className: "seat-id" }, s.seat_id),
       el("div", { className: "meta" }, `${who} — ${s.floor}`),
     );
-    row.addEventListener("click", () => selectSeat(s.seat_id));
+    row.addEventListener("click", () => selectResult(s));
     row.addEventListener("keydown", (e) => {
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
-        selectSeat(s.seat_id);
+        selectResult(s);
       }
     });
-    els.results.appendChild(row);
+    els.resultsList.appendChild(row);
   }
+}
+
+async function selectResult(seat) {
+  // A search result may live on a different floor (office or all-offices
+  // scope) — navigate there first, then highlight the seat.
+  if (seat.floor && seat.floor !== state.currentFloorId) {
+    const officeId = state.floorToOffice.get(seat.floor);
+    if (!officeId) {
+      showError(new Error(`unknown office for floor ${seat.floor}`));
+      return;
+    }
+    try {
+      await loadFloor(officeId, seat.floor, state.currentAsOf);
+      setFloorPickerValue(officeId, seat.floor);
+    } catch (err) {
+      showError(err);
+      return;
+    }
+  }
+  selectSeat(seat.seat_id);
 }
 
 function applySeatClasses() {
@@ -287,13 +338,55 @@ function debounce(fn, ms) {
   };
 }
 
-const onSearch = debounce(() => {
+async function ensureFuseFor(scope) {
+  if (!globalThis.Fuse) return null;
+  if (scope === "floor") {
+    return state.fuses.floor;
+  }
+  if (scope === "office") {
+    const officeId = state.currentOfficeId;
+    if (!officeId) return null;
+    if (state.fuses.office && state.fuseOfficeKey === officeId) {
+      return state.fuses.office;
+    }
+    const data = await fetchSeats(officeId, state.currentAsOf);
+    state.fuses.office = new globalThis.Fuse(
+      data.seats.map(searchableSeat),
+      FUSE_OPTIONS,
+    );
+    state.fuseOfficeKey = officeId;
+    return state.fuses.office;
+  }
+  if (scope === "all") {
+    if (state.fuses.all) return state.fuses.all;
+    const data = await fetchSeats("", state.currentAsOf);
+    state.fuses.all = new globalThis.Fuse(
+      data.seats.map(searchableSeat),
+      FUSE_OPTIONS,
+    );
+    return state.fuses.all;
+  }
+  return null;
+}
+
+function searchScope() {
+  return els.searchScope ? els.searchScope.value : "floor";
+}
+
+const onSearch = debounce(async () => {
   const q = els.search.value.trim();
   if (!q) {
-    els.results.replaceChildren(el("p", { className: "empty" }, "Type to search…"));
+    els.resultsList.replaceChildren(el("p", { className: "empty" }, "Type to search…"));
     return;
   }
-  const matches = state.fuse ? state.fuse.search(q).slice(0, 50) : [];
+  let fuse;
+  try {
+    fuse = await ensureFuseFor(searchScope());
+  } catch (err) {
+    showError(err);
+    return;
+  }
+  const matches = fuse ? fuse.search(q).slice(0, 50) : [];
   renderResults(matches);
 }, 150);
 
@@ -342,14 +435,25 @@ async function loadFloor(officeId, floorId, asOf) {
     throw new Error(`unknown floor: ${floorId}`);
   }
   const data = await fetchFloor(floorId, asOf);
+  const officeChanged = state.currentOfficeId !== officeId;
+  const asOfChanged = state.currentAsOf !== (asOf || null);
   state.currentOfficeId = officeId;
   state.currentFloorId = floorId;
   state.currentAsOf = asOf || null;
   state.seats = data.seats;
   renderUserInfo(data.user || null);
-  state.fuse = globalThis.Fuse
+  state.fuses.floor = globalThis.Fuse
     ? new globalThis.Fuse(state.seats.map(searchableSeat), FUSE_OPTIONS)
     : null;
+  if (officeChanged) {
+    state.fuses.office = null;
+    state.fuseOfficeKey = null;
+  }
+  if (asOfChanged) {
+    state.fuses.office = null;
+    state.fuses.all = null;
+    state.fuseOfficeKey = null;
+  }
 
   const svgName = svgNameFromUrl(data.svg_url);
   if (!svgName) {
@@ -369,22 +473,32 @@ async function loadFloor(officeId, floorId, asOf) {
 async function loadOffices() {
   const data = await fetchOffices();
   state.offices = data.offices;
+  state.officesById = new Map(state.offices.map((o) => [o.id, o]));
   state.knownFloorIds = new Set();
-  els.floorPicker.replaceChildren();
+  state.floorToOffice = new Map();
   for (const office of state.offices) {
     for (const floor of office.floors) {
       state.knownFloorIds.add(floor.id);
-      els.floorPicker.appendChild(
-        el(
-          "option",
-          { value: `${office.id}|${floor.id}` },
-          `${office.name} / ${floor.id}`,
-        ),
-      );
+      state.floorToOffice.set(floor.id, office.id);
     }
   }
+  populateOfficePicker();
+  els.officePicker.addEventListener("change", async () => {
+    const officeId = els.officePicker.value;
+    populateFloorPicker(officeId);
+    const office = state.officesById.get(officeId);
+    if (!office || !office.floors.length) return;
+    const floorId = office.floors[0].id;
+    try {
+      await loadFloor(officeId, floorId, urlState().asOf);
+      pushUrl(officeId, floorId, null);
+    } catch (err) {
+      showError(err);
+    }
+  });
   els.floorPicker.addEventListener("change", async () => {
-    const [officeId, floorId] = els.floorPicker.value.split("|");
+    const officeId = els.officePicker.value;
+    const floorId = els.floorPicker.value;
     try {
       await loadFloor(officeId, floorId, urlState().asOf);
       pushUrl(officeId, floorId, null);
@@ -394,8 +508,35 @@ async function loadOffices() {
   });
 }
 
+function populateOfficePicker() {
+  els.officePicker.replaceChildren();
+  for (const office of state.offices) {
+    if (!office.floors.length) continue;
+    els.officePicker.appendChild(
+      el("option", { value: office.id }, office.name),
+    );
+  }
+  // Seed the floor picker with the first office's floors so it isn't
+  // blank before syncFromUrl runs.
+  if (els.officePicker.value) {
+    populateFloorPicker(els.officePicker.value);
+  }
+}
+
+function populateFloorPicker(officeId) {
+  els.floorPicker.replaceChildren();
+  const office = state.officesById.get(officeId);
+  if (!office) return;
+  for (const floor of office.floors) {
+    const label = floor.status === "draft" ? `${floor.id} (draft)` : floor.id;
+    els.floorPicker.appendChild(el("option", { value: floor.id }, label));
+  }
+}
+
 function setFloorPickerValue(officeId, floorId) {
-  els.floorPicker.value = `${officeId}|${floorId}`;
+  els.officePicker.value = officeId;
+  populateFloorPicker(officeId);
+  els.floorPicker.value = floorId;
 }
 
 function renderUserInfo(user) {
@@ -465,8 +606,11 @@ globalThis.addEventListener("popstate", () => {
   syncFromUrl().catch(showError);
 });
 els.search.addEventListener("input", onSearch);
+if (els.searchScope) {
+  els.searchScope.addEventListener("change", onSearch);
+}
 
-els.results.replaceChildren(el("p", { className: "empty" }, "Type to search…"));
+els.resultsList.replaceChildren(el("p", { className: "empty" }, "Type to search…"));
 
 try {
   await loadOffices();

--- a/office_cli/server/static/app.js
+++ b/office_cli/server/static/app.js
@@ -49,6 +49,7 @@ const state = {
   // or office switch (for "office" only).
   fuses: { floor: null, office: null, all: null },
   fuseOfficeKey: null,
+  searchGen: 0,
 };
 
 function urlState() {
@@ -214,7 +215,7 @@ function renderResults(matches) {
   }
   for (const m of matches) {
     const s = m.item.raw;
-    const who = s.hidden && s.employee_email
+    const who = s.redacted
       ? "(private)"
       : s.employee_email || "(vacant)";
     const row = el(
@@ -268,7 +269,7 @@ function applySeatClasses() {
     const sid = node.id;
     const s = bySeatId.get(sid);
     if (!s) continue;
-    if (s.hidden && s.employee_email) {
+    if (s.redacted) {
       node.classList.add("private");
     } else if (s.employee_email) {
       node.classList.add("occupied");
@@ -299,7 +300,7 @@ function renderDetail(seatId) {
     els.detail.hidden = true;
     return;
   }
-  const who = s.hidden && s.employee_email
+  const who = s.redacted
     ? "(private)"
     : s.employee_email || "(vacant)";
   const dl = el(
@@ -339,32 +340,40 @@ function debounce(fn, ms) {
 }
 
 async function ensureFuseFor(scope) {
+  // Capture (officeId, asOf) at entry so the post-await write only lands
+  // when the SPA's view of the world hasn't moved on. Otherwise a slow
+  // /api/seats fetch could repopulate a cache that loadFloor() invalidated
+  // mid-flight, producing stale search results for the new context.
   if (!globalThis.Fuse) return null;
   if (scope === "floor") {
     return state.fuses.floor;
   }
+  const officeAtStart = state.currentOfficeId;
+  const asOfAtStart = state.currentAsOf;
   if (scope === "office") {
-    const officeId = state.currentOfficeId;
-    if (!officeId) return null;
-    if (state.fuses.office && state.fuseOfficeKey === officeId) {
+    if (!officeAtStart) return null;
+    if (state.fuses.office && state.fuseOfficeKey === officeAtStart) {
       return state.fuses.office;
     }
-    const data = await fetchSeats(officeId, state.currentAsOf);
-    state.fuses.office = new globalThis.Fuse(
-      data.seats.map(searchableSeat),
-      FUSE_OPTIONS,
-    );
-    state.fuseOfficeKey = officeId;
-    return state.fuses.office;
+    const data = await fetchSeats(officeAtStart, asOfAtStart);
+    const fuse = new globalThis.Fuse(data.seats.map(searchableSeat), FUSE_OPTIONS);
+    if (
+      state.currentOfficeId === officeAtStart
+      && state.currentAsOf === asOfAtStart
+    ) {
+      state.fuses.office = fuse;
+      state.fuseOfficeKey = officeAtStart;
+    }
+    return fuse;
   }
   if (scope === "all") {
     if (state.fuses.all) return state.fuses.all;
-    const data = await fetchSeats("", state.currentAsOf);
-    state.fuses.all = new globalThis.Fuse(
-      data.seats.map(searchableSeat),
-      FUSE_OPTIONS,
-    );
-    return state.fuses.all;
+    const data = await fetchSeats("", asOfAtStart);
+    const fuse = new globalThis.Fuse(data.seats.map(searchableSeat), FUSE_OPTIONS);
+    if (state.currentAsOf === asOfAtStart) {
+      state.fuses.all = fuse;
+    }
+    return fuse;
   }
   return null;
 }
@@ -379,11 +388,29 @@ const onSearch = debounce(async () => {
     els.resultsList.replaceChildren(el("p", { className: "empty" }, "Type to search…"));
     return;
   }
+  // Monotonic generation counter — debounce only cancels the timer, not
+  // already-running async work. After awaits we discard if a newer
+  // onSearch invocation has started, so old results never repaint over
+  // newer ones.
+  state.searchGen = (state.searchGen || 0) + 1;
+  const gen = state.searchGen;
+  const scopeAtStart = searchScope();
+  const officeAtStart = state.currentOfficeId;
+  const asOfAtStart = state.currentAsOf;
   let fuse;
   try {
-    fuse = await ensureFuseFor(searchScope());
+    fuse = await ensureFuseFor(scopeAtStart);
   } catch (err) {
+    if (gen !== state.searchGen) return;
     showError(err);
+    return;
+  }
+  if (gen !== state.searchGen) return;
+  if (
+    searchScope() !== scopeAtStart
+    || state.currentOfficeId !== officeAtStart
+    || state.currentAsOf !== asOfAtStart
+  ) {
     return;
   }
   const matches = fuse ? fuse.search(q).slice(0, 50) : [];

--- a/office_cli/server/static/index.html
+++ b/office_cli/server/static/index.html
@@ -12,12 +12,23 @@
   <header class="topbar">
     <div class="brand">office</div>
     <input id="search" type="search" placeholder="Search seats, people, rooms…" autocomplete="off">
+    <select id="office-picker" aria-label="Switch office"></select>
     <select id="floor-picker" aria-label="Switch floor"></select>
     <div id="user-info" class="user-info" hidden></div>
   </header>
   <div id="banner" class="banner" hidden></div>
   <div class="layout">
-    <aside id="results" class="results" aria-label="Search results"></aside>
+    <aside id="results" class="results" aria-label="Search results">
+      <div class="results-header">
+        <label for="search-scope">Search:</label>
+        <select id="search-scope" aria-label="Search scope">
+          <option value="floor">This floor</option>
+          <option value="office">This office</option>
+          <option value="all">All offices</option>
+        </select>
+      </div>
+      <div id="results-list" class="results-list"></div>
+    </aside>
     <main id="map" class="map" aria-label="Floor map"></main>
     <section id="detail" class="detail" aria-label="Selected seat detail" hidden></section>
   </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "office-cli"
-version = "0.16.0"
+version = "0.17.0"
 description = "Office — CLI to manage sittings and meeting rooms in office maps."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_server_app.py
+++ b/tests/test_server_app.py
@@ -46,6 +46,36 @@ def test_get_offices(data_dir: Path) -> None:
         assert body["offices"][0]["floors"] == [{"id": "tlv-floor-5", "status": "active"}]
 
 
+def test_get_seats_returns_all(data_dir: Path) -> None:
+    s = _service(data_dir)
+    s.assign("5-T-01", "alice@example.com")
+    with TestClient(build_app(s, data_dir=data_dir)) as c:
+        r = c.get("/api/seats")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["office"] is None
+        seats = {seat["seat_id"]: seat for seat in body["seats"]}
+        # Every declared seat in the fixture surfaces, occupied or not.
+        assert "5-T-01" in seats
+        assert seats["5-T-01"]["employee_email"] == "alice@example.com"
+        assert seats["5-T-01"]["floor"] == "tlv-floor-5"
+
+
+def test_get_seats_filters_by_office(data_dir: Path) -> None:
+    with _client(data_dir) as c:
+        r = c.get("/api/seats?office=tlv")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["office"] == "tlv"
+        assert {seat["floor"] for seat in body["seats"]} == {"tlv-floor-5"}
+
+
+def test_get_seats_unknown_office_404(data_dir: Path) -> None:
+    with _client(data_dir) as c:
+        r = c.get("/api/seats?office=nope")
+        assert r.status_code == 404
+
+
 def test_get_floor_returns_merged_view(data_dir: Path) -> None:
     s = _service(data_dir)
     s.assign("5-T-01", "alice@example.com")


### PR DESCRIPTION
## Summary

- Replace the flat \"Office / floor\" picker with a cascading **office picker → floor picker**. Floors render with a `(draft)` suffix when `status: draft` so operators see what still needs tracing without leaving the SPA.
- Add a **search-scope selector** under the search bar (placed inside the results panel, where the eye lands after typing) — toggles between `This floor`, `This office`, `All offices`. Office and all-offices Fuse indexes are built lazily and invalidated on office switch / `asOf` change.
- New `GET /api/seats[?office=][&asOf=]` endpoint backing the new scope picker. Reuses `SeatService.list_seats` and the existing `_redact` helper, so role-aware redaction (hidden=TRUE rows surface as `(private)` for viewers) stays consistent with `/api/floors/{id}`.
- Cross-floor result clicks auto-navigate to the result's floor before highlighting (`selectResult`).
- `.gitignore`: extend the operator-local manifest pattern so per-office `data/floor-bootstrap-<office>.yaml` manifests stay out of commits.

## Test plan

- [x] `uv run pytest -n auto` — 538 → 541 (+3 new `/api/seats` tests). All pass.
- [x] `uv run black --check` / `uv run flake8` clean.
- [x] Headless Chrome smoke: office dropdown populates with 7 offices, floor dropdown narrows to selected office (TLV → 7 floors with `(draft)` markers), scope selector visible under search bar, switching scope from `floor` → `office` → `all` swaps Fuse index, cross-floor result click loads the target floor.
- [x] API smoke: `GET /api/seats` returns 1146 seats, `?office=tlv` returns 1106 across 7 floors, `?office=demo` returns 9, unknown office → 404.

Generated with Claude Code

- Claude